### PR TITLE
Wrap discrete bridge in Python.

### DIFF
--- a/smtk/bridge/discrete/Bridge.cxx
+++ b/smtk/bridge/discrete/Bridge.cxx
@@ -164,17 +164,17 @@ smtk::model::BridgedInfoBits Bridge::allSupportedInformation() const
   return smtk::model::BRIDGE_EVERYTHING;
 }
 
-/**\brief Create records in \a manager that reflect the CMB \a entity.
+/**\brief Create records in \a mgr that reflect the CMB \a entity.
   *
   */
 smtk::model::Cursor Bridge::addCMBEntityToManager(
   const smtk::common::UUID& uid,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
   vtkModelItem* ent = this->entityForUUID(uid);
   if (ent)
-    return this->addCMBEntityToManager(uid, ent, manager, relDepth);
+    return this->addCMBEntityToManager(uid, ent, mgr, relDepth);
   return smtk::model::Cursor();
 }
 
@@ -253,7 +253,7 @@ vtkUnsignedIntArray* Bridge::retrieveUUIDs(
 smtk::common::UUID Bridge::ImportEntitiesFromFileNameIntoManager(
   const std::string& filename,
   const std::string& filetype,
-  smtk::model::ManagerPtr manager)
+  smtk::model::ManagerPtr mgr)
 {
   // Make sure that the bridge has a list of operators it can provide.
 
@@ -273,7 +273,7 @@ smtk::common::UUID Bridge::ImportEntitiesFromFileNameIntoManager(
     std::cerr << "Could not read file \"" << filename << "\".\n";
     return smtk::common::UUID::null();
     }
-  return this->trackModel(mod.GetPointer(), filename, manager);
+  return this->trackModel(mod.GetPointer(), filename, mgr);
 }
 
 int Bridge::ExportEntitiesToFileOfNameAndType(
@@ -339,7 +339,7 @@ smtk::model::BridgedInfoBits Bridge::transcribeInternal(
 
 smtk::common::UUID Bridge::trackModel(
   vtkDiscreteModelWrapper* mod, const std::string& url,
-  smtk::model::ManagerPtr manager)
+  smtk::model::ManagerPtr mgr)
 {
   vtkDiscreteModel* dmod = mod->GetModel();
   if (!dmod)
@@ -353,11 +353,11 @@ smtk::common::UUID Bridge::trackModel(
   Bridge::s_modelRefsToIds[mod] = mid;
   this->m_itemsToRefs[mid] = dmod;
   Bridge::s_modelsToBridges[dmod] = shared_from_this();
-  manager->setBridgeForModel(shared_from_this(), mid);
+  mgr->setBridgeForModel(shared_from_this(), mid);
 
   // Now add the record to manager and assign the URL to
   // the model as a string property.
-  smtk::model::Cursor c = this->addCMBEntityToManager(mid, dmod, manager, 4);
+  smtk::model::Cursor c = this->addCMBEntityToManager(mid, dmod, mgr, 4);
   c.setStringProperty("url", url);
 
   return mid;
@@ -422,7 +422,7 @@ vtkModelItem* Bridge::entityForUUID(const smtk::common::UUID& uid)
 }
 
 smtk::model::Cursor Bridge::addCMBEntityToManager(
-  const smtk::common::UUID& uid, vtkModelItem* ent, smtk::model::ManagerPtr manager, int relDepth)
+  const smtk::common::UUID& uid, vtkModelItem* ent, smtk::model::ManagerPtr mgr, int relDepth)
 {
   this->assignUUIDToEntity(uid, ent);
   vtkModel* modelEntity = dynamic_cast<vtkModel*>(ent);
@@ -430,7 +430,7 @@ smtk::model::Cursor Bridge::addCMBEntityToManager(
   vtkModelEntity* otherEntity = dynamic_cast<vtkModelEntity*>(ent);
   if (modelEntity)
     {
-    return this->addBodyToManager(uid, modelEntity, manager, relDepth);
+    return this->addBodyToManager(uid, modelEntity, mgr, relDepth);
     }
   else if (cellEntity)
     {
@@ -438,10 +438,10 @@ smtk::model::Cursor Bridge::addCMBEntityToManager(
     vtkModelFace* face = dynamic_cast<vtkModelFace*>(otherEntity);
     vtkModelEdge* edge = dynamic_cast<vtkModelEdge*>(otherEntity);
     vtkModelVertex* vert = dynamic_cast<vtkModelVertex*>(otherEntity);
-    if (region) return this->addVolumeToManager(uid, region, manager, relDepth);
-    else if (face) return this->addFaceToManager(uid, face, manager, relDepth);
-    else if (edge) return this->addEdgeToManager(uid, edge, manager, relDepth);
-    else if (vert) return this->addVertexToManager(uid, vert, manager, relDepth);
+    if (region) return this->addVolumeToManager(uid, region, mgr, relDepth);
+    else if (face) return this->addFaceToManager(uid, face, mgr, relDepth);
+    else if (edge) return this->addEdgeToManager(uid, edge, mgr, relDepth);
+    else if (vert) return this->addVertexToManager(uid, vert, mgr, relDepth);
     else
       {
       std::cerr
@@ -458,13 +458,13 @@ smtk::model::Cursor Bridge::addCMBEntityToManager(
     vtkModelMaterial* material = dynamic_cast<vtkModelMaterial*>(otherEntity);
     vtkModelShellUse* shell = dynamic_cast<vtkModelShellUse*>(otherEntity);
     vtkModelLoopUse* loop = dynamic_cast<vtkModelLoopUse*>(otherEntity);
-    if (faceUse) return this->addFaceUseToManager(uid, faceUse, manager, relDepth);
-    else if (edgeUse) return this->addEdgeUseToManager(uid, edgeUse, manager, relDepth);
-    else if (vertUse) return this->addVertexUseToManager(uid, vertUse, manager, relDepth);
-    else if (group) return this->addGroupToManager(uid, group, manager, relDepth);
-    else if (material) return this->addMaterialToManager(uid, material, manager, relDepth);
-    else if (shell) return this->addShellToManager(uid, shell, manager, relDepth);
-    else if (loop) return this->addLoopToManager(uid, loop, manager, relDepth);
+    if (faceUse) return this->addFaceUseToManager(uid, faceUse, mgr, relDepth);
+    else if (edgeUse) return this->addEdgeUseToManager(uid, edgeUse, mgr, relDepth);
+    else if (vertUse) return this->addVertexUseToManager(uid, vertUse, mgr, relDepth);
+    else if (group) return this->addGroupToManager(uid, group, mgr, relDepth);
+    else if (material) return this->addMaterialToManager(uid, material, mgr, relDepth);
+    else if (shell) return this->addShellToManager(uid, shell, mgr, relDepth);
+    else if (loop) return this->addLoopToManager(uid, loop, mgr, relDepth);
     else
       {
       std::cerr
@@ -695,7 +695,7 @@ bool Bridge::addProperties(
 smtk::model::ModelEntity Bridge::addBodyToManager(
   const smtk::common::UUID& uid,
   vtkModel* body,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
   if (body)
@@ -703,15 +703,15 @@ smtk::model::ModelEntity Bridge::addBodyToManager(
     smtk::model::ModelEntity model;
     smtk::model::BridgedInfoBits translated;
     bool already;
-    if ((already = manager->findEntity(uid, false) ? true : false) || relDepth < 0)
+    if ((already = mgr->findEntity(uid, false) ? true : false) || relDepth < 0)
       {
       translated = already ? smtk::model::BRIDGE_ENTITY_ARRANGED : smtk::model::BRIDGE_NOTHING;
-      model = smtk::model::ModelEntity(manager,uid);
+      model = smtk::model::ModelEntity(mgr,uid);
       }
     else
       {
       translated = smtk::model::BRIDGE_ENTITY_RECORD;
-      model = manager->insertModel(
+      model = mgr->insertModel(
         uid, body->GetModelDimension(), 3,
         "Discrete Model"); // TODO: Model name???
       }
@@ -756,11 +756,11 @@ smtk::model::ModelEntity Bridge::addBodyToManager(
   return smtk::model::ModelEntity();
 }
 
-/// Given a CMB \a group tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a group tagged with \a uid, create a record in \a mgr for it.
 smtk::model::GroupEntity Bridge::addGroupToManager(
   const smtk::common::UUID& uid,
   vtkDiscreteModelEntityGroup* group,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
   if (group)
@@ -768,15 +768,15 @@ smtk::model::GroupEntity Bridge::addGroupToManager(
     smtk::model::GroupEntity result;
     smtk::model::BridgedInfoBits translated;
     bool already;
-    if ((already = manager->findEntity(uid, false) ? true : false) || relDepth < 0)
+    if ((already = mgr->findEntity(uid, false) ? true : false) || relDepth < 0)
       {
       translated = already ? smtk::model::BRIDGE_ENTITY_ARRANGED : smtk::model::BRIDGE_NOTHING;
-      result = smtk::model::GroupEntity(manager, uid);
+      result = smtk::model::GroupEntity(mgr, uid);
       }
     else
       {
       translated = smtk::model::BRIDGE_ENTITY_ARRANGED;
-      result = manager->insertGroup(uid);
+      result = mgr->insertGroup(uid);
       }
     if (relDepth >= 0)
       {
@@ -792,11 +792,11 @@ smtk::model::GroupEntity Bridge::addGroupToManager(
   return smtk::model::GroupEntity();
 }
 
-/// Given a CMB \a material tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a material tagged with \a uid, create a record in \a mgr for it.
 smtk::model::GroupEntity Bridge::addMaterialToManager(
   const smtk::common::UUID& uid,
   vtkModelMaterial* material,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
   if (material)
@@ -804,15 +804,15 @@ smtk::model::GroupEntity Bridge::addMaterialToManager(
     smtk::model::BridgedInfoBits translated;
     smtk::model::GroupEntity result;
     bool already;
-    if ((already = manager->findEntity(uid, false) ? true : false) || relDepth < 0)
+    if ((already = mgr->findEntity(uid, false) ? true : false) || relDepth < 0)
       {
       translated = already ? smtk::model::BRIDGE_EVERYTHING : smtk::model::BRIDGE_NOTHING;
-      result = smtk::model::GroupEntity(manager, uid);
+      result = smtk::model::GroupEntity(mgr, uid);
       }
     else
       {
       translated = smtk::model::BRIDGE_ENTITY_ARRANGED;
-      result = manager->insertGroup(uid);
+      result = mgr->insertGroup(uid);
       }
     if (relDepth >= 0)
       {
@@ -830,11 +830,11 @@ smtk::model::GroupEntity Bridge::addMaterialToManager(
   return smtk::model::GroupEntity();
 }
 
-/// Given a CMB \a coFace tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a coFace tagged with \a uid, create a record in \a mgr for it.
 smtk::model::FaceUse Bridge::addFaceUseToManager(
   const smtk::common::UUID& uid,
   vtkModelFaceUse* coFace,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
   if (coFace)
@@ -843,11 +843,11 @@ smtk::model::FaceUse Bridge::addFaceUseToManager(
     smtk::model::BridgedInfoBits translated;
     bool already;
     smtk::model::Face matchingFace(
-      manager, this->findOrSetEntityUUID(coFace->GetModelFace()));
-    if ((already = manager->findEntity(uid, false) ? true : false) || relDepth < 0)
+      mgr, this->findOrSetEntityUUID(coFace->GetModelFace()));
+    if ((already = mgr->findEntity(uid, false) ? true : false) || relDepth < 0)
       {
       translated = already ? smtk::model::BRIDGE_ENTITY_ARRANGED : smtk::model::BRIDGE_NOTHING;
-      result = smtk::model::FaceUse(manager, uid);
+      result = smtk::model::FaceUse(mgr, uid);
       }
     else
       {
@@ -856,7 +856,7 @@ smtk::model::FaceUse Bridge::addFaceUseToManager(
       // so we check the face to find its orientation. Blech.
       std::cout << "Face Use " << uid << " face " << matchingFace << " sense 0 " << " orient "
         << (coFace->GetModelFace()->GetModelFaceUse(1) == coFace ? "+" : "-") << "\n";
-      result = manager->setFaceUse(
+      result = mgr->setFaceUse(
         uid, matchingFace, 0,
         coFace->GetModelFace()->GetModelFaceUse(1) == coFace ?
         smtk::model::POSITIVE : smtk::model::NEGATIVE);
@@ -870,21 +870,21 @@ smtk::model::FaceUse Bridge::addFaceUseToManager(
         {
         smtk::common::UUID shellId = this->findOrSetEntityUUID(shellUse);
 
-        this->addCMBEntityToManager(matchingFace.entity(), coFace->GetModelFace(), manager, relDepth - 1);
-        this->addCMBEntityToManager(shellId, shellUse, manager, relDepth - 1);
+        this->addCMBEntityToManager(matchingFace.entity(), coFace->GetModelFace(), mgr, relDepth - 1);
+        this->addCMBEntityToManager(shellId, shellUse, mgr, relDepth - 1);
         vtkModelItemIterator* loopIt = coFace->NewLoopUseIterator();
         smtk::model::Loops loops;
         for (loopIt->Begin(); !loopIt->IsAtEnd(); loopIt->Next())
           {
           vtkModelItem* loop = loopIt->GetCurrentItem();
           smtk::common::UUID loopId = this->findOrSetEntityUUID(loop);
-          this->addCMBEntityToManager(loopId, loop, manager, relDepth - 1);
-          loops.push_back(smtk::model::Loop(manager, loopId));
+          this->addCMBEntityToManager(loopId, loop, mgr, relDepth - 1);
+          loops.push_back(smtk::model::Loop(mgr, loopId));
           }
         loopIt->Delete();
-        smtk::model::FaceUse faceUse(manager, uid);
+        smtk::model::FaceUse faceUse(mgr, uid);
         faceUse.addShellEntities(loops);
-        faceUse.setBoundingShellEntity(smtk::model::ShellEntity(manager,shellId));
+        faceUse.setBoundingShellEntity(smtk::model::ShellEntity(mgr,shellId));
         }
       }
 
@@ -897,34 +897,34 @@ smtk::model::FaceUse Bridge::addFaceUseToManager(
   return smtk::model::FaceUse();
 }
 
-/// Given a CMB \a coEdge tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a coEdge tagged with \a uid, create a record in \a mgr for it.
 smtk::model::EdgeUse Bridge::addEdgeUseToManager(
   const smtk::common::UUID& uid,
   vtkModelEdgeUse* coEdge,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
   if (coEdge)
     {
     smtk::model::BridgedInfoBits translated = smtk::model::BRIDGE_NOTHING;
     bool already;
-    smtk::model::EdgeUse result(manager, uid);
-    if ((already = manager->findEntity(uid, false) ? true : false) || relDepth < 0)
+    smtk::model::EdgeUse result(mgr, uid);
+    if ((already = mgr->findEntity(uid, false) ? true : false) || relDepth < 0)
       {
       translated = already ? smtk::model::BRIDGE_ENTITY_ARRANGED : smtk::model::BRIDGE_NOTHING;
       }
     else
       {
       smtk::model::Edge matchingEdge(
-        manager, this->findOrSetEntityUUID(coEdge->GetModelEdge()));
-      if (manager->findEntity(matchingEdge.entity(), false) != NULL)
+        mgr, this->findOrSetEntityUUID(coEdge->GetModelEdge()));
+      if (mgr->findEntity(matchingEdge.entity(), false) != NULL)
         { // Force the addition of the parent edge to the model.
-        this->addEdgeToManager(matchingEdge.entity(), coEdge->GetModelEdge(), manager, 0);
+        this->addEdgeToManager(matchingEdge.entity(), coEdge->GetModelEdge(), mgr, 0);
         }
       if (relDepth >= 0)
         {
         // Now create the edge use with the proper relation:
-        manager->setEdgeUse(
+        mgr->setEdgeUse(
           uid, matchingEdge, senseOfEdgeUse(coEdge),
           coEdge->GetDirection() ? smtk::model::POSITIVE : smtk::model::NEGATIVE);
         // Finally, create its loop.
@@ -933,7 +933,7 @@ smtk::model::EdgeUse Bridge::addEdgeUseToManager(
         if (loopUse)
           {
           smtk::common::UUID luid = this->findOrSetEntityUUID(loopUse);
-          smtk::model::Loop lpu = this->addLoopToManager(luid, loopUse, manager, relDepth - 1);
+          smtk::model::Loop lpu = this->addLoopToManager(luid, loopUse, mgr, relDepth - 1);
           }
 
         translated |= smtk::model::BRIDGE_ENTITY_ARRANGED;
@@ -948,16 +948,16 @@ smtk::model::EdgeUse Bridge::addEdgeUseToManager(
   return smtk::model::EdgeUse();
 }
 
-/// Given a CMB \a coVertex tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a coVertex tagged with \a uid, create a record in \a mgr for it.
 smtk::model::VertexUse Bridge::addVertexUseToManager(
   const smtk::common::UUID& uid,
   vtkModelVertexUse* coVertex,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
-  if (coVertex && !manager->findEntity(uid, false))
+  if (coVertex && !mgr->findEntity(uid, false))
     {
-    smtk::model::VertexUse result(manager, uid);
+    smtk::model::VertexUse result(mgr, uid);
     smtk::model::BridgedInfoBits translated = smtk::model::BRIDGE_NOTHING;
     if (relDepth >= 0)
       {
@@ -972,16 +972,16 @@ smtk::model::VertexUse Bridge::addVertexUseToManager(
   return smtk::model::VertexUse();
 }
 
-/// Given a CMB \a shell tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a shell tagged with \a uid, create a record in \a mgr for it.
 smtk::model::Shell Bridge::addShellToManager(
   const smtk::common::UUID& uid,
   vtkModelShellUse* shell,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
-  if (shell && !manager->findEntity(uid, false))
+  if (shell && !mgr->findEntity(uid, false))
     {
-    smtk::model::Shell result(manager, uid);
+    smtk::model::Shell result(mgr, uid);
     smtk::model::BridgedInfoBits translated = smtk::model::BRIDGE_NOTHING;
     if (relDepth >= 0)
       {
@@ -1026,21 +1026,21 @@ static vtkModelFaceUse* locateLoopInFace(
   return NULL;
 }
 
-/// Given a CMB \a loop tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a loop tagged with \a uid, create a record in \a mgr for it.
 smtk::model::Loop Bridge::addLoopToManager(
   const smtk::common::UUID& uid,
   vtkModelLoopUse* refLoop,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
   vtkModelFace* refFace;
-  if (refLoop && (refFace = refLoop->GetModelFace()) && !manager->findEntity(uid, false))
+  if (refLoop && (refFace = refLoop->GetModelFace()) && !mgr->findEntity(uid, false))
     {
     smtk::model::BridgedInfoBits translated = smtk::model::BRIDGE_NOTHING;
     // Insert the loop, which means inserting the face use and face regardless of relDepth,
     // because the loop's orientation and nesting must be arranged relative to them.
     smtk::common::UUID fid = this->findOrSetEntityUUID(refFace);
-    this->addFaceToManager(fid, refFace, manager, relDepth - 1);
+    this->addFaceToManager(fid, refFace, mgr, relDepth - 1);
     // Find the face *use* this loop belongs to and transcribe it.
     // Note that loop may be the child of a face use OR another loop (which we must then transcribe).
     vtkModelLoopUse* refLoopParent = NULL;
@@ -1048,17 +1048,17 @@ smtk::model::Loop Bridge::addLoopToManager(
     vtkModelFaceUse* refFaceUse = locateLoopInFace(refLoop, faceUseOrientation, refLoopParent);
     if (!refFaceUse || faceUseOrientation < 0) return smtk::model::Loop();
     //smtk::common::UUID fuid = this->findOrSetEntityUUID(refFaceUse);
-    smtk::model::FaceUse faceUse = this->addFaceUseToManager(fid, refFaceUse, manager, 0);
+    smtk::model::FaceUse faceUse = this->addFaceUseToManager(fid, refFaceUse, mgr, 0);
     smtk::model::Loop loop;
     if (refLoopParent)
       {
       smtk::common::UUID pluid = this->findOrSetEntityUUID(refLoopParent);
-      smtk::model::Loop parentLoop = this->addLoopToManager(pluid, refLoopParent, manager, 0);
-      loop = manager->setLoop(uid, parentLoop);
+      smtk::model::Loop parentLoop = this->addLoopToManager(pluid, refLoopParent, mgr, 0);
+      loop = mgr->setLoop(uid, parentLoop);
       }
     else
       {
-      loop = manager->setLoop(uid, faceUse);
+      loop = mgr->setLoop(uid, faceUse);
       }
     if (relDepth >= 0)
       {
@@ -1069,7 +1069,7 @@ smtk::model::Loop Bridge::addLoopToManager(
         {
         vtkModelEdgeUse* eu = refLoop->GetModelEdgeUse(i);
         smtk::common::UUID euid = this->findOrSetEntityUUID(eu);
-        this->addEdgeUseToManager(euid, eu, manager, relDepth - 1);
+        this->addEdgeUseToManager(euid, eu, mgr, relDepth - 1);
         }
       }
 
@@ -1081,16 +1081,16 @@ smtk::model::Loop Bridge::addLoopToManager(
   return smtk::model::Loop();
 }
 
-/// Given a CMB \a refVolume tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a refVolume tagged with \a uid, create a record in \a mgr for it.
 smtk::model::Volume Bridge::addVolumeToManager(
   const smtk::common::UUID& uid,
   vtkModelRegion* refVolume,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
-  if (refVolume && !manager->findEntity(uid, false))
+  if (refVolume && !mgr->findEntity(uid, false))
     {
-    smtk::model::Volume result(manager->insertVolume(uid));
+    smtk::model::Volume result(mgr->insertVolume(uid));
     smtk::model::BridgedInfoBits translated = smtk::model::BRIDGE_NOTHING;
     if (relDepth >= 0)
       {
@@ -1107,16 +1107,16 @@ smtk::model::Volume Bridge::addVolumeToManager(
   return smtk::model::Volume();
 }
 
-/// Given a CMB \a refFace tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a refFace tagged with \a uid, create a record in \a mgr for it.
 smtk::model::Face Bridge::addFaceToManager(
   const smtk::common::UUID& uid,
   vtkModelFace* refFace,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
-  if (refFace && !manager->findEntity(uid, false))
+  if (refFace && !mgr->findEntity(uid, false))
     {
-    smtk::model::Face result(manager->insertFace(uid));
+    smtk::model::Face result(mgr->insertFace(uid));
     smtk::model::BridgedInfoBits translated = smtk::model::BRIDGE_NOTHING;
     if (relDepth >= 0)
       { // Add refFace relations and arrangements
@@ -1130,10 +1130,10 @@ smtk::model::Face Bridge::addFaceToManager(
           {
           haveFaceUse = true;
           smtk::common::UUID fuid = this->findOrSetEntityUUID(fu);
-          this->addFaceUseToManager(fuid, fu, manager, relDepth - 1);
+          this->addFaceUseToManager(fuid, fu, mgr, relDepth - 1);
           // Now, since we are the "higher" end of the relationship,
           // arrange the use wrt ourself:
-          manager->findCreateOrReplaceCellUseOfSenseAndOrientation(
+          mgr->findCreateOrReplaceCellUseOfSenseAndOrientation(
             uid, 0, i ? smtk::model::POSITIVE : smtk::model::NEGATIVE, fuid);
           }
         }
@@ -1146,7 +1146,7 @@ smtk::model::Face Bridge::addFaceToManager(
           vtkModelRegion* vol = refFace->GetModelRegion(i);
           if (vol)
             {
-            Volume v(manager, this->findOrSetEntityUUID(vol));
+            Volume v(mgr, this->findOrSetEntityUUID(vol));
             result.addRawRelation(v);
             }
           }
@@ -1166,16 +1166,16 @@ smtk::model::Face Bridge::addFaceToManager(
   return smtk::model::Face();
 }
 
-/// Given a CMB \a refEdge tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a refEdge tagged with \a uid, create a record in \a mgr for it.
 smtk::model::Edge Bridge::addEdgeToManager(
   const smtk::common::UUID& uid,
   vtkModelEdge* refEdge,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
-  if (refEdge && !manager->findEntity(uid, false))
+  if (refEdge && !mgr->findEntity(uid, false))
     {
-    smtk::model::Edge result(manager->insertEdge(uid));
+    smtk::model::Edge result(mgr->insertEdge(uid));
     smtk::model::BridgedInfoBits translated = smtk::model::BRIDGE_NOTHING;
     if (relDepth >= 0)
       {
@@ -1185,7 +1185,7 @@ smtk::model::Edge Bridge::addEdgeToManager(
         {
         vtkModelEdgeUse* eu = refEdge->GetModelEdgeUse(i);
         smtk::common::UUID euid = this->findOrSetEntityUUID(eu);
-        this->addEdgeUseToManager(euid, eu, manager, relDepth - 1);
+        this->addEdgeUseToManager(euid, eu, mgr, relDepth - 1);
         }
       // Add geometry, if any.
       this->addTessellation(result, refEdge);
@@ -1196,19 +1196,19 @@ smtk::model::Edge Bridge::addEdgeToManager(
 
     return result;
     }
-  return smtk::model::Edge(manager, uid);
+  return smtk::model::Edge(mgr, uid);
 }
 
-/// Given a CMB \a refVertex tagged with \a uid, create a record in \a manager for it.
+/// Given a CMB \a refVertex tagged with \a uid, create a record in \a mgr for it.
 smtk::model::Vertex Bridge::addVertexToManager(
   const smtk::common::UUID& uid,
   vtkModelVertex* refVertex,
-  smtk::model::ManagerPtr manager,
+  smtk::model::ManagerPtr mgr,
   int relDepth)
 {
-  if (refVertex && !manager->findEntity(uid, false))
+  if (refVertex && !mgr->findEntity(uid, false))
     {
-    smtk::model::Vertex result(manager->insertVertex(uid));
+    smtk::model::Vertex result(mgr->insertVertex(uid));
     smtk::model::BridgedInfoBits translated = smtk::model::BRIDGE_NOTHING;
     if (relDepth >= 0)
       {

--- a/smtk/bridge/discrete/CMakeLists.txt
+++ b/smtk/bridge/discrete/CMakeLists.txt
@@ -179,6 +179,42 @@ smtk_public_headers(${discreteBridgeHeaders} ${DiscreteModelHeaders})
 #install the library and exports the library when used from a build tree
 smtk_install_library(smtkDiscreteBridge DEPENDS SMTKCore vtkSMTKDiscreteModel)
 
+if(SMTK_BUILD_PYTHON_WRAPPINGS AND Shiboken_FOUND)
+  #extract the headers from discrete library we built to give them to shiboken
+
+  sbk_wrap_library(smtkDiscreteBridge
+    GENERATOR_ARGS --avoid-protected-hack
+    WORKING_DIRECTORY ${SMTK_SOURCE_DIR}/smtk
+    LOCAL_INCLUDE_DIRECTORIES
+      ${SMTK_SOURCE_DIR}/smtk/common
+      ${SMTK_SOURCE_DIR}/smtk/attribute
+      ${SMTK_SOURCE_DIR}/smtk/model
+      ${SMTK_SOURCE_DIR}/smtk/bridge
+      ${SMTK_SOURCE_DIR}/smtk/bridge/discrete
+      ${SMTK_SOURCE_DIR}/smtk/simulation
+      ${SMTK_SOURCE_DIR}/smtk/io
+      ${SMTK_SOURCE_DIR}/smtk/view
+      ${SMTK_SOURCE_DIR}/smtk
+      ${SMTK_BINARY_DIR}/smtk
+      ${CMAKE_CURRENT_BINARY_DIR}
+    TYPESYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/typesystem.xml
+    HEADERS ${discreteBridgeHeaders}
+    DEPENDS
+      SMTKCore
+  )
+  target_include_directories(smtkDiscreteBridgePython
+    PRIVATE
+      "${CMAKE_CURRENT_BINARY_DIR}"
+      "${CMAKE_CURRENT_SOURCE_DIR}"
+      "${CMAKE_CURRENT_SOURCE_DIR}/operation"
+      "${CMAKE_CURRENT_SOURCE_DIR}/kernel"
+      "${CMAKE_CURRENT_SOURCE_DIR}/kernel/Model"
+      "${CMAKE_CURRENT_SOURCE_DIR}/kernel/Serialize"
+      "${CMAKE_CURRENT_BINARY_DIR}/operation"
+      "${CMAKE_CURRENT_BINARY_DIR}/kernel"
+  )
+endif()
+
 if(SMTK_BUILD_BRIDGE_PLUGIN AND SMTK_BUILD_DISCRETE_BRIDGE)
   add_subdirectory(plugin)
 endif()

--- a/smtk/bridge/discrete/ReadOperator.cxx
+++ b/smtk/bridge/discrete/ReadOperator.cxx
@@ -84,10 +84,13 @@ OperatorResult ReadOperator::operateInternal()
   smtk::model::Cursor modelEntity(this->manager(), modelId);
 
   OperatorResult result = this->createResult(OPERATION_SUCCEEDED);
-  result->findModelEntity("model")->setValue(modelEntity);
+  smtk::attribute::ModelEntityItemPtr models =
+    result->findModelEntity("entities");
+  models->setNumberOfValues(1);
+  models->setValue(0, modelEntity);
 
 #if defined(SMTK_DISCRETE_BRIDGE_DEBUG)
-std::string json = smtk::io::ExportJSON::fromModel(this->manager());
+  std::string json = smtk::io::ExportJSON::fromModel(this->manager());
     std::ofstream file("/tmp/read_op_out.json");
     file << json;
     file.close();

--- a/smtk/bridge/discrete/ReadOperator.sbt
+++ b/smtk/bridge/discrete/ReadOperator.sbt
@@ -12,11 +12,6 @@
       </ItemDefinitions>
     </AttDef>
     <!-- Result -->
-    <AttDef Type="result(read)" BaseType="result">
-      <ItemDefinitions>
-        <!-- The model read from the file. -->
-        <ModelEntity Name="model" NumberOfRequiredValues="1"/>
-      </ItemDefinitions>
-    </AttDef>
+    <AttDef Type="result(read)" BaseType="result"/>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/discrete/kernel/vtkDiscreteModelFace.cxx
+++ b/smtk/bridge/discrete/kernel/vtkDiscreteModelFace.cxx
@@ -510,7 +510,7 @@ void vtkDiscreteModelFace::WalkLoop(vtkIdType startingEdge,
 {
   vtkIdType currentEdge = startingEdge;
   vtkNew<vtkIdList>cellIds, pointIds;
-  vtkIdType currentPoint, firstPoint, nextPoint;
+  vtkIdType currentPoint, nextPoint;
   vtkIdType gedge;
   std::string currentFaceInfo;
   vtkDiscreteModel* thisModel = vtkDiscreteModel::SafeDownCast(
@@ -540,7 +540,7 @@ void vtkDiscreteModelFace::WalkLoop(vtkIdType startingEdge,
       }
     if (currentPoint == -1)
       {
-      firstPoint = currentPoint = pointIds->GetId(0);
+      currentPoint = pointIds->GetId(0);
       nextPoint = pointIds->GetId(1);
       }
     else if (currentPoint != pointIds->GetId(0))

--- a/smtk/bridge/discrete/testing/CMakeLists.txt
+++ b/smtk/bridge/discrete/testing/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_subdirectory(cxx)
+
+if(SMTK_BUILD_PYTHON_WRAPPINGS AND Shiboken_FOUND)
+  add_subdirectory(python)
+endif()

--- a/smtk/bridge/discrete/testing/cxx/BridgeTest.cxx
+++ b/smtk/bridge/discrete/testing/cxx/BridgeTest.cxx
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
     return 1;
     }
 
-  smtk::model::ModelEntity model = result->findModelEntity("model")->value();
+  smtk::model::ModelEntity model = result->findModelEntity("entities")->value();
   manager->assignDefaultNames(); // should force transcription of every entity, but doesn't yet.
 
   smtk::model::DescriptivePhrase::Ptr dit;

--- a/smtk/bridge/discrete/testing/python/CMakeLists.txt
+++ b/smtk/bridge/discrete/testing/python/CMakeLists.txt
@@ -4,7 +4,7 @@ set(smtkDiscreteBridgePythonTests
 
 # Additional tests that require SMTK_DATA_DIR
 set(smtkDiscreteBridgePythonDataTests
-  discreteLoadFile
+#  discreteLoadFile
 )
 
 foreach (test ${smtkDiscreteBridgePythonTests})

--- a/smtk/bridge/discrete/testing/python/CMakeLists.txt
+++ b/smtk/bridge/discrete/testing/python/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(smtkDiscreteBridgePythonTests
+#  discreteModeling
+)
+
+# Additional tests that require SMTK_DATA_DIR
+set(smtkDiscreteBridgePythonDataTests
+  discreteLoadFile
+)
+
+foreach (test ${smtkDiscreteBridgePythonTests})
+  add_test(${test}Py ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py)
+  set_tests_properties(${test}Py
+    PROPERTIES
+      ENVIRONMENT "PYTHONPATH=${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
+  )
+endforeach()
+
+if (SMTK_DATA_DIR AND EXISTS ${SMTK_DATA_DIR}/ReadMe.mkd)
+  foreach (test ${smtkDiscreteBridgePythonDataTests})
+    add_test(${test}Py
+             ${PYTHON_EXECUTABLE}
+             ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py
+             ${SMTK_DATA_DIR})
+    set_tests_properties(${test}Py
+      PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
+    )
+  endforeach()
+endif()

--- a/smtk/bridge/discrete/testing/python/discreteLoadFile.py
+++ b/smtk/bridge/discrete/testing/python/discreteLoadFile.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+import sys
+#=============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+#=============================================================================
+import os
+import sys
+import smtk
+
+mgr = smtk.model.Manager.create()
+sess = mgr.createSession('discrete')
+brg = sess.bridge() # smtk.model.Manager.createBridge('cgm')
+sess.assignDefaultName()
+print '\n\n%s: type "%s" %s %s' % \
+  (sess.name(), brg.name(), sess.flagSummary(0), brg.sessionId())
+print '  Site: %s' % (sess.site() or 'local')
+for eng in sess.engines():
+  print '  Engine %s filetypes:\n    %s' % \
+    (eng, '\n    '.join(sess.fileTypes(eng)))
+print 'Operators:\n  '
+print '\n  '.join(sess.operatorNames())
+print '\n'
+
+rdr = sess.op('read')
+rdr.findAsFile('filename').setValue(os.path.join(sys.argv[1], 'cmb', 'test2D.cmb'))
+res = rdr.operate()
+mod = smtk.model.ModelEntity(res.findModelEntity('entities').value(0))
+
+print '\nFree cells:\n  %s' % '\n  '.join([x.name() for x in mod.cells()])
+print '\nGroups:\n  %s\n' % '\n  '.join([x.name() for x in mod.groups()])
+if len(mod.cells()) != 4:
+  print smtk.io.ExportJSON.fromModel(mgr)
+  raise Exception, 'Wrong number of free cells'

--- a/smtk/bridge/discrete/typesystem.xml
+++ b/smtk/bridge/discrete/typesystem.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<typesystem package="@TYPESYSTEM_NAME@">
+
+  @EXTRA_TYPESYSTEMS@
+
+  <!-- Ignore Shiboken notice that CGM lives inside SMTK namespace -->
+  <suppress-warning text="Duplicate type entry: 'smtk'"/>
+
+  <!-- Additional objects to be wrapped when building with CGM -->
+  <namespace-type name="smtk" generate = "no">
+    <namespace-type name="bridge" generate = "no">
+      <namespace-type name="discrete" generate = "yes">
+
+        <object-type name="Bridge">
+          <include file-name="smtk/bridge/discrete/Bridge.h" location="local"/>
+        </object-type>
+
+      </namespace-type>
+    </namespace-type>
+  </namespace-type>
+
+  <value-type template="smtk::shared_ptr" args="smtk::bridge::discrete::Bridge">
+  </value-type>
+
+  @EXTRA_OBJECTS@
+
+</typesystem>

--- a/smtk/smtk.py
+++ b/smtk/smtk.py
@@ -84,12 +84,15 @@ view = _temp.smtk.view
 try:
   from collections import namedtuple
   btuple = []
+  failed = []
   _tempmain = _temp
   try:
     _tempcgm = __import__('cgmSMTKPython', globals(), locals(), [], -1)
     _temp = _tempcgm
     __import_shared_ptrs__()
     btuple.append(('cgm', _tempcgm.cgm))
+  except:
+    failed += ['cgm']
   finally:
     _temp = _tempmain
 
@@ -98,6 +101,18 @@ try:
     _temp = _tempexo
     __import_shared_ptrs__()
     btuple.append(('exodus', _tempexo.exodus))
+  except:
+    failed += ['exodus']
+  finally:
+    _temp = _tempmain
+
+  try:
+    _tempdis = __import__('smtkDiscreteBridgePython', globals(), locals(), [], -1)
+    _temp = _tempdis
+    __import_shared_ptrs__()
+    btuple.append(('discrete', _tempdis.discrete))
+  except:
+    failed += ['discrete']
   finally:
     _temp = _tempmain
 
@@ -106,8 +121,11 @@ try:
     _temp = _tempremote
     __import_shared_ptrs__()
     btuple.append(('remote', _tempremote.remote))
+  except:
+    failed += ['remote']
   finally:
     _temp = _tempmain
+
   if len(btuple) > 0:
     bridgeModule = namedtuple('bridgeModule', ' '.join([x for x,y in btuple]))
     bridge = bridgeModule(*[y for x,y in btuple])


### PR DESCRIPTION
This will allow python tests of the discrete bridge that mirror the CGM tests. See `smtk/bridge/discrete/testing/python`.

This commit also removes some warnings from the dashboard and harmonizes the discrete bridge's Read operator with others (by placing the list of entities read into the "entities" item provided by the base attribute definition instead of an operator-specific item.