### PR TITLE
Add an iterator class for traversing models.

### DIFF
--- a/smtk/io/ExportJSON.cxx
+++ b/smtk/io/ExportJSON.cxx
@@ -489,9 +489,9 @@ int ExportJSON::forOperatorResult(OperatorResult res, cJSON* entRec)
     {
     // If the operator reports new/modified entities, transcribe the affected models.
     // TODO: In the future, this may be more conservative (i.e., fewer records
-    //       would be included to save time and memory) than JSON_MODELS.
+    //       would be included to save time and memory) than ITERATE_MODELS.
     cJSON* records = cJSON_CreateObject();
-    ExportJSON::forEntities(records, ents, JSON_MODELS, JSON_CLIENT_DATA);
+    ExportJSON::forEntities(records, ents, smtk::model::ITERATE_MODELS, JSON_CLIENT_DATA);
     cJSON_AddItemToObject(entRec, "records", records);
     }
 

--- a/smtk/io/ExportJSON.h
+++ b/smtk/io/ExportJSON.h
@@ -16,6 +16,7 @@
 #include "smtk/common/UUID.h"
 
 #include "smtk/model/Manager.h" // For UUIDWithEntity
+#include "smtk/model/EntityIterator.h" // For IteratorStyle
 
 #ifndef SHIBOKEN_SKIP
 #  include "cJSON.h"
@@ -41,16 +42,6 @@ enum JSONFlags
   JSON_DEFAULT       = 0xff  //!< By default, export everything.
 };
 
-/**\brief Indicate what records should be exported to JSON.
-  *
-  */
-enum JSONRecords
-{
-  JSON_BARE          = 0, //!< Export only the specified entities and no more
-  JSON_CHILDREN      = 1, //!< (Reserved but unimplemented.) Export the specified entities and their children.
-  JSON_MODELS        = 2  //!< Export all entities with an owning model that also owns any of the specified entities.
-};
-
 /**\brief Export an SMTK model into a JSON-formatted string.
   *
   * Methods are also provided for creating cJSON nodes representing
@@ -71,12 +62,12 @@ public:
   static int forEntities(
     cJSON* json,
     const T& entities,
-    JSONRecords relatedEntities = JSON_MODELS,
+    smtk::model::IteratorStyle relatedEntities = smtk::model::ITERATE_MODELS,
     JSONFlags sections = JSON_DEFAULT);
   template<typename T>
   static std::string forEntities(
     const T& entities,
-    JSONRecords relatedEntities = JSON_MODELS,
+    smtk::model::IteratorStyle relatedEntities = smtk::model::ITERATE_MODELS,
     JSONFlags sections = JSON_DEFAULT);
 
   static int forManager(cJSON* body, cJSON* sess, smtk::model::ManagerPtr modelMgr, JSONFlags sections = JSON_DEFAULT);

--- a/smtk/io/ExportJSON.txx
+++ b/smtk/io/ExportJSON.txx
@@ -22,7 +22,7 @@ template<typename T>
 int ExportJSON::forEntities(
   cJSON* json,
   const T& entities,
-  JSONRecords relatedEntities,
+  smtk::model::IteratorStyle relatedEntities,
   JSONFlags sections)
 {
   using namespace smtk::model;
@@ -34,7 +34,7 @@ int ExportJSON::forEntities(
   // If we are asked to return all the entities of the related model(s),
   // find the owning model
   smtk::model::Model parent;
-  if (relatedEntities == JSON_MODELS)
+  if (relatedEntities == smtk::model::ITERATE_MODELS)
     {
     for (typename T::const_iterator rit = entities.begin(); rit != entities.end(); ++rit)
       {
@@ -105,8 +105,8 @@ int ExportJSON::forEntities(
       {
       // Both children and models fetch the same related entities...
       // but JSON_MODEL starts with a different initial queue:
-    case JSON_MODELS:
-    case JSON_CHILDREN:
+    case smtk::model::ITERATE_MODELS:
+    case smtk::model::ITERATE_CHILDREN:
         {
         EntityRefs children;
         if (ent.isCellEntity())
@@ -141,7 +141,7 @@ int ExportJSON::forEntities(
             queue.insert(*cit);
         }
       break;
-    case JSON_BARE: // Add nothing to the list of requested entities
+    case smtk::model::ITERATE_BARE: // Add nothing to the list of requested entities
     default:
       break; // do nothing.
       }
@@ -156,7 +156,7 @@ int ExportJSON::forEntities(
 template<typename T>
 std::string ExportJSON::forEntities(
   const T& entities,
-  JSONRecords relatedEntities,
+  smtk::model::IteratorStyle relatedEntities,
   JSONFlags sections)
 {
   using namespace smtk::model;

--- a/smtk/io/ExportJSON.txx
+++ b/smtk/io/ExportJSON.txx
@@ -3,12 +3,7 @@
 
 #include "smtk/io/ExportJSON.h"
 
-#include "smtk/model/CellEntity.h"
-#include "smtk/model/Group.h"
-#include "smtk/model/Instance.h"
-#include "smtk/model/Model.h"
-#include "smtk/model/ShellEntity.h"
-#include "smtk/model/UseEntity.h"
+#include "smtk/model/EntityIterator.h"
 
 #include "cJSON.h"
 
@@ -30,47 +25,13 @@ int ExportJSON::forEntities(
   if (!json || sections == JSON_NOTHING)
     return 1;
 
-  std::set<EntityRef> queue;
-  // If we are asked to return all the entities of the related model(s),
-  // find the owning model
-  smtk::model::Model parent;
-  if (relatedEntities == smtk::model::ITERATE_MODELS)
-    {
-    for (typename T::const_iterator rit = entities.begin(); rit != entities.end(); ++rit)
-      {
-      if ((parent = rit->owningModel()).isValid())
-        {
-        queue.insert(parent);
-        smtk::model::SessionRef sref = parent.session();
-        if (sref.isValid())
-          queue.insert(sref);
-        }
-      else if (rit->isModel())
-        {
-        smtk::model::Model model(*rit);
-        smtk::model::SessionRef sref = model.session();
-        queue.insert(model);
-        if (sref.isValid())
-          queue.insert(sref);
-        }
-      else
-        {
-        queue.insert(*rit); // Well, if it doesn't have a parent, at least make sure it's included.
-        }
-      }
-    }
-  else
-    {
-    queue.insert(entities.begin(), entities.end());
-    }
-
-  EntityRefs visited;
+  EntityIterator iter;
+  iter.traverse(entities.begin(), entities.end(), relatedEntities);
   int status = 1;
-  while (!queue.empty())
+  for (iter.begin(); !iter.isAtEnd(); ++iter)
     {
     // Pull the first entry off the queue.
-    EntityRef ent = *queue.begin();
-    queue.erase(queue.begin());
+    EntityRef ent = *iter;
 
     // Generate JSON for the queued entity
     ManagerPtr modelMgr = ent.manager();
@@ -99,53 +60,6 @@ int ExportJSON::forEntities(
       status &= ExportJSON::forManagerStringProperties(it->first, curChild, modelMgr);
       status &= ExportJSON::forManagerIntegerProperties(it->first, curChild, modelMgr);
       }
-
-    // Now push any requested relations to queue as needed and mark the entry as visited
-    switch (relatedEntities)
-      {
-      // Both children and models fetch the same related entities...
-      // but JSON_MODEL starts with a different initial queue:
-    case smtk::model::ITERATE_MODELS:
-    case smtk::model::ITERATE_CHILDREN:
-        {
-        EntityRefs children;
-        if (ent.isCellEntity())
-          {
-          children = ent.boundaryEntities();
-          }
-        else if (ent.isUseEntity())
-          {
-          children = ent.as<UseEntity>().shellEntities<EntityRefs>();
-          }
-        else if (ent.isShellEntity())
-          {
-          children = ent.as<ShellEntity>().uses<EntityRefs>();
-          }
-        else if (ent.isGroup())
-          {
-          children = ent.as<Group>().members<EntityRefs>();
-          }
-        else if (ent.isModel())
-          { // Grrr....
-          CellEntities mcells = ent.as<smtk::model::Model>().cells();
-          children.insert(mcells.begin(), mcells.end());
-
-          Groups mgroups = ent.as<smtk::model::Model>().groups();
-          children.insert(mgroups.begin(), mgroups.end());
-
-          Models msubmodels = ent.as<smtk::model::Model>().submodels();
-          children.insert(msubmodels.begin(), msubmodels.end());
-          }
-        for (EntityRefs::const_iterator cit = children.begin(); cit != children.end(); ++cit)
-          if (visited.find(*cit) == visited.end())
-            queue.insert(*cit);
-        }
-      break;
-    case smtk::model::ITERATE_BARE: // Add nothing to the list of requested entities
-    default:
-      break; // do nothing.
-      }
-    visited.insert(ent);
     }
   return 0;
 }

--- a/smtk/io/testing/cxx/unitImportExportJSON.cxx
+++ b/smtk/io/testing/cxx/unitImportExportJSON.cxx
@@ -76,7 +76,7 @@ void testLoggerSerialization2()
 }
 
 void testExportEntityRef(
-  const EntityRefs& entities, JSONRecords relations, int correctCount)
+  const EntityRefs& entities, IteratorStyle relations, int correctCount)
 {
   cJSON* json = cJSON_CreateObject();
   ExportJSON::forEntities(json, entities, relations, JSON_ENTITIES);
@@ -109,11 +109,11 @@ void testModelExport()
   EntityRefs entities;
   entities.insert(EntityRef(sm, uids[8])); // An edge
 
-  testExportEntityRef(entities, JSON_BARE, 1);
-  testExportEntityRef(entities, JSON_CHILDREN, 9);
-  testExportEntityRef(entities, JSON_MODELS, 78);
+  testExportEntityRef(entities, smtk::model::ITERATE_BARE, 1);
+  testExportEntityRef(entities, smtk::model::ITERATE_CHILDREN, 9);
+  testExportEntityRef(entities, smtk::model::ITERATE_MODELS, 78);
 
-  std::string json = ExportJSON::forEntities(entities, JSON_BARE, JSON_DEFAULT);
+  std::string json = ExportJSON::forEntities(entities, smtk::model::ITERATE_BARE, JSON_DEFAULT);
   std::cout << "json for vertex is \n" << json << "\n";
 }
 

--- a/smtk/model/CMakeLists.txt
+++ b/smtk/model/CMakeLists.txt
@@ -17,6 +17,7 @@ set(modelSrcs
   Edge.cxx
   EdgeUse.cxx
   Entity.cxx
+  EntityIterator.cxx
   EntityListPhrase.cxx
   EntityPhrase.cxx
   Face.cxx
@@ -63,6 +64,7 @@ set(modelHeaders
   Edge.h
   EdgeUse.h
   Entity.h
+  EntityIterator.h
   EntityListPhrase.h
   EntityPhrase.h
   EntityTypeBits.h

--- a/smtk/model/EntityIterator.cxx
+++ b/smtk/model/EntityIterator.cxx
@@ -1,0 +1,189 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/model/EntityIterator.h"
+
+#include "smtk/model/CellEntity.h"
+#include "smtk/model/Group.h"
+#include "smtk/model/ShellEntity.h"
+#include "smtk/model/UseEntity.h"
+
+namespace smtk {
+  namespace model {
+
+void EntityIterator::traverse(const EntityRef& x)
+{
+  this->traverse(x, smtk::io::JSON_CHILDREN);
+}
+
+void EntityIterator::traverse(const EntityRef& x, smtk::io::JSONRecords style)
+{
+  this->m_related = style;
+  this->m_visited.clear();
+  if (this->m_related == smtk::io::JSON_MODELS)
+    {
+    Model parent;
+    if ((parent = x.owningModel()).isValid())
+      {
+      this->m_visited.insert(parent);
+      SessionRef sref = parent.session();
+      if (sref.isValid())
+        this->m_visited.insert(sref);
+      }
+    else if (x.isModel())
+      {
+      Model model(x);
+      SessionRef sref = model.session();
+      this->m_visited.insert(model);
+      if (sref.isValid())
+        this->m_visited.insert(sref);
+      }
+    else
+      {
+      this->m_visited.insert(x); // Well, if it doesn't have a parent, at least make sure it's included.
+      }
+    }
+  else
+    {
+    this->m_visited.insert(x);
+    }
+}
+
+void EntityIterator::begin()
+{
+  this->m_queue = this->m_visited;
+  this->m_visited.clear();
+}
+
+/// Advance to the next item, returning true until reaching the end of iteration.
+bool EntityIterator::advance()
+{
+  ++(*this);
+  return !this->isAtEnd();
+}
+
+/// Return true when iteration complete, false otherwise.
+bool EntityIterator::isAtEnd() const
+{
+  return this->m_queue.empty();
+}
+
+/**\brief Prefix increment operator.
+  *
+  * This advances the iterator and returns the newly-updated current item.
+  */
+EntityRef EntityIterator::operator ++ ()
+{
+  if (this->isAtEnd())
+    return EntityRef();
+
+  EntityRefs::iterator it = this->m_queue.begin();
+  this->m_visited.insert(*it);
+  // Always call after inserting argument into m_visited to prevent stupidity:
+  this->updateQueue(*it);
+  this->m_queue.erase(it);
+  return this->isAtEnd() ?
+    EntityRef() :
+    *this->m_queue.begin();
+}
+
+/**\brief Postfix increment operator.
+  *
+  * This advances the iterator but returns the item that
+  * was current before advancing the iterator.
+  */
+EntityRef EntityIterator::operator ++ (int i)
+{
+  if (this->isAtEnd())
+    return EntityRef();
+
+  EntityRef result = *this->m_queue.begin();
+  this->m_visited.insert(result);
+  // Always call after inserting argument into m_visited to prevent stupidity:
+  this->updateQueue(result);
+  this->m_queue.erase(this->m_queue.begin());
+  return result;
+}
+
+/// A convenience that returns this->current().
+EntityRef EntityIterator::operator * () const
+{
+  return this->current();
+}
+
+/// A convenience that returns this->current().
+const EntityRef* EntityIterator::operator -> () const
+{
+  return &this->current();
+}
+
+/// Return the current value of the iterator (or an invalid cursor).
+const EntityRef& EntityIterator::current() const
+{
+  static EntityRef dummy;
+  return this->isAtEnd() ?
+    dummy :
+    *this->m_queue.begin();
+}
+
+/**\brief Add entities related to \a ent to the queue as required by the style.
+  *
+  * Used by next and the increment-operators to append items to the queue when
+  * iterating over models for the first time.
+  */
+void EntityIterator::updateQueue(const EntityRef& ent)
+{
+  switch (this->m_related)
+    {
+  case smtk::io::JSON_CHILDREN:
+  case smtk::io::JSON_MODELS:
+      {
+      EntityRefs children;
+      if (ent.isCellEntity())
+        {
+        children = ent.boundaryEntities();
+        }
+      else if (ent.isUseEntity())
+        {
+        children = ent.as<UseEntity>().shellEntities<EntityRefs>();
+        }
+      else if (ent.isShellEntity())
+        {
+        children = ent.as<ShellEntity>().uses<EntityRefs>();
+        }
+      else if (ent.isGroup())
+        {
+        children = ent.as<Group>().members<EntityRefs>();
+        }
+      else if (ent.isModel())
+        { // Grrr.... too much cruft.
+        CellEntities mcells = ent.as<smtk::model::Model>().cells();
+        children.insert(mcells.begin(), mcells.end());
+
+        Groups mgroups = ent.as<smtk::model::Model>().groups();
+        children.insert(mgroups.begin(), mgroups.end());
+
+        Models msubmodels = ent.as<smtk::model::Model>().submodels();
+        children.insert(msubmodels.begin(), msubmodels.end());
+        }
+      for (EntityRefs::const_iterator cit = children.begin(); cit != children.end(); ++cit)
+        if (this->m_visited.find(*cit) == this->m_visited.end())
+          this->m_queue.insert(*cit);
+      }
+    break;
+  default:
+    // Do nothing.
+    break;
+    }
+  if (this->m_queue.empty() && this->m_related != smtk::io::JSON_BARE)
+    this->m_related = smtk::io::JSON_BARE; // No need to recompute things to visit next time around.
+}
+
+  } // namespace model
+} // namespace smtk

--- a/smtk/model/EntityIterator.cxx
+++ b/smtk/model/EntityIterator.cxx
@@ -19,14 +19,14 @@ namespace smtk {
 
 void EntityIterator::traverse(const EntityRef& x)
 {
-  this->traverse(x, smtk::io::JSON_CHILDREN);
+  this->traverse(x, ITERATE_CHILDREN);
 }
 
-void EntityIterator::traverse(const EntityRef& x, smtk::io::JSONRecords style)
+void EntityIterator::traverse(const EntityRef& x, IteratorStyle style)
 {
   this->m_related = style;
   this->m_visited.clear();
-  if (this->m_related == smtk::io::JSON_MODELS)
+  if (this->m_related == ITERATE_MODELS)
     {
     Model parent;
     if ((parent = x.owningModel()).isValid())
@@ -141,8 +141,8 @@ void EntityIterator::updateQueue(const EntityRef& ent)
 {
   switch (this->m_related)
     {
-  case smtk::io::JSON_CHILDREN:
-  case smtk::io::JSON_MODELS:
+  case ITERATE_CHILDREN:
+  case ITERATE_MODELS:
       {
       EntityRefs children;
       if (ent.isCellEntity())
@@ -181,8 +181,8 @@ void EntityIterator::updateQueue(const EntityRef& ent)
     // Do nothing.
     break;
     }
-  if (this->m_queue.empty() && this->m_related != smtk::io::JSON_BARE)
-    this->m_related = smtk::io::JSON_BARE; // No need to recompute things to visit next time around.
+  if (this->m_queue.empty() && this->m_related != ITERATE_BARE)
+    this->m_related = ITERATE_BARE; // No need to recompute things to visit next time around.
 }
 
   } // namespace model

--- a/smtk/model/EntityIterator.h
+++ b/smtk/model/EntityIterator.h
@@ -12,19 +12,27 @@
 
 #include "smtk/model/Manager.h"
 
-#include "smtk/io/ExportJSON.h" // for JSONRecords
-
 namespace smtk {
   namespace model {
+
+/**\brief Indicate what records should be visited.
+  *
+  */
+enum IteratorStyle
+{
+  ITERATE_BARE     = 0, //!< Visit only the specified entities and no others
+  ITERATE_CHILDREN = 1, //!< Visit the specified entities and their children.
+  ITERATE_MODELS   = 2  //!< Visit all entities with an owning model that also owns any of the specified entities. Also visits the owning session, but not all of the owning session's models.
+};
 
 class SMTKCORE_EXPORT EntityIterator
 {
 public:
   template<typename C> void traverse(C begin, C end);
-  template<typename C> void traverse(C begin, C end, smtk::io::JSONRecords style);
+  template<typename C> void traverse(C begin, C end, IteratorStyle style);
 
   void traverse(const EntityRef& x);
-  void traverse(const EntityRef& x, smtk::io::JSONRecords style);
+  void traverse(const EntityRef& x, IteratorStyle style);
 
   void begin();
   bool advance();
@@ -42,7 +50,7 @@ protected:
 
   EntityRefs m_queue;
   EntityRefs m_visited;
-  smtk::io::JSONRecords m_related;
+  IteratorStyle m_related;
 };
 
 /**\brief Iterate over the given entities and **only** those entities.
@@ -50,17 +58,17 @@ protected:
 template<typename C>
 void EntityIterator::traverse(C begin, C end)
 {
-  this->traverse(begin, end, smtk::io::JSON_BARE);
+  this->traverse(begin, end, ITERATE_BARE);
 }
 
 /**\brief Iterate over the given entities and the specified \a related records.
   */
 template<typename C>
-void EntityIterator::traverse(C begin, C end, smtk::io::JSONRecords related)
+void EntityIterator::traverse(C begin, C end, IteratorStyle related)
 {
   this->m_related = related;
   this->m_visited.clear();
-  if (this->m_related == smtk::io::JSON_MODELS)
+  if (this->m_related == ITERATE_MODELS)
     {
     Model parent;
     for (C rit = begin; rit != end; ++rit)

--- a/smtk/model/EntityIterator.h
+++ b/smtk/model/EntityIterator.h
@@ -1,0 +1,98 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#ifndef __smtk_model_EntityIterator_h
+#define __smtk_model_EntityIterator_h
+
+#include "smtk/model/Manager.h"
+
+#include "smtk/io/ExportJSON.h" // for JSONRecords
+
+namespace smtk {
+  namespace model {
+
+class SMTKCORE_EXPORT EntityIterator
+{
+public:
+  template<typename C> void traverse(C begin, C end);
+  template<typename C> void traverse(C begin, C end, smtk::io::JSONRecords style);
+
+  void traverse(const EntityRef& x);
+  void traverse(const EntityRef& x, smtk::io::JSONRecords style);
+
+  void begin();
+  bool advance();
+  bool isAtEnd() const;
+
+  EntityRef operator ++ ();
+  EntityRef operator ++ (int i);
+
+  EntityRef operator * () const;
+  const EntityRef* operator -> () const;
+  const EntityRef& current() const;
+
+protected:
+  void updateQueue(const EntityRef& ent);
+
+  EntityRefs m_queue;
+  EntityRefs m_visited;
+  smtk::io::JSONRecords m_related;
+};
+
+/**\brief Iterate over the given entities and **only** those entities.
+  */
+template<typename C>
+void EntityIterator::traverse(C begin, C end)
+{
+  this->traverse(begin, end, smtk::io::JSON_BARE);
+}
+
+/**\brief Iterate over the given entities and the specified \a related records.
+  */
+template<typename C>
+void EntityIterator::traverse(C begin, C end, smtk::io::JSONRecords related)
+{
+  this->m_related = related;
+  this->m_visited.clear();
+  if (this->m_related == smtk::io::JSON_MODELS)
+    {
+    Model parent;
+    for (C rit = begin; rit != end; ++rit)
+      {
+      if ((parent = rit->owningModel()).isValid())
+        {
+        this->m_visited.insert(parent);
+        SessionRef sref = parent.session();
+        if (sref.isValid())
+          this->m_visited.insert(sref);
+        }
+      else if (rit->isModel())
+        {
+        Model model(*rit);
+        SessionRef sref = model.session();
+        this->m_visited.insert(model);
+        if (sref.isValid())
+          this->m_visited.insert(sref);
+        }
+      else
+        {
+        this->m_visited.insert(*rit); // Well, if it doesn't have a parent, at least make sure it's included.
+        }
+      }
+    }
+  else
+    {
+    this->m_visited.insert(begin, end);
+    }
+}
+
+  } // namespace model
+} // namespace smtk
+
+#endif // __smtk_model_EntityIterator_h

--- a/smtk/model/EntityRef.cxx
+++ b/smtk/model/EntityRef.cxx
@@ -1300,30 +1300,20 @@ ManagerEventRelationType EntityRef::subsetRelationType(const EntityRef& member) 
   case SESSION:
     switch (member.entityFlags() & ENTITY_MASK)
       {
-    case MODEL_ENTITY: reln = SESSION_INCLUDES_MODEL; break;
+    case MODEL_ENTITY: reln = SESSION_SUPERSET_OF_MODEL; break;
       }
     break;
   case MODEL_ENTITY:
     switch (member.entityFlags() & ENTITY_MASK)
       {
-    case MODEL_ENTITY: reln = MODEL_INCLUDES_MODEL; break;
-    case SHELL_ENTITY: reln = MODEL_INCLUDES_FREE_SHELL; break;
-    case CELL_ENTITY: reln = MODEL_INCLUDES_FREE_CELL; break;
-    case USE_ENTITY: reln = MODEL_INCLUDES_FREE_USE; break;
+    case MODEL_ENTITY: reln = MODEL_SUPERSET_OF_MODEL; break;
+    case GROUP_ENTITY: reln = MODEL_SUPERSET_OF_GROUP; break;
       }
     break;
-  case CELL_ENTITY:
-    switch (member.entityFlags() & ENTITY_MASK)
-      {
-    case CELL_ENTITY: reln = CELL_INCLUDES_CELL; break;
-      }
+  case GROUP_ENTITY:
+    reln = GROUP_SUPERSET_OF_ENTITY;
     break;
-  case SHELL_ENTITY:
-    switch (member.entityFlags() & ENTITY_MASK)
-      {
-    case SHELL_ENTITY: reln = SHELL_INCLUDES_SHELL; break;
-    case USE_ENTITY: reln = SHELL_HAS_USE; break;
-      }
+  default:
     break;
     }
 

--- a/smtk/model/Events.h
+++ b/smtk/model/Events.h
@@ -87,7 +87,7 @@ enum ManagerEventRelationType
   ENTITY_HAS_ATTRIBUTE,         //!< The entity is being associated/disassociated to/from an attribute.
 
   // Events affecting both Arrangement and Entity records (additions, removals, modifications of arrangements)
-  SESSION_INCLUDES_MODEL,       //!< The entity is a session with a child model
+  SESSION_INCLUDES_MODEL,       //!< The entity is a session with a child model being added or removed.
 
   MODEL_INCLUDES_FREE_CELL,     //!< The entity is a model with a free cell.
   MODEL_INCLUDES_FREE_USE,      //!< The entity is a model with a free use (not really sensical?).
@@ -102,6 +102,9 @@ enum ManagerEventRelationType
   SHELL_INCLUDES_SHELL,         //!< The entity is a shell that includes another shell (e.g., a void)
 
   GROUP_SUPERSET_OF_ENTITY,     //!< The entity is a group whose membership is being modified.
+  MODEL_SUPERSET_OF_MODEL,      //!< The entity is a model whose set of child models is being modified.
+  MODEL_SUPERSET_OF_GROUP,      //!< The entity is a model whose set of child groups is being modified.
+  SESSION_SUPERSET_OF_MODEL,    //!< The entity is a session whose set of child models is being modified.
 
   INSTANCE_OF_ENTITY,           //!< The entity is an instance being inserted, removed, or modified (retargeting what it instances).
 

--- a/smtk/model/Model.cxx
+++ b/smtk/model/Model.cxx
@@ -66,8 +66,11 @@ void Model::setSession(const SessionRef& sess)
   if (curSess.isValid())
     curSess.removeMemberEntity(*this);
 
-  SessionRef mutableSess(sess);
-  mutableSess.addMemberEntity(*this);
+  if (sess.isValid())
+    {
+    SessionRef mutableSess(sess);
+    mutableSess.addMemberEntity(*this);
+    }
 }
 
 /// Return the cells directly owned by this model.

--- a/smtk/model/testing/cxx/CMakeLists.txt
+++ b/smtk/model/testing/cxx/CMakeLists.txt
@@ -20,6 +20,10 @@ add_executable(unitManager unitManager.cxx)
 target_link_libraries(unitManager SMTKCore SMTKCoreModelTesting)
 add_test(unitManager ${EXECUTABLE_OUTPUT_PATH}/unitManager)
 
+add_executable(unitIterators unitIterators.cxx)
+target_link_libraries(unitIterators SMTKCore SMTKCoreModelTesting)
+add_test(unitIterators ${EXECUTABLE_OUTPUT_PATH}/unitIterators)
+
 add_executable(unitTessellation unitTessellation.cxx)
 target_link_libraries(unitTessellation SMTKCore SMTKCoreModelTesting)
 add_test(unitTessellation ${EXECUTABLE_OUTPUT_PATH}/unitTessellation)

--- a/smtk/model/testing/cxx/unitIterators.cxx
+++ b/smtk/model/testing/cxx/unitIterators.cxx
@@ -21,7 +21,7 @@ using namespace smtk::model;
 using namespace smtk::common;
 using namespace smtk::model::testing;
 
-void testExplicitTraversal(smtk::io::JSONRecords style, int correctCount)
+void testExplicitTraversal(IteratorStyle style, int correctCount)
 {
   Manager::Ptr mgr = Manager::create();
   SessionRef sess = mgr->createSession("native");
@@ -88,9 +88,9 @@ void testModelTraversal()
 int main()
 {
   testModelTraversal();
-  testExplicitTraversal(smtk::io::JSON_BARE, 7);
-  testExplicitTraversal(smtk::io::JSON_CHILDREN, 14); // Vertex uses are children of vertices
-  testExplicitTraversal(smtk::io::JSON_MODELS, 79);
+  testExplicitTraversal(ITERATE_BARE, 7);
+  testExplicitTraversal(ITERATE_CHILDREN, 14); // Vertex uses are children of vertices
+  testExplicitTraversal(ITERATE_MODELS, 79);
   // TODO: Test iteration while model is being modified.
   return 0;
 }

--- a/smtk/model/testing/cxx/unitIterators.cxx
+++ b/smtk/model/testing/cxx/unitIterators.cxx
@@ -1,0 +1,96 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/model/EntityIterator.h"
+#include "smtk/model/Model.h"
+#include "smtk/model/Volume.h"
+
+#include "smtk/model/testing/cxx/helpers.h"
+
+#include "smtk/common/testing/cxx/helpers.h"
+
+#include <sstream>
+
+using namespace smtk::model;
+using namespace smtk::common;
+using namespace smtk::model::testing;
+
+void testExplicitTraversal(smtk::io::JSONRecords style, int correctCount)
+{
+  Manager::Ptr mgr = Manager::create();
+  SessionRef sess = mgr->createSession("native");
+
+  UUIDArray uids = createTet(mgr);
+  Model model = mgr->addModel();
+  model.addCell(Volume(mgr, uids[21]));
+  model.setSession(sess);
+  mgr->assignDefaultNames();
+
+  EntityRefs justVerts = mgr->entitiesMatchingFlagsAs<EntityRefs>(VERTEX);
+  EntityIterator it;
+  it.traverse(justVerts.begin(), justVerts.end(), style);
+  int count1 = 0;
+  std::cout << "\n---\n\n";
+  for (it.begin(); !it.isAtEnd(); ++it)
+    {
+    std::cout << "  " << it->name() << " (" << it->flagSummary() << ")\n";
+    ++count1;
+    }
+
+  std::cout << "\n---\n\n" << "  " << count1 << "\n";
+  std::ostringstream msg;
+  msg
+    << "Expected to iterate over " << correctCount
+    << " entities, did iterate over " << count1 << ".";
+  test(count1 == correctCount, msg.str());
+}
+
+void testModelTraversal()
+{
+  Manager::Ptr mgr = Manager::create();
+  SessionRef sess = mgr->createSession("native");
+
+  UUIDArray uids = createTet(mgr);
+  Model model = mgr->addModel();
+  model.addCell(Volume(mgr, uids[21]));
+  model.setSession(sess);
+  mgr->assignDefaultNames();
+
+  EntityIterator it;
+  it.traverse(model);
+  int count1 = 0;
+  std::cout << "\n---\n\n";
+  for (it.begin(); !it.isAtEnd(); ++it)
+    {
+    std::cout << "  " << it->name() << " (" << it->flagSummary() << ")\n";
+    ++count1;
+    }
+
+  int count2 = 0;
+  std::cout << "\n---\n\n";
+  for (it.begin(); !it.isAtEnd(); ++it)
+    {
+    std::cout << "  " << it->name() << " (" << it->flagSummary() << ")\n";
+    ++count2;
+    }
+
+  std::cout << "\n---\n\n" << "  " << count1 << "  " << count2 << "\n";
+  test(count1 == 78, "Expected to iterate over 78 entities");
+  test(count1 == count2, "Expected iterating twice to count the same number of items.");
+}
+
+int main()
+{
+  testModelTraversal();
+  testExplicitTraversal(smtk::io::JSON_BARE, 7);
+  testExplicitTraversal(smtk::io::JSON_CHILDREN, 14); // Vertex uses are children of vertices
+  testExplicitTraversal(smtk::io::JSON_MODELS, 79);
+  // TODO: Test iteration while model is being modified.
+  return 0;
+}

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -992,6 +992,10 @@
         <include file-name="smtk/model/ArrangementKind.h" location="local"/>
       </enum-type>
 
+      <enum-type name="IteratorStyle">
+        <include file-name="smtk/model/EntityIterator.h" location="local"/>
+      </enum-type>
+
       <enum-type name="OperatorEventType">
         <include file-name="smtk/model/Events.h" location="local"/>
       </enum-type>
@@ -1834,10 +1838,6 @@
       </object-type>
 
       <enum-type name="JSONFlags">
-        <include file-name="smtk/io/ExportJSON.h" location="local"/>
-      </enum-type>
-
-      <enum-type name="JSONRecords">
         <include file-name="smtk/io/ExportJSON.h" location="local"/>
       </enum-type>
 


### PR DESCRIPTION
These commits add a reusable iterator class (EntityIterator) for traversing any set of entities but is particularly useful for iterating over all the entities in the model owning some entity.