### PR TITLE
Fixed a bug in Session destructor.

### DIFF
--- a/smtk/bridge/discrete/Session.h
+++ b/smtk/bridge/discrete/Session.h
@@ -19,6 +19,7 @@
 #include "smtk/common/UUIDGenerator.h"
 
 #include "vtkSmartPointer.h"
+#include "vtkWeakPointer.h"
 
 #include <map>
 
@@ -135,6 +136,7 @@ protected:
     const smtk::common::UUID& itemId, vtkModelItem* item);
   smtk::common::UUID findOrSetEntityUUID(vtkModelItem* item);
   smtk::common::UUID findOrSetEntityUUID(vtkInformation* itemProperties);
+  void untrackEntity(const smtk::common::UUID& itemId);
 
   //static vtkDiscreteModel* owningModel(vtkModelItem* e);
   vtkModelItem* entityForUUID(const smtk::common::UUID& uid);
@@ -166,7 +168,7 @@ protected:
 
   vtkItemWatcherCommand* m_itemWatcher;
   smtk::common::UUIDGenerator m_idGenerator;
-  std::map<smtk::common::UUID,vtkModelItem*> m_itemsToRefs;
+  std::map<smtk::common::UUID, vtkWeakPointer<vtkModelItem> > m_itemsToRefs;
 
   static std::map<vtkDiscreteModel*,WeakPtr> s_modelsToSessions;
   static std::map<smtk::common::UUID,vtkSmartPointer<vtkDiscreteModelWrapper> > s_modelIdsToRefs;


### PR DESCRIPTION
The session has a map of UUIDs to vtkModelItem, and has observers on
these items. In the session destrutor, it tries to remove the observers,
and it will crash if any of those vtkModelItem(s) is invalid. Two changes
are added to fix this. One is to use vtkWeakPointer in the map; second is
to listen to the DeleteEvent of vtkModelItem, and remove it from the map.