### PR TITLE
Added signal to notify data changed in modelView

### DIFF
--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -621,6 +621,7 @@ void qtModelView::changeVisibility( const QModelIndex& idx)
     }
 
   emit this->operationRequested(brOp);
+  this->dataChanged(idx, idx);
 }
 
 //----------------------------------------------------------------------------
@@ -669,6 +670,7 @@ void qtModelView::changeColor( const QModelIndex& idx)
       }
 
     emit this->operationRequested(brOp);
+    this->dataChanged(idx, idx);
     }
 }
 


### PR DESCRIPTION
When a color or visibility is changed for an entity, a dataChanged is
called so that the treeView will redraw that entity item. This way
the whole tree does not need to be redrawn, only the items that got changed.
