### PR TITLE
Improve speed of assignDefaultNames().

### DIFF
--- a/smtk/model/BRepModel.h
+++ b/smtk/model/BRepModel.h
@@ -183,6 +183,12 @@ protected:
   smtk::common::UUIDGenerator m_uuidGenerator;
   IntegerList m_globalCounters; // first entry is bridge counter, second is model counter
 
+  void assignDefaultNamesWithOwner(
+    const UUIDWithEntity& irec,
+    const smtk::common::UUID& owner,
+    const std::string& ownersName,
+    std::set<smtk::common::UUID>& remaining,
+    bool nokids);
   std::string assignDefaultName(const smtk::common::UUID& uid, BitFlags entityFlags);
   IntegerList& entityCounts(const smtk::common::UUID& modelId, BitFlags entityFlags);
   void prepareForEntity(std::pair<smtk::common::UUID,Entity>& entry);

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -117,6 +117,7 @@
   <suppress-warning text="skipping field 'Manager::m_arrangements' with unmatched type 'shared_ptr&lt;UUIDsToArrangements&gt;'"/>
   <suppress-warning text="skipping field 'UUIDGenerator::P' with unmatched type 'Internal'"/>
   <suppress-warning text="skipping field 'BRepModel::m_modelBridges' with unmatched type 'std::map&lt;smtk::common::UUID,BridgePtr&gt;'"/>
+  <suppress-warning text="skipping function 'smtk::model::BRepModel::assignDefaultNamesWithOwner', unmatched parameter type 'smtk::model::UUIDWithEntity const&amp;'"/>
 
   <!-- do not support input or output streams-->
   <suppress-warning text="skipping function 'smtk::common::operator&lt;&lt;', unmatched return type 'std::ostream&amp;'"/>


### PR DESCRIPTION
Now instead of looking up the owner of each item, we descend the
model hierarchy keeping track of the owning model as we go.