### PR TITLE
Add convenience method for vector-valued items.

### DIFF
--- a/smtk/attribute/ModelEntityItem.h
+++ b/smtk/attribute/ModelEntityItem.h
@@ -53,6 +53,24 @@ public:
   smtk::model::EntityRef value(std::size_t element = 0) const;
   bool setValue(const smtk::model::EntityRef& val);
   bool setValue(std::size_t element, const smtk::model::EntityRef& val);
+  template<typename I>
+  bool setValues(I begin, I end)
+    {
+    bool ok = false;
+    std::size_t num = end - begin;
+    if (this->setNumberOfValues(num))
+      {
+      ok = true;
+      std::size_t i = 0;
+      for (I it = begin; it != end; ++it, ++i)
+        if (!this->setValue(i, *it))
+          {
+          ok = false;
+          break;
+          }
+      }
+    return ok;
+    }
   bool appendValue(const smtk::model::EntityRef& val);
   bool removeValue(std::size_t element);
   virtual void reset();

--- a/smtk/attribute/ValueItemTemplate.h
+++ b/smtk/attribute/ValueItemTemplate.h
@@ -43,6 +43,24 @@ namespace smtk
       bool setValue(const DataT &val)
       {return this->setValue(0, val);}
       bool setValue(std::size_t element, const DataT &val);
+      template<typename I>
+      bool setValues(I begin, I end)
+        {
+        bool ok = false;
+        std::size_t num = end - begin;
+        if (this->setNumberOfValues(num))
+          {
+          ok = true;
+          std::size_t i = 0;
+          for (I it = begin; it != end; ++it, ++i)
+            if (!this->setValue(i, *it))
+              {
+              ok = false;
+              break;
+              }
+          }
+        return ok;
+        }
       bool appendValue(const DataT &val);
       virtual bool appendExpression(smtk::attribute::AttributePtr exp);
       bool removeValue(std::size_t element);

--- a/smtk/bridge/cgm/operators/BooleanIntersection.cxx
+++ b/smtk/bridge/cgm/operators/BooleanIntersection.cxx
@@ -79,20 +79,27 @@ smtk::model::OperatorResult BooleanIntersection::operateInternal()
   DLIList<Body*> cgmBodiesIn;
   DLIList<Body*> cgmBodiesOut;
   Body* cgmBody;
+  EntityRefArray expunged;
   for (it = bodiesIn.begin(); it != bodiesIn.end(); ++it)
     {
     cgmBody = dynamic_cast<Body*>(this->cgmEntity(*it));
     if (cgmBody)
       cgmBodiesIn.append(cgmBody);
     if (!keepInputs)
+      {
       this->manager()->eraseModel(*it);
+      expunged.push_back(*it);
+      }
     }
 
   if (toolIn->numberOfValues() > 0)
     {
     cgmToolBody = dynamic_cast<Body*>(this->cgmEntity(toolIn->value()));
     if (!keepInputs)
+      {
       this->manager()->eraseModel(toolIn->value());
+      expunged.push_back(toolIn->value());
+      }
     if (!cgmToolBody)
       {
       smtkInfoMacro(
@@ -136,6 +143,8 @@ smtk::model::OperatorResult BooleanIntersection::operateInternal()
     if (session->transcribe(smtkEntry, smtk::model::SESSION_EVERYTHING, false))
       resultBodies->setValue(i, smtkEntry);
     }
+
+  result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
 
   return result;
 }

--- a/smtk/bridge/cgm/operators/BooleanSubtraction.cxx
+++ b/smtk/bridge/cgm/operators/BooleanSubtraction.cxx
@@ -61,13 +61,17 @@ smtk::model::OperatorResult BooleanSubtraction::operateInternal()
   DLIList<Body*> cgmBodiesOut;
   DLIList<Body*> cgmToolsIn;
   Body* cgmBody;
+  EntityRefArray expunged;
   for (it = bodiesIn.begin(); it != bodiesIn.end(); ++it)
     {
     cgmBody = dynamic_cast<Body*>(this->cgmEntity(*it));
     if (cgmBody)
       cgmBodiesIn.append(cgmBody);
     if (!keepInputs)
+      {
       this->manager()->eraseModel(*it);
+      expunged.push_back(*it);
+      }
     }
 
   if (cgmBodiesIn.size() < 1)
@@ -83,7 +87,10 @@ smtk::model::OperatorResult BooleanSubtraction::operateInternal()
     if (cgmBody)
       cgmToolsIn.append(cgmBody);
     if (!keepInputs)
+      {
       this->manager()->eraseModel(*toolIt);
+      expunged.push_back(*it);
+      }
     }
 
   DLIList<RefEntity*> imported;
@@ -116,6 +123,8 @@ smtk::model::OperatorResult BooleanSubtraction::operateInternal()
     if (session->transcribe(smtkEntry, smtk::model::SESSION_EVERYTHING, false))
       resultBodies->setValue(i, smtkEntry);
     }
+
+  result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
 
   return result;
 }

--- a/smtk/bridge/cgm/operators/BooleanUnion.cxx
+++ b/smtk/bridge/cgm/operators/BooleanUnion.cxx
@@ -112,15 +112,7 @@ smtk::model::OperatorResult BooleanUnion::operateInternal()
       resultBodies->setValue(i, smtkEntry);
     }
 
-  int numExpunged = expunged.size();
-  if (numExpunged)
-    {
-    smtk::attribute::ModelEntityItem::Ptr expungedOut =
-      result->findModelEntity("expunged");
-    expungedOut->setNumberOfValues(numExpunged);
-    for (int i = 0; i < numExpunged; ++i)
-      expungedOut->setValue(i, expunged[i]);
-    }
+  result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
 
   return result;
 }


### PR DESCRIPTION
This adds a templated `setValues(I begin, I end)` method to
ModelEntityItem and ValueItemTemplate.
It can be used with vector iterators but not set iterators
because `end - begin` must be defined and return an integer
so that the smtk::attribute::Item's numberOfItems can be set.

This commit also uses the above to fix the CGM boolean operators
so that they properly list the expunged entities.