### PR TITLE
Update operator model association and UI when entities removed.

### DIFF
--- a/smtk/extension/qt/qtModelOperationWidget.cxx
+++ b/smtk/extension/qt/qtModelOperationWidget.cxx
@@ -211,6 +211,27 @@ bool qtModelOperationWidget::setCurrentOperation(
 }
 
 //----------------------------------------------------------------------------
+void qtModelOperationWidget::expungeEntities(
+        const smtk::model::EntityRefs& expungedEnts)
+{
+  QMapIterator<std::string, qtModelOperationWidgetInternals::OperatorInfo > it(
+    this->Internals->OperatorMap);
+  while(it.hasNext())
+    {
+    it.next();
+    if(it.value().opPtr && it.value().opPtr->specification()->isValid())
+      {
+      for (EntityRefs::iterator bit = expungedEnts.begin();
+        bit != expungedEnts.end(); ++bit)
+        {
+        //std::cout << "expunge from op " << bit->flagSummary(0) << " " << bit->entity() << "\n";
+        it.value().opPtr->specification()->disassociateEntity(*bit);
+        }
+      }
+    }
+}
+
+//----------------------------------------------------------------------------
 void qtModelOperationWidget::onOperationSelected()
 {
   this->setCurrentOperation(

--- a/smtk/extension/qt/qtModelOperationWidget.cxx
+++ b/smtk/extension/qt/qtModelOperationWidget.cxx
@@ -12,7 +12,8 @@
 
 #include "smtk/extension/qt/qtUIManager.h"
 #include "smtk/extension/qt/qtAttribute.h"
-#include "smtk/extension/qt/qtModelEntityItem.h"
+#include "smtk/extension/qt/qtBaseView.h"
+
 
 #include "smtk/attribute/Attribute.h"
 #include "smtk/attribute/Definition.h"
@@ -52,6 +53,7 @@ public:
   smtk::model::OperatorPtr opPtr;
   QPointer<qtUIManager> opUiManager;
   QPointer<QFrame> opUiParent;
+  QPointer<qtBaseView> opUiView;
   };
 
   smtk::model::WeakOperatorPtr CurrentOp;
@@ -197,11 +199,12 @@ bool qtModelOperationWidget::setCurrentOperation(
   QObject::connect(uiManager, SIGNAL(fileItemCreated(smtk::attribute::qtFileItem*)),
     this, SIGNAL(fileItemCreated(smtk::attribute::qtFileItem*)));
 
-  uiManager->initializeView(opParent, instanced, false);
+  qtBaseView* theView = uiManager->initializeView(opParent, instanced, false);
   qtModelOperationWidgetInternals::OperatorInfo opInfo;
   opInfo.opPtr = brOp;
   opInfo.opUiParent = opParent;
   opInfo.opUiManager = uiManager;
+  opInfo.opUiView = theView;
 
   this->Internals->OperatorMap[opName] = opInfo;
   this->Internals->OperationsLayout->addWidget(opParent);
@@ -228,6 +231,7 @@ void qtModelOperationWidget::expungeEntities(
         it.value().opPtr->specification()->disassociateEntity(*bit);
         }
       }
+    it.value().opUiView->updateUI();
     }
 }
 

--- a/smtk/extension/qt/qtModelOperationWidget.h
+++ b/smtk/extension/qt/qtModelOperationWidget.h
@@ -44,6 +44,8 @@ namespace smtk
     public slots:
       virtual bool setCurrentOperation(
         const std::string& opName, smtk::model::SessionPtr session);
+      virtual void expungeEntities(
+        const smtk::model::EntityRefs& expungedEnts);
 
     signals:
       void operationRequested(const smtk::model::OperatorPtr& brOp);

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -805,6 +805,14 @@ void qtModelView::syncEntityColor(
     }
 }
 
+//-----------------------------------------------------------------------------
+void qtModelView::onEntitiesExpunged(
+  const smtk::model::EntityRefs& expungedEnts)
+{
+  if(!this->m_OperatorsWidget)
+    return;
+  this->m_OperatorsWidget->expungeEntities(expungedEnts);
+}
 
   } // namespace model
 } // namespace smtk

--- a/smtk/extension/qt/qtModelView.h
+++ b/smtk/extension/qt/qtModelView.h
@@ -66,6 +66,8 @@ public slots:
   void operatorInvoked();
   void toggleEntityVisibility( const QModelIndex& );
   void changeEntityColor( const QModelIndex&);
+  void onEntitiesExpunged(
+    const smtk::model::EntityRefs& expungedEnts);
 
 signals:
   void entitiesSelected(const smtk::model::EntityRefs& selEntityRefs);


### PR DESCRIPTION
After certain model operations, some entities could be removed, for
example, merge or union op. Once these operations are done, the attribute
for the operator should be updated since we are keeping these operators
around in the application.