### PR TITLE
Added field data to multi-block model source

### DIFF
--- a/smtk/extension/vtk/vtkModelMultiBlockSource.h
+++ b/smtk/extension/vtk/vtkModelMultiBlockSource.h
@@ -56,6 +56,12 @@ public:
   vtkSetMacro(AllowNormalGeneration,int);
   vtkBooleanMacro(AllowNormalGeneration,int);
 
+  // Description:
+  // Functions get string names used to store cell/field data.
+  static const char* GetEntityTagName() { return "Entity UUID"; }
+  static const char* GetGroupTagName() { return "Group"; }
+  static const char* GetVolumeTagName() { return "Volume"; }
+
 protected:
   vtkModelMultiBlockSource();
   virtual ~vtkModelMultiBlockSource();
@@ -78,7 +84,8 @@ protected:
   void SetCachedOutput(vtkMultiBlockDataSet*);
 
   void FindEntitiesWithTessellation(
-    const smtk::model::CellEntities &cellents, smtk::model::Cursors &cursors);
+    const smtk::model::CellEntity &cellent,
+    std::map<smtk::model::Cursor, smtk::model::Cursor> &cursorMap);
 
   smtk::model::ManagerPtr ModelMgr;
   vtkMultiBlockDataSet* CachedOutput;


### PR DESCRIPTION
To use the new functionality of coloring by string-data field arrays in paraview4.3,
we added new field data arrays in vtkModelMultiBlockSource, so that the model entities
can be colored by those arrays, such as Entity, Group, or Volume. This gives user
better visual knowledge of the model.