### PR TITLE
Relax constraints on entity types that can be selected.

### DIFF
--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -196,7 +196,7 @@ void qtModelView::selectionChanged (
   foreach(QModelIndex sel, this->selectedIndexes())
     {
     this->recursiveSelect(qmodel->getItem(sel), selentityrefs,
-      CELL_ENTITY /*| SHELL_ENTITY  | GROUP_ENTITY | MODEL_ENTITY */);
+      CELL_ENTITY | SHELL_ENTITY  | GROUP_ENTITY | MODEL_ENTITY | INSTANCE_ENTITY);
     }
 
   emit this->entitiesSelected(selentityrefs);


### PR DESCRIPTION
When selecting in the tree view, only certain types of entities
will be processed to signal what's selected. More types are added
to the constraints so that sessions that have tesselations in
non-traditional entity types can also be linked with selection in
the application render view.