### PR TITLE
Fixed a bug in grow operator and made MeshSelectionItem to be wrapped by shiboken

### DIFF
--- a/smtk/bridge/discrete/operators/GrowOperator.cxx
+++ b/smtk/bridge/discrete/operators/GrowOperator.cxx
@@ -268,7 +268,7 @@ bool GrowOperator::convertAndResetOutSelection(
     vtkDiscreteModel::ClassificationType& classified =
                               model->GetMeshClassification();
     smtk::common::UUID faceUUID;
-    vtkIdType faceCellId;
+    vtkIdType masterId, faceCellId;
     // Gather up cells for each existing model face that are in the selection
     // the CellIds are with respect to the master grid.
     std::map<vtkModelEntity*, std::set<vtkIdType> > entityCellIds;
@@ -290,9 +290,11 @@ bool GrowOperator::convertAndResetOutSelection(
         {
         for(vtkIdType j=0;j<cellIds->GetNumberOfTuples();j++)
           {
-          faceCellId = cellIds->GetValue(j);
+          masterId = cellIds->GetValue(j);
           vtkDiscreteModelGeometricEntity* cmbEntity =
-              classified.GetEntity(faceCellId);
+              classified.GetEntity(masterId);
+          faceCellId = classified.GetEntityIndex(masterId);
+
           vtkModelEntity* entity = cmbEntity->GetThisModelEntity();
           faceUUID = opsession->findOrSetEntityUUID(entity);
           this->m_outSelection[faceUUID].insert(faceCellId);

--- a/smtk/extension/qt/qtMeshSelectionItem.cxx
+++ b/smtk/extension/qt/qtMeshSelectionItem.cxx
@@ -56,12 +56,15 @@ public:
   QPointer<QToolButton> GrowMinusButton;
   QPointer<QToolButton> CancelButton;
   QPointer<QToolButton> AcceptButton;
+  QPointer<QButtonGroup> ButtonGroup;
 
   void uncheckGrowButtons()
   {
+    this->ButtonGroup->setExclusive(false);
     this->GrowButton->setChecked(false);
     this->GrowPlusButton->setChecked(false);
     this->GrowMinusButton->setChecked(false);
+    this->ButtonGroup->setExclusive(true);
   }
 
 };
@@ -177,6 +180,7 @@ void qtMeshSelectionItem::addMeshOpButtons()
     buttonLayout, bgroup, false, this);
 
   this->Internals->EntryLayout->addLayout(buttonLayout, 0, 1);
+  this->Internals->ButtonGroup = bgroup;
 }
 
 //----------------------------------------------------------------------------
@@ -288,6 +292,7 @@ void qtMeshSelectionItem::setOutputOptional(int state)
       this->baseView()->valueChanged(this->getObject());
     }
 }
+
 //----------------------------------------------------------------------------
 void qtMeshSelectionItem::clearSelection()
 {
@@ -318,12 +323,13 @@ void qtMeshSelectionItem::setSelection(const smtk::common::UUID& entid,
       this->Internals->uncheckGrowButtons();
       break;
     case MeshSelectionItem::RESET:
-    case MeshSelectionItem::MERGE:
-    case MeshSelectionItem::SUBTRACT:
-    // The MeshSelectionItem is really just a place holder for
-    // current selection. The operator itself will handle
-    // different selection types given current selection.
       meshSelectionItem->setValues(entid, vals);
+      break;
+    case MeshSelectionItem::MERGE:
+       meshSelectionItem->unionValues(entid, vals);
+       break;
+    case MeshSelectionItem::SUBTRACT:
+      meshSelectionItem->removeValues(entid, vals);
       break;
     case MeshSelectionItem::NONE:
       this->Internals->uncheckGrowButtons();

--- a/smtk/model/Operator.cxx
+++ b/smtk/model/Operator.cxx
@@ -374,7 +374,7 @@ smtk::attribute::ModelEntityItemPtr Operator::findModelEntity(const std::string&
 }
 
 /// Return the mesh-entity-item parameter named \a name or NULL if it does not exist.
-smtk::attribute::MeshSelectionItemPtr Operator::findMeshEntity(const std::string& pname, smtk::attribute::SearchStyle search)
+smtk::attribute::MeshSelectionItemPtr Operator::findMeshSelection(const std::string& pname, smtk::attribute::SearchStyle search)
 {
   return this->specification()->findAs<MeshSelectionItem>(pname, search);
 }

--- a/smtk/model/Operator.h
+++ b/smtk/model/Operator.h
@@ -210,7 +210,7 @@ public:
   smtk::attribute::ModelEntityItemPtr findModelEntity(
     const std::string& name,
     smtk::attribute::SearchStyle style = smtk::attribute::ALL_CHILDREN);
-  smtk::attribute::MeshSelectionItemPtr findMeshEntity(
+  smtk::attribute::MeshSelectionItemPtr findMeshSelection(
     const std::string& name,
     smtk::attribute::SearchStyle style = smtk::attribute::ALL_CHILDREN);
 

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -372,6 +372,9 @@
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findDouble', unmatched return type 'smtk::attribute::ConstDoubleItemPtr'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findString', unmatched return type 'smtk::attribute::ConstStringItemPtr'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findModelEntity', unmatched return type 'smtk::attribute::ConstModelEntityItemPtr'"/>
+  <suppress-warning text="skipping function 'smtk::attribute::Attribute::findMeshSelection', unmatched return type 'smtk::attribute::ConstMeshSelectionItemPtr'"/>
+  <suppress-warning text="skipping function 'smtk::attribute::Attribute::findMeshSelection', unmatched return type 'smtk::attribute::MeshSelectionItemPtr'"/>
+  <suppress-warning text="skipping function 'smtk::model::Operator::findMeshSelection', unmatched return type 'smtk::attribute::MeshSelectionItemPtr'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findGroup', unmatched return type 'smtk::attribute::ConstGroupItemPtr'"/>
 
 
@@ -951,6 +954,8 @@
   <value-type template="smtk::shared_ptr" args="smtk::attribute::StringItemDefinition" />
   <value-type template="smtk::shared_ptr" args="smtk::attribute::ModelEntityItem" />
   <value-type template="smtk::shared_ptr" args="smtk::attribute::ModelEntityItemDefinition" />
+  <value-type template="smtk::shared_ptr" args="smtk::attribute::MeshSelectionItem" />
+  <value-type template="smtk::shared_ptr" args="smtk::attribute::MeshSelectionItemDefinition" />
   <value-type template="smtk::shared_ptr" args="smtk::attribute::VoidItem" />
   <value-type template="smtk::shared_ptr" args="smtk::attribute::VoidItemDefinition" />
 
@@ -1764,6 +1769,39 @@
                       return-type="smtk::shared_ptr&lt;smtk::attribute::ModelEntityItemDefinition &gt;">
           <inject-code>
             %RETURN_TYPE %0 = smtk::dynamic_pointer_cast&lt;smtk::attribute::ModelEntityItemDefinition &gt;(%1);
+            %PYARG_0 = %CONVERTTOPYTHON[%RETURN_TYPE](%0);
+          </inject-code>
+        </add-function>
+      </object-type>
+
+      <object-type name="MeshSelectionItem">
+        <include file-name="smtk/attribute/MeshSelectionItem.h" location="local" />
+        <add-function signature="CastTo(smtk::shared_ptr&lt;smtk::attribute::Item &gt; &amp;)"
+                      static="yes"
+                      return-type="smtk::shared_ptr&lt;smtk::attribute::MeshSelectionItem &gt;">
+          <inject-code>
+            %RETURN_TYPE %0 = smtk::dynamic_pointer_cast&lt;smtk::attribute::MeshSelectionItem &gt;(%1);
+            %PYARG_0 = %CONVERTTOPYTHON[%RETURN_TYPE](%0);
+          </inject-code>
+        </add-function>
+      </object-type>
+
+      <object-type name="MeshSelectionItemDefinition">
+        <include file-name="smtk/attribute/MeshSelectionItemDefinition.h" location="local" />
+        <modify-function signature="MeshSelectionItemDefinition(const std::string &amp;)" access="private" />
+        <add-function signature="ToItemDefinition(const smtk::shared_ptr&lt;smtk::attribute::MeshSelectionItemDefinition &gt;)"
+                      static="yes"
+                      return-type="smtk::shared_ptr&lt;smtk::attribute::ItemDefinition &gt;">
+          <inject-code>
+            %RETURN_TYPE %0 = smtk::dynamic_pointer_cast&lt;smtk::attribute::ItemDefinition &gt;(%1);
+            %PYARG_0 = %CONVERTTOPYTHON[%RETURN_TYPE](%0);
+          </inject-code>
+        </add-function>
+        <add-function signature="CastTo(smtk::shared_ptr&lt;smtk::attribute::ItemDefinition &gt; &amp;)"
+                      static="yes"
+                      return-type="smtk::shared_ptr&lt;smtk::attribute::MeshSelectionItemDefinition &gt;">
+          <inject-code>
+            %RETURN_TYPE %0 = smtk::dynamic_pointer_cast&lt;smtk::attribute::MeshSelectionItemDefinition &gt;(%1);
             %PYARG_0 = %CONVERTTOPYTHON[%RETURN_TYPE](%0);
           </inject-code>
         </add-function>


### PR DESCRIPTION
This should fix the failed python tests caused by MeshSelectionItem is not being wrapped. Also, minor UI clean up in qtMeshSelectionItem