### PR TITLE
Add "assign names" property to model Operator.

### DIFF
--- a/smtk/model/Manager.h
+++ b/smtk/model/Manager.h
@@ -183,6 +183,7 @@ public:
   smtk::common::UUID modelOwningEntity(const smtk::common::UUID& uid) const;
 
   void assignDefaultNames();
+  void assignDefaultNamesToModelChildren(const smtk::common::UUID& modelId);
   std::string assignDefaultName(const smtk::common::UUID& uid);
   static std::string shortUUIDName(const smtk::common::UUID& uid, BitFlags entityFlags);
 

--- a/smtk/model/Model.cxx
+++ b/smtk/model/Model.cxx
@@ -210,5 +210,11 @@ StringList Model::operatorNames() const
   return this->session().operatorNames();
 }
 
+/// An efficient method for assigning default names to all of the model's entities.
+void Model::assignDefaultNames()
+{
+  this->manager()->assignDefaultNamesToModelChildren(this->entity());
+}
+
   } // namespace model
 } // namespace smtk

--- a/smtk/model/Model.h
+++ b/smtk/model/Model.h
@@ -57,6 +57,8 @@ public:
 
   OperatorPtr op(const std::string& operatorName) const;
   StringList operatorNames() const;
+
+  void assignDefaultNames();
 };
 
 /// Add all the free cells in \a container to this model.

--- a/smtk/model/Operator.cxx
+++ b/smtk/model/Operator.cxx
@@ -94,6 +94,22 @@ OperatorResult Operator::operate()
       result = this->operateInternal();
     else
       result = this->createResult(OPERATION_CANCELED);
+    smtk::attribute::IntItem::Ptr assignNamesItem;
+    if (
+      result->findInt("outcome")->value() == OPERATION_SUCCEEDED &&
+      (assignNamesItem = this->specification()->findInt("assign names")) &&
+      assignNamesItem->isEnabled() &&
+      assignNamesItem->value() != 0)
+      {
+      ModelEntityItem::Ptr thingsToName = result->findModelEntity("entities");
+      EntityRefArray::const_iterator it;
+      for (it = thingsToName->begin(); it != thingsToName->end(); ++it)
+        {
+        Model model(*it);
+        if (model.isValid())
+          model.assignDefaultNames();
+        }
+      }
     std::size_t logEnd = this->log().numberOfRecords();
     if (logEnd > logStart)
       { // Serialize relevant log records to JSON.

--- a/smtk/model/Session.cxx
+++ b/smtk/model/Session.cxx
@@ -284,9 +284,17 @@ void Session::initializeOperatorSystem(const OperatorConstructors* opList)
 
   this->m_operatorSys = new smtk::attribute::System;
   // Create the "base" definitions that all operators and results will inherit.
-  this->m_operatorSys->createDefinition("operator");
+  Definition::Ptr opdefn = this->m_operatorSys->createDefinition("operator");
 
-  Definition::Ptr defn = this->m_operatorSys->createDefinition("result");
+  IntItemDefinition::Ptr assignNamesDefn = IntItemDefinition::New("assign names");
+  // Do not assign names to entities after the operation by default:
+  assignNamesDefn->setDefaultValue(0);
+  assignNamesDefn->setIsOptional(true);
+  assignNamesDefn->setAdvanceLevel(11);
+
+  opdefn->addItemDefinition(assignNamesDefn);
+
+  Definition::Ptr resultdefn = this->m_operatorSys->createDefinition("result");
   IntItemDefinition::Ptr outcomeDefn = IntItemDefinition::New("outcome");
   ModelEntityItemDefinition::Ptr entoutDefn = ModelEntityItemDefinition::New("entities");
   ModelEntityItemDefinition::Ptr entremDefn = ModelEntityItemDefinition::New("expunged");
@@ -305,10 +313,10 @@ void Session::initializeOperatorSystem(const OperatorConstructors* opList)
   logDefn->setIsExtensible(1);
   logDefn->setIsOptional(true);
 
-  defn->addItemDefinition(outcomeDefn);
-  defn->addItemDefinition(entoutDefn);
-  defn->addItemDefinition(entremDefn);
-  defn->addItemDefinition(logDefn);
+  resultdefn->addItemDefinition(outcomeDefn);
+  resultdefn->addItemDefinition(entoutDefn);
+  resultdefn->addItemDefinition(entremDefn);
+  resultdefn->addItemDefinition(logDefn);
 
   if (!opList && this->inheritsOperators())
     {


### PR DESCRIPTION
When set (it is optional and its default value is OFF),
entity names will be assigned after each operation is
performed.

Names will only be assigned to models listed explicitly
by UUID in the operator result's "entities" item.

This is an efficient way for user interfaces to control
"prettification" of names.