### PR TITLE
Expose CGM's sweep helix op and fix bugs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ endif()
 
 #turn on ctest if we want testing
 if (SMTK_ENABLE_TESTING)
-  message(STATUS "SMTK_ENABLE_TESTING")
   enable_testing()
   include(CTest)
 

--- a/smtk/attribute/ModelEntityItem.cxx
+++ b/smtk/attribute/ModelEntityItem.cxx
@@ -140,7 +140,17 @@ bool ModelEntityItem::setValue(std::size_t i, const smtk::model::EntityRef& val)
 
 bool ModelEntityItem::appendValue(const smtk::model::EntityRef& val)
 {
-  // First - are we allowed to change the number of values?
+  // First - are there unset values waiting to be set?
+  std::size_t n = this->numberOfValues();
+  for (std::size_t i = 0; i < n; ++i)
+    {
+    if (!this->isSet(i))
+      {
+      this->setValue(i, val);
+      return true;
+      }
+    }
+  // Second - are we allowed to change the number of values?
   const ModelEntityItemDefinition* def =
     static_cast<const ModelEntityItemDefinition *>(this->definition().get());
   if (

--- a/smtk/bridge/cgm/operators/Sweep.sbt
+++ b/smtk/bridge/cgm/operators/Sweep.sbt
@@ -89,10 +89,44 @@
               </DetailedDescription>
             </Double>
             <Double Name="sweep angle" NumberOfRequiredValues="1">
+              <Min Inclusive="true">-360.0</Min>
+              <Max Inclusive="true">360.</Max>
               <DefaultValue>360.</DefaultValue>
               <BriefDescription>The angle (in degrees) through which the associated entities should be revolved.</BriefDescription>
             </Double>
-            <!-- Option 3: curves (sweep path) -->
+            <!-- Option 3: axis base point, axis of revolution, pitch, helix angle, and handedness -->
+            <Double Name="helix angle" NumberOfRequiredValues="1">
+              <DefaultValue>360.</DefaultValue>
+              <BriefDescription>The angle (in degrees) through which the associated entities should be revolved.</BriefDescription>
+            </Double>
+            <Double Name="pitch" NumberOfRequiredValues="1">
+              <DefaultValue>1.</DefaultValue>
+              <BriefDescription>The distance between corresponding points measured along the axis of the sweep.</BriefDescription>
+            </Double>
+            <Int Name="handedness" NumberOfRequiredValues="1">
+              <BriefDescription>Should the helix be right- or left-handed?</BriefDescription>
+              <DetailedDescription>
+                A helix translates geometry along the direction of the axis of revolution while
+                at the same time rotating it tangent to this axis.
+                A right-handed helix performs a positive translation (i.e., codirectional with the axis)
+                while rotating in a direction given by aligning a right thumb with the axis and curling
+                the fingers toward the thumb.
+                A left-handed helix rotates the opposite direction for the same positive translation.
+              </DetailedDescription>
+              <ChildrenDefinitions/>
+              <DiscreteInfo DefaultIndex="1">
+                <!-- Values from CGM's GeometryType enum in util/GeometryDefines.h -->
+                <Structure>
+                  <Value Enum="left-handed">0</Value>
+                  <Items/>
+                </Structure>
+                <Structure>
+                  <Value Enum="right-handed">1</Value>
+                  <Items/>
+                </Structure>
+              </DiscreteInfo>
+            </Int>
+            <!-- Option 4: curves (sweep path) -->
             <ModelEntity Name="sweep path" NumberOfRequiredValues="1" Extensible="true">
               <MembershipMask>edge</MembershipMask>
               <BriefDescription>The curve along which to sweep the associated entities.</BriefDescription>

--- a/smtk/bridge/cgm/testing/python/CMakeLists.txt
+++ b/smtk/bridge/cgm/testing/python/CMakeLists.txt
@@ -10,7 +10,6 @@ set(smtkCGMSessionPythonDataTests
   cgmLoadFile
 )
 
-message("PYTHONPATH=${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}")
 foreach (test ${smtkCGMSessionPythonTests})
   add_test(${test}Py ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py)
   set_tests_properties(${test}Py

--- a/smtk/bridge/cgm/testing/python/cgmSolidModeling.py
+++ b/smtk/bridge/cgm/testing/python/cgmSolidModeling.py
@@ -64,10 +64,17 @@ res = u1.operate()
 su = res.findModelEntity('entities').value(0)
 # Note that su has same UUID as sph2
 
+
+# Test cylinder creation.
+from smtk.simple import *
+SetActiveSession(sref)
+cyl = CreateCylinder(top_radius=1.0)
+
 #json = smtk.io.ExportJSON.fromModelManager(mgr)
-#sphFile = open('/tmp/s3.json', 'w')
-#print >> sphFile, json
-#sphFile.close()
+#cylFile = open('cyl.json', 'w')
+#print >> cylFile, json
+#cylFile.close()
+
 
 #
 # Now verify that mgr.closeSession removes the entity record for the session.


### PR DESCRIPTION
This branch includes initial support for helical sweeps,
but be aware that only Cubit/ACIS support this kind of
sweep; the CGM OpenCascade backend does not yet perform
sweeps.

This also fixes a bug in `ModelEntityItem::appendValue()`.
This bug causes issues when `Operator::associateEntity()` is
called and the association has a minimum number of expected
values; because there are not default UUID values, the first
numberOfValues() entries are null UUIDs; the associated entity
is appended to the end of this array, which leaves null values
at the front of the array. So, even though it is slow, we must
verify that existing slots for model entities are actually in use.

Finally, this branch tweaks the smtk.simple API a little bit:

* Add CreateCylinder to simple python API.
* Solid modeling operations print the error
  log when an operation does not succeed.