### PR TITLE
Remote operator surgery

### DIFF
--- a/doc/tutorials/python_first_steps/first_steps.py
+++ b/doc/tutorials/python_first_steps/first_steps.py
@@ -90,7 +90,7 @@ matProp = asys.createAttribute('fluid', matDef)
 # TODO: Replace with resource.readModel()
 jsonFile = open(modelFileName,'r')
 json = jsonFile.read()
-smtk.io.ImportJSON.intoModel(json, mmgr)
+smtk.io.ImportJSON.intoModelManager(json, mmgr)
 
 # Now find groups corresponding to IC/BCs:
 models = mmgr.findEntitiesByProperty('name', 'Test Model')

--- a/smtk/attribute/Attribute.h
+++ b/smtk/attribute/Attribute.h
@@ -129,6 +129,7 @@ namespace smtk
 
       ModelEntityItemPtr findModelEntity(const std::string &name);
       ConstModelEntityItemPtr findModelEntity(const std::string &name) const;
+      template<typename T> T modelEntitiesAs(const std::string& name) const;
 
       void references(std::vector<smtk::attribute::ItemPtr> &list) const;
 
@@ -229,6 +230,24 @@ namespace smtk
       this->m_color[1]= g;
       this->m_color[2]= b;
       this->m_color[3]= a;
+    }
+
+//----------------------------------------------------------------------------
+    template<typename T> T Attribute::modelEntitiesAs(const std::string& name) const
+    {
+      T result;
+      ConstModelEntityItemPtr item = this->findModelEntity(name);
+      if (!item)
+        return result;
+
+      smtk::model::CursorArray::const_iterator it;
+      for (it = item->begin(); it != item->end(); ++it) {
+        typename T::value_type entry(*it);
+        if (entry.isValid()) {
+          result.insert(result.end(), entry);
+        }
+      }
+      return result;
     }
 //----------------------------------------------------------------------------
     template<typename T> T Attribute::associatedModelEntities() const

--- a/smtk/attribute/ModelEntityItem.cxx
+++ b/smtk/attribute/ModelEntityItem.cxx
@@ -194,11 +194,22 @@ std::string ModelEntityItem::valueAsString(std::size_t i) const
   return val.entity().toString();
 }
 
-/// Return whether the \a i-th value is set (i.e., a valid model entity).
+/**\brief Return whether the \a i-th value is set.
+  *
+  * This returns true when the UUID is non-NULL and false otherwise.
+  *
+  * Note that this is <b>not always what you would expect</b>!
+  * You can set a value to be an invalid, non-NULL UUID so that
+  * entities which have been expunged can be reported (and other
+  * use cases).
+  * If you want to guarantee that particular value is valid or
+  * invalid, you should use the Cursor's isValid() method after
+  * fetching the value from the ModelEntityItem.
+  */
 bool ModelEntityItem::isSet(std::size_t i) const
 {
   return i < this->m_values.size() ?
-    this->m_values[i].isValid() :
+    !!this->m_values[i].entity() :
     false;
 }
 

--- a/smtk/attribute/testing/python/copyAttributeTest.py
+++ b/smtk/attribute/testing/python/copyAttributeTest.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     logging.error('Unable to load input file %s' % model_path)
     sys.exit(-3)
   model_manager = smtk.model.Manager.create()
-  ok = smtk.io.ImportJSON.intoModel(json_string, model_manager)
+  ok = smtk.io.ImportJSON.intoModelManager(json_string, model_manager)
   if not ok:
       logging.error("Unable to create model from contents of %s" % model_path)
       sys.exit(-4)

--- a/smtk/bridge/cgm/cgm-convert.cxx
+++ b/smtk/bridge/cgm/cgm-convert.cxx
@@ -501,7 +501,7 @@ void ExportBodyToJSONFile(
   const std::string& filename)
 {
   cJSON* json = cJSON_CreateObject();
-  smtk::io::ExportJSON::fromModel(json, manager);
+  smtk::io::ExportJSON::fromModelManager(json, manager);
   char* exported = cJSON_Print(json);
   cJSON_Delete(json);
   FILE* fid = fopen(filename.c_str(), "w");

--- a/smtk/bridge/cgm/facet-convert.cxx
+++ b/smtk/bridge/cgm/facet-convert.cxx
@@ -505,7 +505,7 @@ void ExportBodyToJSONFile(
   const std::string& filename)
 {
   cJSON* json = cJSON_CreateObject();
-  smtk::io::ExportJSON::fromModel(json, manager);
+  smtk::io::ExportJSON::fromModelManager(json, manager);
   char* exported = cJSON_Print(json);
   cJSON_Delete(json);
   FILE* fid = fopen(filename.c_str(), "w");

--- a/smtk/bridge/cgm/operators/Read.cxx
+++ b/smtk/bridge/cgm/operators/Read.cxx
@@ -114,7 +114,7 @@ smtk::model::OperatorResult Read::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
   smtk::attribute::ModelEntityItem::Ptr resultModels =
-    result->findModelEntity("model");
+    result->findModelEntity("entities");
 
   Bridge* bridge = this->cgmBridge();
   std::string modelName = filename.substr(0, filename.find_last_of("."));

--- a/smtk/bridge/cgm/operators/Read.sbt
+++ b/smtk/bridge/cgm/operators/Read.sbt
@@ -13,11 +13,6 @@
       </ItemDefinitions>
     </AttDef>
     <!-- Result -->
-    <AttDef Type="result(read)" BaseType="result">
-      <ItemDefinitions>
-        <!-- The model read from the file. -->
-        <ModelEntity Name="model" NumberOfRequiredValues="1" Extensible="1" MembershipMask="4096"/>
-      </ItemDefinitions>
-    </AttDef>
+    <AttDef Type="result(read)" BaseType="result"/>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/testing/cxx/test-operators.cxx
+++ b/smtk/bridge/cgm/testing/cxx/test-operators.cxx
@@ -206,7 +206,7 @@ int main (int argc, char* argv[])
   std::cout << "Created " << bodies->value().flagSummary() << "\n";
   std::cout << "   with " << bodies->value().as<ModelEntity>().cells().size() << " cells\n";
   //std::ofstream json("/tmp/sphere.json");
-  //json << ExportJSON::fromModel(mgr);
+  //json << ExportJSON::fromModelManager(mgr);
   //json.close();
 
   return 0;

--- a/smtk/bridge/cgm/testing/python/cgmBooleans.py
+++ b/smtk/bridge/cgm/testing/python/cgmBooleans.py
@@ -146,7 +146,7 @@ bssub = Subtract(workpiece=b0, tool=s0)
 
 Translate(bsint, [0.1, 0.1, 0.1])
 
-json = smtk.io.ExportJSON.fromModel(mgr)
+json = smtk.io.ExportJSON.fromModelManager(mgr)
 sphFile = open('boolean.json', 'w')
 print >> sphFile, json
 sphFile.close()

--- a/smtk/bridge/cgm/testing/python/cgmBuildUp.py
+++ b/smtk/bridge/cgm/testing/python/cgmBuildUp.py
@@ -83,7 +83,7 @@ for face in fedg:
   t.setValue(face[0])
   faces.append(crf.operate().findModelEntity('face').value(0))
 
-json = smtk.io.ExportJSON.fromModel(mgr)
+json = smtk.io.ExportJSON.fromModelManager(mgr)
 sphFile = open('buildup.json', 'w')
 print >> sphFile, json
 sphFile.close()

--- a/smtk/bridge/cgm/testing/python/cgmCreateBrick.py
+++ b/smtk/bridge/cgm/testing/python/cgmCreateBrick.py
@@ -61,7 +61,7 @@ setAxis(off, [8., 3., 7.])
 r4 = top.operate()
 b4 = r4.findModelEntity('entities').value(0)
 
-json = smtk.io.ExportJSON.fromModel(mgr)
+json = smtk.io.ExportJSON.fromModelManager(mgr)
 sphFile = open('/tmp/brickly2.json', 'w')
 print >> sphFile, json
 sphFile.close()

--- a/smtk/bridge/cgm/testing/python/cgmSolidModeling.py
+++ b/smtk/bridge/cgm/testing/python/cgmSolidModeling.py
@@ -65,7 +65,7 @@ res = u1.operate()
 su = res.findModelEntity('entities').value(0)
 # Note that su has same UUID as sph2
 
-#json = smtk.io.ExportJSON.fromModel(mgr)
+#json = smtk.io.ExportJSON.fromModelManager(mgr)
 #sphFile = open('/tmp/s3.json', 'w')
 #print >> sphFile, json
 #sphFile.close()

--- a/smtk/bridge/cgm/testing/python/cgmTransforms.py
+++ b/smtk/bridge/cgm/testing/python/cgmTransforms.py
@@ -43,7 +43,7 @@ brick1 = r1.findModelEntity('entities').value(0)
 r2 = cb.operate()
 brick2 = r2.findModelEntity('entities').value(0)
 
-#json = smtk.io.ExportJSON.fromModel(mgr)
+#json = smtk.io.ExportJSON.fromModelManager(mgr)
 #jsonFile = open('/tmp/skirb1.json', 'w')
 #print >> jsonFile, json
 #jsonFile.close()
@@ -89,7 +89,7 @@ sc.findAsDouble('scale factor').setValue(3.0)
 r6 = sc.operate()
 brick6 = r6.findModelEntity('entities').value(0)
 
-#json = smtk.io.ExportJSON.fromModel(mgr)
+#json = smtk.io.ExportJSON.fromModelManager(mgr)
 #jsonFile = open('/tmp/skirb4.json', 'w')
 #print >> jsonFile, json
 #jsonFile.close()

--- a/smtk/bridge/discrete/EntityGroupOperator.cxx
+++ b/smtk/bridge/discrete/EntityGroupOperator.cxx
@@ -184,7 +184,7 @@ OperatorResult EntityGroupOperator::operateInternal()
       {
       // Return the created or modified group.
       smtk::attribute::ModelEntityItem::Ptr remEntities =
-        result->findModelEntity("deleted entities");
+        result->findModelEntity("expunged");
       remEntities->setNumberOfValues(1);
       remEntities->setValue(0, grpRem);
       }

--- a/smtk/bridge/discrete/EntityGroupOperator.cxx
+++ b/smtk/bridge/discrete/EntityGroupOperator.cxx
@@ -109,7 +109,7 @@ OperatorResult EntityGroupOperator::operateInternal()
       bgroup.setMembershipMask(mask);
       // Add group to model's relationship
       model.addGroup(bgroup);
-      std::cout << "Added " << bgroup.name() << " to " << model.name() << "\n";
+      std::cout << "new group: " << bgroup.name() << " id: " << grpUUID.toString() << "\n";
       }
     }
   else if(optype == "Remove")
@@ -167,6 +167,14 @@ OperatorResult EntityGroupOperator::operateInternal()
     if(bgroup.isValid())
       {
       // Return the created or modified group.
+      smtk::attribute::ModelEntityItem::Ptr entities =
+        result->findModelEntity("entities");
+      entities->setNumberOfValues(1);
+      entities->setValue(0, bgroup);
+
+    // Adding the new group to the "new entities" item, as a convenient method
+    // to get newly created group from result. This group is also listed in the
+    // "entities" item.
       smtk::attribute::ModelEntityItem::Ptr newEntities =
         result->findModelEntity("new entities");
       newEntities->setNumberOfValues(1);
@@ -176,7 +184,7 @@ OperatorResult EntityGroupOperator::operateInternal()
       {
       // Return the created or modified group.
       smtk::attribute::ModelEntityItem::Ptr remEntities =
-        result->findModelEntity("removed entities");
+        result->findModelEntity("deleted entities");
       remEntities->setNumberOfValues(1);
       remEntities->setValue(0, grpRem);
       }

--- a/smtk/bridge/discrete/EntityGroupOperator.sbt
+++ b/smtk/bridge/discrete/EntityGroupOperator.sbt
@@ -58,6 +58,11 @@
     </AttDef>
 
     <!-- Result -->
-    <AttDef Type="result(entity group)" BaseType="result"/>
+    <AttDef Type="result(entity group)" BaseType="result">
+      <ItemDefinitions>
+        <ModelEntity Name="new entities" NumberOfRequiredValues="0" Extensible="1">
+        </ModelEntity>
+      </ItemDefinitions>
+    </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/discrete/ImportOperator.cxx
+++ b/smtk/bridge/discrete/ImportOperator.cxx
@@ -152,7 +152,12 @@ OperatorResult ImportOperator::operateInternal()
   smtk::model::Cursor modelEntity(this->manager(), modelId);
 
   OperatorResult result = this->createResult(OPERATION_SUCCEEDED);
-  result->findModelEntity("model")->setValue(modelEntity);
+
+  smtk::attribute::ModelEntityItemPtr models =
+    result->findModelEntity("entities");
+  models->setNumberOfValues(1);
+  models->setValue(0, modelEntity);
+
 /*
 //#include "smtk/io/ExportJSON.h"
 //#include "cJSON.h"

--- a/smtk/bridge/discrete/ImportOperator.cxx
+++ b/smtk/bridge/discrete/ImportOperator.cxx
@@ -158,12 +158,12 @@ OperatorResult ImportOperator::operateInternal()
 //#include "cJSON.h"
 
   cJSON* json = cJSON_CreateObject();
-  smtk::io::ExportJSON::fromModel(json, this->manager());
+  smtk::io::ExportJSON::fromModelManager(json, this->manager());
   std::cout << "Result " << cJSON_Print(json) << "\n";
   cJSON_Delete(json);
   */
 /*
-std::string json = smtk::io::ExportJSON::fromModel(this->manager());
+std::string json = smtk::io::ExportJSON::fromModelManager(this->manager());
     std::ofstream file("/tmp/import_op_out.json");
     file << json;
     file.close();

--- a/smtk/bridge/discrete/ImportOperator.sbt
+++ b/smtk/bridge/discrete/ImportOperator.sbt
@@ -12,11 +12,6 @@
       </ItemDefinitions>
     </AttDef>
     <!-- Result -->
-    <AttDef Type="result(import)" BaseType="result">
-      <ItemDefinitions>
-        <!-- The model imported from the file. -->
-        <ModelEntity Name="model" NumberOfRequiredValues="1"/>
-      </ItemDefinitions>
-    </AttDef>
+    <AttDef Type="result(import)" BaseType="result"/>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/discrete/MergeOperator.cxx
+++ b/smtk/bridge/discrete/MergeOperator.cxx
@@ -17,10 +17,14 @@
 #include "smtk/attribute/ModelEntityItem.h"
 
 #include "smtk/model/ModelEntity.h"
+#include "smtk/model/CellEntity.h"
 #include "smtk/model/Manager.h"
+#include "smtk/model/Volume.h"
 
 #include "vtkModelItem.h"
 #include "vtkModelEntity.h"
+#include "vtkModelFace.h"
+#include "vtkModelRegion.h"
 
 #include "MergeOperator_xml.h"
 
@@ -78,18 +82,44 @@ OperatorResult MergeOperator::operateInternal()
       this->specification()->findModelEntity("target cell")->value();
 
     // Get rid of the old entity.
+/*
+    Cursors bdys = srcEnt.as<CellEntity>().lowerDimensionalBoundaries(-1);
+    for (Cursors::iterator bit = bdys.begin(); bit != bdys.end(); ++bit)
+      {
+      //std::cout << "Erasing " << bit->flagSummary(0) << " " << bit->entity() << "\n";
+      store->erase(bit->entity());
+      }
+ */
     store->erase(srcEnt.entity());
 
     // re-add target
     smtk::common::UUID eid = tgtEnt.entity();
     vtkModelItem* origItem =
       bridge->entityForUUID(eid);
+
     store->erase(eid);
 
     // Now re-add it (it will have new edges)
     eid = bridge->findOrSetEntityUUID(origItem);
     smtk::model::Cursor c = bridge->addCMBEntityToManager(
       eid, origItem, store, true);
+    if(vtkModelFace* origFace = vtkModelFace::SafeDownCast(origItem))
+      {
+      vtkModelRegion* v1 = origFace->GetModelRegion(0);
+      vtkModelRegion* v2 = origFace->GetModelRegion(1);
+      Volume vol1 = v1 ? Volume(store, bridge->findOrSetEntityUUID(v1)) : Volume();
+      Volume vol2 = v2 ? Volume(store, bridge->findOrSetEntityUUID(v2)) : Volume();
+      if(vol1.isValid())
+        {
+        c.addRawRelation(vol1);
+        vol1.addRawRelation(c);
+        }
+      if(vol2.isValid())
+        {
+        c.addRawRelation(vol2);
+        vol2.addRawRelation(c);
+        }
+      }
 
     // Return the list of entities that were created
     // so that remote bridges can track what records
@@ -100,12 +130,12 @@ OperatorResult MergeOperator::operateInternal()
     resultEntities->setValue(0, c);
 
     smtk::attribute::ModelEntityItem::Ptr removedEntities =
-      result->findModelEntity("removed entities");
+      result->findModelEntity("deleted entities");
     removedEntities->setNumberOfValues(1);
     removedEntities->setValue(0, srcEnt);
 
     smtk::attribute::IntItem::Ptr eventEntity =
-      result->findInt("eventtype");
+      result->findInt("event type");
     eventEntity->setNumberOfValues(1);
     eventEntity->setValue(0, TESSELLATION_ENTRY);
 

--- a/smtk/bridge/discrete/MergeOperator.cxx
+++ b/smtk/bridge/discrete/MergeOperator.cxx
@@ -130,7 +130,7 @@ OperatorResult MergeOperator::operateInternal()
     resultEntities->setValue(0, c);
 
     smtk::attribute::ModelEntityItem::Ptr removedEntities =
-      result->findModelEntity("deleted entities");
+      result->findModelEntity("expunged");
     removedEntities->setNumberOfValues(1);
     removedEntities->setValue(0, srcEnt);
 

--- a/smtk/bridge/discrete/MergeOperator.cxx
+++ b/smtk/bridge/discrete/MergeOperator.cxx
@@ -132,6 +132,7 @@ OperatorResult MergeOperator::operateInternal()
     smtk::attribute::ModelEntityItem::Ptr removedEntities =
       result->findModelEntity("expunged");
     removedEntities->setNumberOfValues(1);
+    removedEntities->setIsEnabled(true);
     removedEntities->setValue(0, srcEnt);
 
     smtk::attribute::IntItem::Ptr eventEntity =

--- a/smtk/bridge/discrete/MergeOperator.sbt
+++ b/smtk/bridge/discrete/MergeOperator.sbt
@@ -18,6 +18,11 @@
       </ItemDefinitions>
     </AttDef>
     <!-- Result -->
-    <AttDef Type="result(merge)" BaseType="result"/>
+    <AttDef Type="result(merge)" BaseType="result">
+      <ItemDefinitions>
+        <Int Name="event type" NumberOfRequiredValues="1" />
+      </ItemDefinitions>
+    </AttDef>
+
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/discrete/ReadOperator.cxx
+++ b/smtk/bridge/discrete/ReadOperator.cxx
@@ -90,7 +90,7 @@ OperatorResult ReadOperator::operateInternal()
   models->setValue(0, modelEntity);
 
 #if defined(SMTK_DISCRETE_BRIDGE_DEBUG)
-  std::string json = smtk::io::ExportJSON::fromModel(this->manager());
+  std::string json = smtk::io::ExportJSON::fromModelManager(this->manager());
     std::ofstream file("/tmp/read_op_out.json");
     file << json;
     file.close();

--- a/smtk/bridge/discrete/SplitFaceOperator.sbt
+++ b/smtk/bridge/discrete/SplitFaceOperator.sbt
@@ -21,6 +21,13 @@
       </ItemDefinitions>
     </AttDef>
     <!-- Result -->
-    <AttDef Type="result(split face)" BaseType="result"/>
+    <AttDef Type="result(split face)" BaseType="result">
+      <ItemDefinitions>
+        <ModelEntity Name="new entities" NumberOfRequiredValues="0" Extensible="1">
+          <MembershipMask>face</MembershipMask>
+        </ModelEntity>
+        <Int Name="event type" NumberOfRequiredValues="1" />
+      </ItemDefinitions>
+    </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/discrete/legacycmb/CMBModel/vtkSMTKJsonModelReader.cxx
+++ b/smtk/bridge/discrete/legacycmb/CMBModel/vtkSMTKJsonModelReader.cxx
@@ -82,7 +82,7 @@ int vtkSMTKJsonModelReader::RequestData(
 //vtkErrorMacro( << "json model (data): " << data.c_str());
   ManagerPtr sm = Manager::create();
 
-  int status = ! ImportJSON::intoModel(data.c_str(), sm);
+  int status = ! ImportJSON::intoModelManager(data.c_str(), sm);
   if (status)
     {
     vtkErrorMacro( << "Error status from ImportJSON: " << status);

--- a/smtk/bridge/discrete/testing/cxx/BridgeTest.cxx
+++ b/smtk/bridge/discrete/testing/cxx/BridgeTest.cxx
@@ -153,7 +153,7 @@ int main(int argc, char* argv[])
     std::cout << "  done\n";
     }
 
-  std::string json = smtk::io::ExportJSON::fromModel(manager);
+  std::string json = smtk::io::ExportJSON::fromModelManager(manager);
   if (!json.empty())
     {
     std::ofstream jsonFile("bridgeTest.json");

--- a/smtk/bridge/discrete/testing/python/discreteLoadFile.py
+++ b/smtk/bridge/discrete/testing/python/discreteLoadFile.py
@@ -37,5 +37,5 @@ mod = smtk.model.ModelEntity(res.findModelEntity('entities').value(0))
 print '\nFree cells:\n  %s' % '\n  '.join([x.name() for x in mod.cells()])
 print '\nGroups:\n  %s\n' % '\n  '.join([x.name() for x in mod.groups()])
 if len(mod.cells()) != 4:
-  print smtk.io.ExportJSON.fromModel(mgr)
+  print smtk.io.ExportJSON.fromModelManager(mgr)
   raise Exception, 'Wrong number of free cells'

--- a/smtk/bridge/remote/RemusRPCWorker.cxx
+++ b/smtk/bridge/remote/RemusRPCWorker.cxx
@@ -297,7 +297,7 @@ void RemusRPCWorker::processJob(
         cJSON* model = cJSON_CreateObject();
         // Never include bridge session list or tessellation data
         // Until someone makes us.
-        smtk::io::ExportJSON::fromModel(model, this->m_modelMgr,
+        smtk::io::ExportJSON::fromModelManager(model, this->m_modelMgr,
           static_cast<smtk::io::JSONFlags>(
             smtk::io::JSON_ENTITIES | smtk::io::JSON_PROPERTIES));
         cJSON_AddItemToObject(result, "result", model);

--- a/smtk/bridge/remote/RemusRemoteBridge.cxx
+++ b/smtk/bridge/remote/RemusRemoteBridge.cxx
@@ -139,7 +139,7 @@ smtk::model::OperatorResult RemusRemoteBridge::operateDelegate(
     !resp ||
     (err = cJSON_GetObjectItem(resp, "error")) ||
     !(res = cJSON_GetObjectItem(resp, "result")) ||
-    !smtk::io::ImportJSON::ofOperatorResult(res, result, op->bridge()->operatorSystem()))
+    !smtk::io::ImportJSON::ofOperatorResult(res, result, op))
     {
     return op->createResult(smtk::model::OPERATION_FAILED);
     }

--- a/smtk/extension/qt/qtCheckItemComboBox.cxx
+++ b/smtk/extension/qt/qtCheckItemComboBox.cxx
@@ -115,7 +115,6 @@ void qtModelEntityItemCombo::init()
   QStandardItemModel* itemModel = qobject_cast<QStandardItemModel*>(this->model());
   // need to update the list, since it may be changed
   int row=1;
-  int numChecked = 0;
   smtk::model::Cursors modelEnts = modelManager->entitiesMatchingFlagsAs<smtk::model::Cursors>(
     itemDef->membershipMask(), false);
   for(smtk::model::Cursors::iterator it = modelEnts.begin(); it != modelEnts.end(); ++it)

--- a/smtk/extension/qt/testing/cxx/browseModel.cxx
+++ b/smtk/extension/qt/testing/cxx/browseModel.cxx
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
 
 
   smtk::model::ManagerPtr model = smtk::model::Manager::create();
-  smtk::io::ImportJSON::intoModel(json.c_str(), model);
+  smtk::io::ImportJSON::intoModelManager(json.c_str(), model);
   model->assignDefaultNames();
 
   smtk::model::QEntityItemModel* qmodel = new smtk::model::QEntityItemModel;
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
   if (argc > 4)
     {
     std::ofstream result(argv[4]);
-    result << smtk::io::ExportJSON::fromModel(model).c_str() << "\n";
+    result << smtk::io::ExportJSON::fromModelManager(model).c_str() << "\n";
     result.close();
     }
 

--- a/smtk/extension/vtk/testing/cxx/displayModel.cxx
+++ b/smtk/extension/vtk/testing/cxx/displayModel.cxx
@@ -281,7 +281,7 @@ int main(int argc, char* argv[])
 
   ManagerPtr sm = smtk::model::Manager::create();
 
-  int status = ! ImportJSON::intoModel(data.c_str(), sm);
+  int status = ! ImportJSON::intoModelManager(data.c_str(), sm);
   if (! status)
     {
     vtkNew<vtkModelView> view;

--- a/smtk/extension/vtk/testing/cxx/displayMultiBlockModel.cxx
+++ b/smtk/extension/vtk/testing/cxx/displayMultiBlockModel.cxx
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
 
   ManagerPtr sm = Manager::create();
 
-  int status = ! ImportJSON::intoModel(data.c_str(), sm);
+  int status = ! ImportJSON::intoModelManager(data.c_str(), sm);
   if (! status)
     {
     vtkNew<vtkActor> act;

--- a/smtk/io/ExportJSON.cxx
+++ b/smtk/io/ExportJSON.cxx
@@ -8,6 +8,7 @@
 //  PURPOSE.  See the above copyright notice for more information.
 //=========================================================================
 #include "smtk/io/ExportJSON.h"
+#include "smtk/io/ExportJSON.txx"
 
 #include "smtk/common/Version.h"
 
@@ -483,6 +484,17 @@ int ExportJSON::forOperatorResult(OperatorResult res, cJSON* entRec)
 {
   cJSON_AddItemToObject(entRec, "name", cJSON_CreateString(res->type().c_str()));
   cJSON_AddAttributeSpec(entRec, "result", "resultXML", res);
+  Cursors ents = res->modelEntitiesAs<Cursors>("entities");
+  if (!ents.empty())
+    {
+    // If the operator reports new/modified entities, transcribe the affected models.
+    // TODO: In the future, this may be more conservative (i.e., fewer records
+    //       would be included to save time and memory) than JSON_MODELS.
+    cJSON* records = cJSON_CreateObject();
+    ExportJSON::forEntities(records, ents, JSON_MODELS, JSON_DEFAULT);
+    cJSON_AddItemToObject(entRec, "records", records);
+    }
+
   return 1;
 }
 

--- a/smtk/io/ExportJSON.cxx
+++ b/smtk/io/ExportJSON.cxx
@@ -150,7 +150,7 @@ cJSON* ExportJSON::fromUUIDs(const UUIDs& uids)
   return a;
 }
 
-int ExportJSON::fromModel(cJSON* json, ManagerPtr modelMgr, JSONFlags sections)
+int ExportJSON::fromModelManager(cJSON* json, ManagerPtr modelMgr, JSONFlags sections)
 {
   int status = 0;
   if (!json || !modelMgr)
@@ -187,10 +187,10 @@ int ExportJSON::fromModel(cJSON* json, ManagerPtr modelMgr, JSONFlags sections)
   return status;
 }
 
-std::string ExportJSON::fromModel(ManagerPtr modelMgr, JSONFlags sections)
+std::string ExportJSON::fromModelManager(ManagerPtr modelMgr, JSONFlags sections)
 {
   cJSON* top = cJSON_CreateObject();
-  ExportJSON::fromModel(top, modelMgr, sections);
+  ExportJSON::fromModelManager(top, modelMgr, sections);
   char* json = cJSON_Print(top);
   std::string result(json);
   free(json);

--- a/smtk/io/ExportJSON.h
+++ b/smtk/io/ExportJSON.h
@@ -26,7 +26,7 @@ namespace smtk {
 
 class Logger;
 
-/**\brief Indicate what data should be exported to JSON.
+/**\brief Indicate what type of data should be exported to JSON.
   *
   */
 enum JSONFlags
@@ -37,6 +37,16 @@ enum JSONFlags
   JSON_TESSELLATIONS = 0x04, //!< Export tessellations of model-entity entries in the Manager.
   JSON_PROPERTIES    = 0x08, //!< Export string/float/integer properties of model-entity entries in the Manager.
   JSON_DEFAULT       = 0xff  //!< By default, export everything.
+};
+
+/**\brief Indicate what records should be exported to JSON.
+  *
+  */
+enum JSONRecords
+{
+  JSON_BARE          = 0, //!< Export only the specified entities and no more
+  JSON_CHILDREN      = 1, //!< (Reserved but unimplemented.) Export the specified entities and their children.
+  JSON_MODELS        = 2  //!< Export all entities with an owning model that also owns any of the specified entities.
 };
 
 /**\brief Export an SMTK model into a JSON-formatted string.
@@ -54,6 +64,18 @@ public:
 
   static int fromModelManager(cJSON* json, smtk::model::ManagerPtr modelMgr, JSONFlags sections = JSON_DEFAULT);
   static std::string fromModelManager(smtk::model::ManagerPtr modelMgr, JSONFlags sections = JSON_DEFAULT);
+
+  template<typename T>
+  static int forEntities(
+    cJSON* json,
+    const T& entities,
+    JSONRecords relatedEntities = JSON_MODELS,
+    JSONFlags sections = JSON_DEFAULT);
+  template<typename T>
+  static std::string forEntities(
+    const T& entities,
+    JSONRecords relatedEntities = JSON_MODELS,
+    JSONFlags sections = JSON_DEFAULT);
 
   static int forManager(cJSON* body, cJSON* sess, smtk::model::ManagerPtr modelMgr, JSONFlags sections = JSON_DEFAULT);
   static int forManagerEntity(smtk::model::UUIDWithEntity& entry, cJSON*, smtk::model::ManagerPtr modelMgr);

--- a/smtk/io/ExportJSON.h
+++ b/smtk/io/ExportJSON.h
@@ -52,8 +52,8 @@ class SMTKCORE_EXPORT ExportJSON
 public:
   static cJSON* fromUUIDs(const smtk::common::UUIDs& uids);
 
-  static int fromModel(cJSON* json, smtk::model::ManagerPtr modelMgr, JSONFlags sections = JSON_DEFAULT);
-  static std::string fromModel(smtk::model::ManagerPtr modelMgr, JSONFlags sections = JSON_DEFAULT);
+  static int fromModelManager(cJSON* json, smtk::model::ManagerPtr modelMgr, JSONFlags sections = JSON_DEFAULT);
+  static std::string fromModelManager(smtk::model::ManagerPtr modelMgr, JSONFlags sections = JSON_DEFAULT);
 
   static int forManager(cJSON* body, cJSON* sess, smtk::model::ManagerPtr modelMgr, JSONFlags sections = JSON_DEFAULT);
   static int forManagerEntity(smtk::model::UUIDWithEntity& entry, cJSON*, smtk::model::ManagerPtr modelMgr);

--- a/smtk/io/ExportJSON.txx
+++ b/smtk/io/ExportJSON.txx
@@ -1,0 +1,156 @@
+#ifndef __smtk_io_ExportJSON_txx
+#define __smtk_io_ExportJSON_txx
+
+#include "smtk/io/ExportJSON.h"
+
+#include "smtk/model/CellEntity.h"
+#include "smtk/model/GroupEntity.h"
+#include "smtk/model/InstanceEntity.h"
+#include "smtk/model/ModelEntity.h"
+#include "smtk/model/ShellEntity.h"
+#include "smtk/model/UseEntity.h"
+
+#include "cJSON.h"
+
+namespace smtk {
+  namespace io {
+
+/**\brief Populate the \a json node with the record(s) related to given \a entities.
+  *
+  */
+template<typename T>
+int ExportJSON::forEntities(
+  cJSON* json,
+  const T& entities,
+  JSONRecords relatedEntities,
+  JSONFlags sections)
+{
+  using namespace smtk::model;
+
+  if (!json || sections == JSON_NOTHING)
+    return 1;
+
+  typename T::const_iterator eit = entities.begin();
+  std::set<Cursor> queue;
+  // If we are asked to return all the entities of the related model(s),
+  // find the owning model
+  smtk::model::ModelEntity parent;
+  if (relatedEntities == JSON_MODELS)
+    for (typename T::const_iterator rit = entities.begin(); rit != entities.end(); ++rit)
+      if ((parent = rit->owningModel()).isValid())
+        queue.insert(parent);
+      else
+        queue.insert(*rit); // Well, if it doesn't have a parent, at least make sure it's included.
+  else
+    queue.insert(entities.begin(), entities.end());
+
+  Cursors visited;
+  int status = 1;
+  while (!queue.empty())
+    {
+    // Pull the first entry off the queue.
+    Cursor ent = *queue.begin();
+    queue.erase(queue.begin());
+
+    // Generate JSON for the queued entity
+    ManagerPtr modelMgr = ent.manager();
+    UUIDWithEntity it = modelMgr->topology().find(ent.entity());
+    if (
+      (it == ent.manager()->topology().end()) ||
+      ((it->second.entityFlags() & BRIDGE_SESSION) && !(sections & JSON_BRIDGES)))
+      continue;
+
+    cJSON* curChild = cJSON_CreateObject();
+      {
+      std::string suid = it->first.toString();
+      cJSON_AddItemToObject(json, suid.c_str(), curChild);
+      }
+    if (sections & JSON_ENTITIES)
+      {
+      status &= ExportJSON::forManagerEntity(it, curChild, modelMgr);
+      status &= ExportJSON::forManagerArrangement(
+        modelMgr->arrangements().find(it->first), curChild, modelMgr);
+      }
+    if (sections & JSON_TESSELLATIONS)
+      status &= ExportJSON::forManagerTessellation(it->first, curChild, modelMgr);
+    if (sections & JSON_PROPERTIES)
+      {
+      status &= ExportJSON::forManagerFloatProperties(it->first, curChild, modelMgr);
+      status &= ExportJSON::forManagerStringProperties(it->first, curChild, modelMgr);
+      status &= ExportJSON::forManagerIntegerProperties(it->first, curChild, modelMgr);
+      }
+
+    // Now push any requested relations to queue as needed and mark the entry as visited
+    switch (relatedEntities)
+      {
+      // Both children and models fetch the same related entities...
+      // but JSON_MODEL starts with a different initial queue:
+    case JSON_MODELS:
+    case JSON_CHILDREN:
+        {
+        Cursors children;
+        if (ent.isCellEntity())
+          {
+          children = ent.boundaryEntities();
+          }
+        else if (ent.isUseEntity())
+          {
+          children = ent.as<UseEntity>().shellEntities<Cursors>();
+          }
+        else if (ent.isShellEntity())
+          {
+          children = ent.as<ShellEntity>().uses<Cursors>();
+          }
+        else if (ent.isGroupEntity())
+          {
+          children = ent.as<GroupEntity>().members<Cursors>();
+          }
+        else if (ent.isModelEntity())
+          { // Grrr....
+          CellEntities mcells = ent.as<smtk::model::ModelEntity>().cells();
+          children.insert(mcells.begin(), mcells.end());
+
+          GroupEntities mgroups = ent.as<smtk::model::ModelEntity>().groups();
+          children.insert(mgroups.begin(), mgroups.end());
+
+          ModelEntities msubmodels = ent.as<smtk::model::ModelEntity>().submodels();
+          children.insert(msubmodels.begin(), msubmodels.end());
+          }
+        for (Cursors::const_iterator cit = children.begin(); cit != children.end(); ++cit)
+          if (visited.find(*cit) == visited.end())
+            queue.insert(*cit);
+        }
+      break;
+    case JSON_BARE: // Add nothing to the list of requested entities
+    default:
+      break; // do nothing.
+      }
+    visited.insert(ent);
+    }
+  return 0;
+}
+
+/**\brief Populate the \a json node with the record(s) related to given \a entities.
+  *
+  */
+template<typename T>
+std::string ExportJSON::forEntities(
+  const T& entities,
+  JSONRecords relatedEntities,
+  JSONFlags sections)
+{
+  using namespace smtk::model;
+
+  cJSON* top = cJSON_CreateObject();
+  ExportJSON::forEntities(top, entities, relatedEntities, sections);
+  char* json = cJSON_Print(top);
+  std::string result(json);
+  free(json);
+  cJSON_Delete(top);
+  return result;
+}
+
+  } // namespace io
+} // namespace smtk
+
+#endif // __smtk_io_ExportJSON_txx

--- a/smtk/io/ImportJSON.cxx
+++ b/smtk/io/ImportJSON.cxx
@@ -855,9 +855,18 @@ int ImportJSON::ofOperator(cJSON* node, OperatorPtr& op, ManagerPtr context)
   return 1;
 }
 
-int ImportJSON::ofOperatorResult(cJSON* node, OperatorResult& resOut, smtk::attribute::System* opSys)
+int ImportJSON::ofOperatorResult(cJSON* node, OperatorResult& resOut, smtk::model::RemoteOperatorPtr op)
 {
-  return cJSON_GetObjectParameters(node, resOut, opSys, "result", "resultXML");
+  smtk::attribute::System* opSys = op->bridge()->operatorSystem();
+  // Deserialize the OperatorResult into \a resOut:
+  int status = cJSON_GetObjectParameters(node, resOut, opSys, "result", "resultXML");
+  // Deserialize the relevant transcribed entities into the
+  // remote operator's model manager:
+  smtk::model::ManagerPtr mgr = op->manager();
+  cJSON* records = cJSON_GetObjectItem(node, "records");
+  if (mgr && records)
+    ImportJSON::ofManager(records, mgr);
+  return status;
 }
 
 int ImportJSON::ofDanglingEntities(cJSON* node, ManagerPtr context)

--- a/smtk/io/ImportJSON.cxx
+++ b/smtk/io/ImportJSON.cxx
@@ -348,7 +348,7 @@ int cJSON_GetObjectParameters(cJSON* node, T& obj, smtk::attribute::System* sys,
   * The top level JSON object must be a dictionary with key "type" set to "Manager"
   * and key "topo" set to a dictionary of UUIDs with matching entries.
   */
-int ImportJSON::intoModel(
+int ImportJSON::intoModelManager(
   const char* json, ManagerPtr manager)
 {
   int status = 0;

--- a/smtk/io/ImportJSON.cxx
+++ b/smtk/io/ImportJSON.cxx
@@ -860,12 +860,33 @@ int ImportJSON::ofOperatorResult(cJSON* node, OperatorResult& resOut, smtk::mode
   smtk::attribute::System* opSys = op->bridge()->operatorSystem();
   // Deserialize the OperatorResult into \a resOut:
   int status = cJSON_GetObjectParameters(node, resOut, opSys, "result", "resultXML");
+
+  // Remove entities that the operator result reports as expunged:
+  smtk::attribute::ModelEntityItemPtr expunged = resOut->findModelEntity("expunged");
+  std::size_t num = expunged->numberOfValues();
+  //std::cout << "Should expunge " << num << " entries\n";
+  for (std::size_t i = 0; i < num; ++i)
+    {
+    //std::cout << "  " << expunged->value(i).entity() << "\n";
+    expunged->value(i).manager()->erase(expunged->value(i));
+    }
+
   // Deserialize the relevant transcribed entities into the
   // remote operator's model manager:
   smtk::model::ManagerPtr mgr = op->manager();
   cJSON* records = cJSON_GetObjectItem(node, "records");
   if (mgr && records)
+    {
+    int num = 0;
+    for (cJSON* c = records->child; c; c = c->next)
+      {
+      //std::cout << "  x " << c->string << " " << Entity::flagSummary(cJSON_GetObjectItem(c, "e")->valueint,0) << "\n";
+      mgr->erase(smtk::common::UUID(c->string));
+      ++num;
+      }
+    //std::cout << "*** Result included " << num << " records\n";
     ImportJSON::ofManager(records, mgr);
+    }
   return status;
 }
 

--- a/smtk/io/ImportJSON.h
+++ b/smtk/io/ImportJSON.h
@@ -45,7 +45,7 @@ public:
   static int ofRemoteBridgeSession(cJSON*, smtk::model::DefaultBridgePtr destBridge, smtk::model::ManagerPtr context);
   static int ofLocalBridgeSession(cJSON*, smtk::model::ManagerPtr context);
   static int ofOperator(cJSON* node, smtk::model::OperatorPtr& op, smtk::model::ManagerPtr context);
-  static int ofOperatorResult(cJSON* node, smtk::model::OperatorResult& resOut, smtk::attribute::System* opSys);
+  static int ofOperatorResult(cJSON* node, smtk::model::OperatorResult& resOut, smtk::model::RemoteOperatorPtr op);
   static int ofDanglingEntities(cJSON* node, smtk::model::ManagerPtr context);
 
   static int ofLog(cJSON* logrecordarray, smtk::io::Logger& log);

--- a/smtk/io/ImportJSON.h
+++ b/smtk/io/ImportJSON.h
@@ -34,7 +34,7 @@ class Logger;
 class SMTKCORE_EXPORT ImportJSON
 {
 public:
-  static int intoModel(const char* json, smtk::model::ManagerPtr manager);
+  static int intoModelManager(const char* json, smtk::model::ManagerPtr manager);
   static int ofManager(cJSON* body, smtk::model::ManagerPtr manager);
   static int ofManagerEntity(const smtk::common::UUID& uid, cJSON*, smtk::model::ManagerPtr manager);
   static int ofManagerArrangement(const smtk::common::UUID& uid, cJSON*, smtk::model::ManagerPtr manager);

--- a/smtk/io/testing/cxx/CMakeLists.txt
+++ b/smtk/io/testing/cxx/CMakeLists.txt
@@ -6,7 +6,7 @@ set(ioTests
 
 foreach (test ${ioTests})
   add_executable(${test}  ${test}.cxx)
-  target_link_libraries(${test} SMTKCore)
+  target_link_libraries(${test} SMTKCore SMTKCoreModelTesting)
   add_test(${test} ${EXECUTABLE_OUTPUT_PATH}/${test})
 endforeach()
 

--- a/smtk/io/testing/cxx/unitImportExportJSON.cxx
+++ b/smtk/io/testing/cxx/unitImportExportJSON.cxx
@@ -85,8 +85,8 @@ int main(int argc, char* argv[])
   ManagerPtr sm = Manager::create();
 
   int status = 0;
-  status |= ImportJSON::intoModel(data.c_str(), sm);
-  status |= ExportJSON::fromModel(json, sm,
+  status |= ImportJSON::intoModelManager(data.c_str(), sm);
+  status |= ExportJSON::fromModelManager(json, sm,
     // Do not export bridge sessions; they will have different UUIDs
     static_cast<JSONFlags>(JSON_ENTITIES | JSON_TESSELLATIONS | JSON_PROPERTIES));
 
@@ -95,8 +95,8 @@ int main(int argc, char* argv[])
   json = cJSON_CreateObject();
   ManagerPtr sm2 = Manager::create();
 
-  status |= ImportJSON::intoModel(exported, sm2);
-  status |= ExportJSON::fromModel(json, sm2,
+  status |= ImportJSON::intoModelManager(exported, sm2);
+  status |= ExportJSON::fromModelManager(json, sm2,
     // Do not export bridge sessions; they will have different UUIDs
     static_cast<JSONFlags>(JSON_ENTITIES | JSON_TESSELLATIONS | JSON_PROPERTIES));
   char* exported2 = cJSON_Print(json);

--- a/smtk/model/Bridge.cxx
+++ b/smtk/model/Bridge.cxx
@@ -289,9 +289,7 @@ void Bridge::initializeOperatorSystem(const OperatorConstructors* opList)
   Definition::Ptr defn = this->m_operatorSys->createDefinition("result");
   IntItemDefinition::Ptr outcomeDefn = IntItemDefinition::New("outcome");
   ModelEntityItemDefinition::Ptr entoutDefn = ModelEntityItemDefinition::New("entities");
-  ModelEntityItemDefinition::Ptr entnewDefn = ModelEntityItemDefinition::New("new entities");
-  ModelEntityItemDefinition::Ptr entremDefn = ModelEntityItemDefinition::New("removed entities");
-  IntItemDefinition::Ptr eventTypeDefn = IntItemDefinition::New("eventtype");
+  ModelEntityItemDefinition::Ptr entremDefn = ModelEntityItemDefinition::New("deleted entities");
 
   StringItemDefinition::Ptr logDefn = StringItemDefinition::New("log");
   outcomeDefn->setNumberOfRequiredValues(1);
@@ -299,14 +297,9 @@ void Bridge::initializeOperatorSystem(const OperatorConstructors* opList)
   entoutDefn->setNumberOfRequiredValues(0);
   entoutDefn->setIsOptional(true);
   entoutDefn->setIsExtensible(true);
-  entnewDefn->setNumberOfRequiredValues(0);
-  entnewDefn->setIsOptional(true);
-  entnewDefn->setIsExtensible(true);
   entremDefn->setNumberOfRequiredValues(0);
   entremDefn->setIsOptional(true);
   entremDefn->setIsExtensible(true);
-  eventTypeDefn->setNumberOfRequiredValues(1);
-  eventTypeDefn->setIsOptional(true);
 
   logDefn->setNumberOfRequiredValues(0);
   logDefn->setIsExtensible(1);
@@ -314,9 +307,7 @@ void Bridge::initializeOperatorSystem(const OperatorConstructors* opList)
 
   defn->addItemDefinition(outcomeDefn);
   defn->addItemDefinition(entoutDefn);
-  defn->addItemDefinition(entnewDefn);
   defn->addItemDefinition(entremDefn);
-  defn->addItemDefinition(eventTypeDefn);
   defn->addItemDefinition(logDefn);
 
   if (!opList && this->inheritsOperators())

--- a/smtk/model/Bridge.cxx
+++ b/smtk/model/Bridge.cxx
@@ -289,7 +289,7 @@ void Bridge::initializeOperatorSystem(const OperatorConstructors* opList)
   Definition::Ptr defn = this->m_operatorSys->createDefinition("result");
   IntItemDefinition::Ptr outcomeDefn = IntItemDefinition::New("outcome");
   ModelEntityItemDefinition::Ptr entoutDefn = ModelEntityItemDefinition::New("entities");
-  ModelEntityItemDefinition::Ptr entremDefn = ModelEntityItemDefinition::New("deleted entities");
+  ModelEntityItemDefinition::Ptr entremDefn = ModelEntityItemDefinition::New("expunged");
 
   StringItemDefinition::Ptr logDefn = StringItemDefinition::New("log");
   outcomeDefn->setNumberOfRequiredValues(1);

--- a/smtk/model/testing/cxx/benchmarkModel.cxx
+++ b/smtk/model/testing/cxx/benchmarkModel.cxx
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
 
   // ### Benchmark JSON export ###
   t.mark();
-  std::string json = ExportJSON::fromModel(sm);
+  std::string json = ExportJSON::fromModelManager(sm);
   double jsonTime = t.elapsed();
   t.mark();
   std::ofstream jsonFile("/tmp/benchmark.json");
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
     {
     ManagerPtr sm2 = Manager::create();
     t.mark();
-    ImportJSON::intoModel(json.c_str(), sm2);
+    ImportJSON::intoModelManager(json.c_str(), sm2);
     deltaT = t.elapsed();
     }
   std::cout << deltaT << " seconds to ingest JSON\n";

--- a/smtk/model/testing/cxx/demoReportArrangements.cxx
+++ b/smtk/model/testing/cxx/demoReportArrangements.cxx
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
   ManagerPtr sm = Manager::create();
 
   int status = 0;
-  status |= ImportJSON::intoModel(data.c_str(), sm);
+  status |= ImportJSON::intoModelManager(data.c_str(), sm);
   if (status)
     {
     if (argc > 3)

--- a/smtk/model/testing/cxx/unitCursor.cxx
+++ b/smtk/model/testing/cxx/unitCursor.cxx
@@ -273,7 +273,7 @@ int main(int argc, char* argv[])
     InstanceEntities ies = model.instances<InstanceEntities>();
     test(ies.size() == 1 && ies[0] == ie, "Prototype should list its instances.");
 
-    std::string json = ExportJSON::fromModel(sm);
+    std::string json = ExportJSON::fromModelManager(sm);
     std::ofstream jsonFile("/tmp/cursor.json");
     jsonFile << json;
     jsonFile.close();

--- a/smtk/model/testing/cxx/unitDescriptivePhrase.cxx
+++ b/smtk/model/testing/cxx/unitDescriptivePhrase.cxx
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
       (std::istreambuf_iterator<char>(file)),
       (std::istreambuf_iterator<char>()));
 
-    if (data.empty() || !ImportJSON::intoModel(data.c_str(), sm))
+    if (data.empty() || !ImportJSON::intoModelManager(data.c_str(), sm))
       {
       std::cerr << "Error importing model from file \"" << fname << "\"\n";
       return 1;

--- a/smtk/model/testing/cxx/unitManager.cxx
+++ b/smtk/model/testing/cxx/unitManager.cxx
@@ -167,7 +167,7 @@ int main(int argc, char* argv[])
   test(sm->hasStringProperty(uids[11], "name"));
 
   cJSON* root = cJSON_CreateObject();
-  ExportJSON::fromModel(root, sm);
+  ExportJSON::fromModelManager(root, sm);
   cJSON_AddItemToObject(root, "nodes", ExportJSON::fromUUIDs(nodes));
   cJSON_AddItemToObject(root, "edges", ExportJSON::fromUUIDs(edges));
   cJSON_AddItemToObject(root, "faces", ExportJSON::fromUUIDs(faces));

--- a/smtk/model/testing/python/cursorTutorial.py
+++ b/smtk/model/testing/python/cursorTutorial.py
@@ -41,7 +41,7 @@ print sm.entitiesOfDimension(3)
 try:
   # If the file isn't present, just skip loading geometry.
   jsonData = file(airFoilFile, 'r').read()
-  ok = smtk.io.ImportJSON.intoModel(jsonData, sm)
+  ok = smtk.io.ImportJSON.intoModelManager(jsonData, sm)
 except:
   pass
 
@@ -72,4 +72,4 @@ sm.addToGroup(skin.entity(), [
   UUID('bcf0ed16-3f05-4043-9313-a6a3617121fb'),
   ])
 
-json = smtk.io.ExportJSON.fromModel(sm)
+json = smtk.io.ExportJSON.fromModelManager(sm)

--- a/smtk/model/testing/python/modelAttributes.py
+++ b/smtk/model/testing/python/modelAttributes.py
@@ -227,7 +227,7 @@ if __name__ == '__main__':
     logging.error('Unable to load input file')
     sys.exit(2)
   scope.store = smtk.model.Manager.create()
-  ok = smtk.io.ImportJSON.intoModel(json_string, scope.store)
+  ok = smtk.io.ImportJSON.intoModelManager(json_string, scope.store)
 
   # Load cross-reference file
   load_xref(scope, model_folder)
@@ -250,7 +250,7 @@ if __name__ == '__main__':
 
   # Re-import model
   test_store = smtk.model.Manager.create()
-  ok = smtk.io.ImportJSON.intoModel(json_string, test_store)
+  ok = smtk.io.ImportJSON.intoModelManager(json_string, test_store)
   scope.store = test_store
 
   # Re-read attribute file

--- a/smtk/model/testing/python/modelBodyCursors.py
+++ b/smtk/model/testing/python/modelBodyCursors.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     store.findEntity(uids[6], True).pushRelation(uids[4]).pushRelation(uids[3])
 
     store.assignDefaultNames()
-    print smtk.io.ExportJSON.fromModel(store)
+    print smtk.io.ExportJSON.fromModelManager(store)
 
     status = \
         len(vert1.edges()) != 2 or \

--- a/smtk/model/testing/python/modelSetPropertyOp.py
+++ b/smtk/model/testing/python/modelSetPropertyOp.py
@@ -30,7 +30,7 @@ with open(model_path, 'r') as f:
 if json is None:
   logging.error('Unable to load input file')
   sys.exit(2)
-if not smtk.io.ImportJSON.intoModel(json, mgr):
+if not smtk.io.ImportJSON.intoModelManager(json, mgr):
   logging.error('Uname to parse json input file')
   sys.exit(4)
 mgr.assignDefaultNames()

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -24,6 +24,7 @@
 
   <!-- Suppressed because they are templated methods -->
   <suppress-warning text="skipping function 'smtk::view::Group::addSubView', unmatched return type 'smtk::internal::shared_ptr_type&lt;T&gt;::SharedPointerType'"/>
+  <suppress-warning text="skipping function 'smtk::attribute::Attribute::modelEntitiesAs', unmatched return type 'T'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::associatedModelEntities', unmatched return type 'T'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findAs', unmatched return type 'T::Ptr'"/>
   <suppress-warning text="skipping function 'smtk::attribute::GroupItemDefinition::addItemDefinition', unmatched return type 'smtk::internal::shared_ptr_type&lt;T&gt;::SharedPointerType'"/>

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -98,7 +98,7 @@
   <suppress-warning text="skipping function 'smtk::io::ExportJSON::forModelWorker', unmatched parameter type 'cJSON*'"/>
   <suppress-warning text="skipping function 'smtk::io::ExportJSON::forOperatorResult', unmatched parameter type 'smtk::model::OperatorResult const&amp;'"/>
   <suppress-warning text="skipping function 'smtk::io::ExportJSON::fromUUIDs', unmatched return type 'cJSON*'"/>
-  <suppress-warning text="skipping function 'smtk::io::ExportJSON::fromModel', unmatched parameter type 'cJSON*'"/>
+  <suppress-warning text="skipping function 'smtk::io::ExportJSON::fromModelManager', unmatched parameter type 'cJSON*'"/>
   <suppress-warning text="skipping function 'smtk::io::ImportJSON::bridgeNameFromTagData', unmatched parameter type 'cJSON*'"/>
   <suppress-warning text="skipping function 'smtk::io::ImportJSON::bridgeFileTypesFromTagData', unmatched parameter type 'cJSON*'"/>
   <suppress-warning text="skipping function 'smtk::io::ExportJSON::createIntegerArray', unmatched return type 'cJSON*'"/>

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -105,6 +105,11 @@
   <suppress-warning text="skipping function 'smtk::io::ExportJSON::createUUIDArray', unmatched return type 'cJSON*'"/>
   <suppress-warning text="skipping function 'smtk::io::ExportJSON::createRPCRequest', unmatched return type 'cJSON*'"/>
   <suppress-warning text="skipping function 'smtk::io::ExportJSON::createStringArray', unmatched return type 'cJSON*'"/>
+  <suppress-warning text="skipping function 'smtk::io::ExportJSON::forOperatorResult', unmatched parameter type 'cJSON*'"/>
+  <suppress-warning text="skipping function 'smtk::io::ExportJSON::forOperatorDefinitions', unmatched parameter type 'cJSON*'"/>
+  <suppress-warning text="skipping function 'smtk::io::ExportJSON::forOperator', unmatched parameter type 'cJSON*'"/>
+  <suppress-warning text="skipping function 'smtk::io::ExportJSON::forEntities', unmatched parameter type 'T const&amp;'"/>
+  <suppress-warning text="skipping function 'smtk::io::ExportJSON::forEntities', unmatched parameter type 'cJSON*'"/>
 
   <!-- Ignore warnings from protected functions and members -->
   <suppress-warning text="skipping function 'smtk::model::BRepModel::insertEntityReferences', unmatched parameter type 'smtk::model::UUIDWithEntity const&amp;'"/>
@@ -356,10 +361,7 @@
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findDirectory', unmatched return type 'smtk::attribute::ConstDirectoryItemPtr'"/>
   <suppress-warning text="skipping function 'smtk::model::Bridge::findOperatorConstructor', unmatched return type 'smtk::model::OperatorConstructor'"/>
   <suppress-warning text="skipping function 'smtk::model::Bridge::findOperatorConstructorInternal', unmatched return type 'smtk::model::OperatorConstructor'"/>
-  <suppress-warning text="skipping function 'smtk::io::ExportJSON::forOperatorResult', unmatched parameter type 'cJSON*'"/>
-  <suppress-warning text="skipping function 'smtk::io::ExportJSON::forOperatorDefinitions', unmatched parameter type 'cJSON*'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findDouble', unmatched return type 'smtk::attribute::ConstDoubleItemPtr'"/>
-  <suppress-warning text="skipping function 'smtk::io::ExportJSON::forOperator', unmatched parameter type 'cJSON*'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findString', unmatched return type 'smtk::attribute::ConstStringItemPtr'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findModelEntity', unmatched return type 'smtk::attribute::ConstModelEntityItemPtr'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findGroup', unmatched return type 'smtk::attribute::ConstGroupItemPtr'"/>
@@ -1843,6 +1845,10 @@
       </object-type>
 
       <enum-type name="JSONFlags">
+        <include file-name="smtk/io/ExportJSON.h" location="local"/>
+      </enum-type>
+
+      <enum-type name="JSONRecords">
         <include file-name="smtk/io/ExportJSON.h" location="local"/>
       </enum-type>
 


### PR DESCRIPTION
This branch extends `ExportJSON::forOperatorResult()` and `ImportJSON::ofOperatorResult()` so that model entities listed in the "entities" item of the result attribute are serialized (by ExportJSON) and deserialized (by ImportJSON). The effect is that now — not only are new/modified entities reported by the result attribute — they are also automatically transferred to the model manager holding the remote operator. **Note** that this changes the signature of the ImportJSON method so that the model manager is available.

This also addresses #4 by adding new methods to ExportJSON and renaming `ImportJSON::intoModel()` &rarr; `ImportJSON::intoModelManager()` and `ExportJSON::fromModel()` &rarr; `ExportJSON::fromModelManager()`.

Finally, this adds a templated method `Attribute::modelEntitiesAs<T>()` to match `Attribute::associatedModelEntities<T>()`.