### PR TITLE
Fixed a couple issues with parsing set-property op result

### DIFF
--- a/smtk/attribute/ModelEntityItemDefinition.cxx
+++ b/smtk/attribute/ModelEntityItemDefinition.cxx
@@ -215,6 +215,8 @@ createCopy(ItemDefinition::CopyInfo& info) const
 
   newDef->setMembershipMask(m_membershipMask);
   newDef->setNumberOfRequiredValues(m_numberOfRequiredValues);
+  newDef->setMaxNumberOfValues(m_maxNumberOfValues);
+  newDef->setIsExtensible(m_isExtensible);
   if (m_useCommonLabel)
     {
     newDef->setCommonValueLabel(m_valueLabels[0]);
@@ -226,10 +228,6 @@ createCopy(ItemDefinition::CopyInfo& info) const
       newDef->setValueLabel(i, m_valueLabels[i]);
       }
     }
-
-  newDef->setIsOptional(m_isOptional);
-  newDef->setIsExtensible(m_isExtensible);
-  newDef->setIsEnabledByDefault(m_isEnabledByDefault);
 
   return newDef;
 }

--- a/smtk/extension/qt/qtEntityItemDelegate.cxx
+++ b/smtk/extension/qt/qtEntityItemDelegate.cxx
@@ -229,22 +229,22 @@ void QEntityItemDelegate::commitAndCloseEditor()
   emit closeEditor(entityEditor);
 }
 
-bool QEntityItemDelegate::eventFilter(QObject* editor, QEvent* event)
+bool QEntityItemDelegate::eventFilter(QObject* editor, QEvent* evt)
 {
-  if(event->type()==QEvent::MouseButtonPress)
+  if(evt->type()==QEvent::MouseButtonPress)
     return false;
-  return QStyledItemDelegate::eventFilter(editor, event);
+  return QStyledItemDelegate::eventFilter(editor, evt);
 }
 
 bool QEntityItemDelegate::editorEvent (
-  QEvent * eve, QAbstractItemModel * mod,
+  QEvent * evt, QAbstractItemModel * mod,
   const QStyleOptionViewItem & option, const QModelIndex & idx)
 {
   bool res = this->QStyledItemDelegate::editorEvent(
-      eve, mod, option, idx);
-  if(eve->type() != QEvent::MouseButtonPress)
+      evt, mod, option, idx);
+  if(evt->type() != QEvent::MouseButtonPress)
     return res;
-  QMouseEvent* e = dynamic_cast<QMouseEvent*>(eve);
+  QMouseEvent* e = dynamic_cast<QMouseEvent*>(evt);
   if(!e)
     return res;
 

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -604,9 +604,8 @@ void qtModelView::changeVisibility( const QModelIndex& idx)
   nameItem->setNumberOfValues(1);
   nameItem->setValue("visible");
   visItem->setNumberOfValues(1);
-  visItem->setValue(
-    (visItem->numberOfValues() == 0 ||
-    (visItem->numberOfValues() && visItem->value())) ? 0 : 1);
+  DescriptivePhrasePtr dp = this->getModel()->getItem(idx);
+  visItem->setValue(dp->relatedEntity().visible() ? 0 : 1);
 
   smtk::common::UUIDs ids;
   this->recursiveSelect(this->getModel(), idx, ids,
@@ -654,6 +653,7 @@ void qtModelView::changeColor( const QModelIndex& idx)
     colorItem->setValue(0, newColor.redF());
     colorItem->setValue(1, newColor.greenF());
     colorItem->setValue(2, newColor.blueF());
+    colorItem->setValue(3, newColor.alphaF());
 
     smtk::common::UUIDs ids;
     this->recursiveSelect(this->getModel(), idx, ids,

--- a/smtk/io/XmlV2StringWriter.cxx
+++ b/smtk/io/XmlV2StringWriter.cxx
@@ -1131,16 +1131,13 @@ void XmlV2StringWriter::processModelEntityItem(pugi::xml_node &node,
 {
   size_t i=0, n = item->numberOfValues();
   std::size_t  numRequiredVals = item->numberOfRequiredValues();
+  // we should always have "NumberOfValues" set
+  node.append_attribute("NumberOfValues").set_value(static_cast<unsigned int>(n));
 
   xml_node val;
   if (!n)
     {
     return;
-    }
-
-  if (!numRequiredVals)
-    {
-    node.append_attribute("NumberOfValues").set_value(static_cast<unsigned int>(n));
     }
 
   if (numRequiredVals == 1)

--- a/smtk/model/Bridge.cxx
+++ b/smtk/model/Bridge.cxx
@@ -292,7 +292,7 @@ void Bridge::initializeOperatorSystem(const OperatorConstructors* opList)
   StringItemDefinition::Ptr logDefn = StringItemDefinition::New("log");
   outcomeDefn->setNumberOfRequiredValues(1);
   outcomeDefn->setIsOptional(false);
-  entoutDefn->setNumberOfRequiredValues(1);
+  entoutDefn->setNumberOfRequiredValues(0);
   entoutDefn->setIsOptional(true);
   entoutDefn->setIsExtensible(true);
   logDefn->setNumberOfRequiredValues(0);

--- a/smtk/model/Cursor.cxx
+++ b/smtk/model/Cursor.cxx
@@ -278,7 +278,7 @@ bool Cursor::visible() const
     return false;
 
   const IntegerList& prop(this->integerProperty("visible"));
-  return (!prop.empty() && prop[0]);
+  return (!prop.empty() && (prop[0] != 0));
 }
 
 /** Assign the visible property to an entity.

--- a/smtk/model/EntityPhrase.cxx
+++ b/smtk/model/EntityPhrase.cxx
@@ -34,7 +34,8 @@ EntityPhrase::Ptr EntityPhrase::setup(const Cursor& entity, DescriptivePhrase::P
   this->DescriptivePhrase::setup(ENTITY_SUMMARY, parnt);
   this->m_entity = entity;
   this->m_mutability = 3; // both color and title are mutable by default.
-  this->m_entity.setVisible(true); // set "visible" property to true
+  if(!this->m_entity.hasVisibility())
+    this->m_entity.setVisible(true); // set "visible" property to true
   return this->shared_from_this();
 }
 


### PR DESCRIPTION
There are a couple issues being addressed int this commit. First,
the ModelEntityItemDef is not copied properly. It is missing
isExtensible and MaxNumValues variables. Second, the XmlV2String
writer and parser have mis-matched logic for processing ModelEntityItem.
Last thing was fixed is the wrong initialization of visibility for entityphrase.
