### PR TITLE
Fix style and warnings.

### DIFF
--- a/smtk/attribute/MeshSelectionItem.cxx
+++ b/smtk/attribute/MeshSelectionItem.cxx
@@ -8,7 +8,6 @@
 //  PURPOSE.  See the above copyright notice for more information.
 //=========================================================================
 
-
 #include "smtk/attribute/MeshSelectionItem.h"
 #include "smtk/attribute/MeshSelectionItemDefinition.h"
 #include "smtk/attribute/Attribute.h"
@@ -19,7 +18,7 @@
 using namespace smtk::attribute;
 
 //----------------------------------------------------------------------------
-MeshSelectionItem::MeshSelectionItem(Attribute *owningAttribute,
+MeshSelectionItem::MeshSelectionItem(Attribute* owningAttribute,
                    int itemPosition):
   Item(owningAttribute, itemPosition)
 {
@@ -28,7 +27,7 @@ MeshSelectionItem::MeshSelectionItem(Attribute *owningAttribute,
 }
 
 //----------------------------------------------------------------------------
-MeshSelectionItem::MeshSelectionItem(Item *inOwningItem,
+MeshSelectionItem::MeshSelectionItem(Item* inOwningItem,
                    int itemPosition,
                    int inSubGroupPosition):
   Item(inOwningItem, itemPosition, inSubGroupPosition)
@@ -41,8 +40,8 @@ setDefinition(smtk::attribute::ConstItemDefinitionPtr adef)
 {
   // Note that we do a dynamic cast here since we don't
   // know if the proper definition is being passed
-  const MeshSelectionItemDefinition *def =
-    dynamic_cast<const MeshSelectionItemDefinition *>(adef.get());
+  const MeshSelectionItemDefinition* def =
+    dynamic_cast<const MeshSelectionItemDefinition*>(adef.get());
 
   // Call the parent's set definition - similar to constructor calls
   // we call from base to derived
@@ -61,8 +60,8 @@ MeshSelectionItem::~MeshSelectionItem()
 //----------------------------------------------------------------------------
 Item::Type MeshSelectionItem::type() const
 {
-  const MeshSelectionItemDefinition *def =
-    static_cast<const MeshSelectionItemDefinition *>(this->definition().get());
+  const MeshSelectionItemDefinition* def =
+    static_cast<const MeshSelectionItemDefinition*>(this->definition().get());
   if (def != NULL)
     {
     return def->type();
@@ -142,8 +141,7 @@ smtk::attribute::MeshSelectionItem::const_sel_map_it MeshSelectionItem::end() co
 }
 
 //----------------------------------------------------------------------------
-std::string MeshSelectionItem::selectMode2String(
-  MeshSelectionItem::MeshSelectionMode m)
+std::string MeshSelectionItem::selectMode2String(MeshSelectionMode m)
 {
   switch (m)
     {
@@ -164,8 +162,7 @@ std::string MeshSelectionItem::selectMode2String(
 }
 
 //----------------------------------------------------------------------------
-MeshSelectionItem::MeshSelectionMode MeshSelectionItem::string2SelectMode(
-  const std::string &s)
+MeshSelectionMode MeshSelectionItem::string2SelectMode(const std::string &s)
 {
   if (s == "NONE")
     {

--- a/smtk/attribute/MeshSelectionItem.h
+++ b/smtk/attribute/MeshSelectionItem.h
@@ -7,10 +7,6 @@
 //  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 //  PURPOSE.  See the above copyright notice for more information.
 //=========================================================================
-// .NAME MeshSelectionItem.h -
-// .SECTION Description
-// .SECTION See Also
-
 #ifndef __smtk_attribute_MeshSelectionItem_h
 #define __smtk_attribute_MeshSelectionItem_h
 
@@ -21,69 +17,72 @@
 #include <set>
 #include <map>
 
-namespace smtk
+namespace smtk {
+  namespace attribute {
+
+class MeshSelectionItemDefinition;
+
+/// Enumeration of mesh values modification type.
+enum MeshSelectionMode {
+  NONE,             //!< Cancel current operation mode
+  RESET,            //!< Reset the existing list)
+  MERGE,            //!< Append to the existing list
+  SUBTRACT,         //!< Subtract from existing list
+  ACCEPT,           //!< Accept the existing list)
+  NUM_OF_MODES      //!< The number of mesh selection modes.
+};
+
+/**\brief Provide a way for an attribute to refer to mesh entities.
+  *
+  */
+class SMTKCORE_EXPORT MeshSelectionItem : public Item
 {
-  namespace attribute
-  {
-    class MeshSelectionItemDefinition;
-    class SMTKCORE_EXPORT MeshSelectionItem : public Item
-    {
-    friend class MeshSelectionItemDefinition;
-    public:
+public:
+  typedef std::map<smtk::common::UUID, std::set<int> >::const_iterator const_sel_map_it;
 
-typedef std::map<smtk::common::UUID, std::set<int> >::const_iterator const_sel_map_it;
+  smtkTypeMacro(MeshSelectionItem);
+  virtual ~MeshSelectionItem();
+  virtual Item::Type type() const;
 
-      smtkTypeMacro(MeshSelectionItem);
-      virtual ~MeshSelectionItem();
-      virtual Item::Type type() const;
+  void setValues(const smtk::common::UUID&, const std::set<int>&);
+  void unionValues(const smtk::common::UUID&, const std::set<int>&);
+  void removeValues(const smtk::common::UUID&, const std::set<int>&);
+  void setMeshSelectMode(MeshSelectionMode mode)
+    { this->m_selectMode = mode; }
+  MeshSelectionMode meshSelectMode() const
+    {return this->m_selectMode;}
+  void setCtrlKeyDown(bool val)
+    { this->m_isCtrlKeyDown = val; }
+  bool isCtrlKeyDown() const
+    {return this->m_isCtrlKeyDown;}
 
-  /// Enumeration of mesh values modification type.
-  enum MeshSelectionMode {
-    NONE            ,//!< Cancel current operation mode
-    RESET           , //!< Reset the existing list)
-    MERGE           , //!< Append to the existing list
-    SUBTRACT        , //!< Subtract from existing list
-    ACCEPT          , //!< Accept the existing list)
-    NUM_OF_MODES
-  };
+  std::size_t numberOfValues() const;
+  const std::set<int>& values(const smtk::common::UUID&);
+  virtual void reset();
+  virtual void copyFrom(
+    const smtk::attribute::ItemPtr sourceItem,
+    smtk::attribute::Item::CopyInfo& info);
 
-      void setValues(const smtk::common::UUID&, const std::set<int>&);
-      void unionValues(const smtk::common::UUID&, const std::set<int>&);
-      void removeValues(const smtk::common::UUID&, const std::set<int>&);
-      void setMeshSelectMode(MeshSelectionMode mode)
-      { this->m_selectMode = mode; }
-      MeshSelectionMode meshSelectMode() const
-      {return this->m_selectMode;}
-      void setCtrlKeyDown(bool val)
-      { this->m_isCtrlKeyDown = val; }
-      bool isCtrlKeyDown() const
-      {return this->m_isCtrlKeyDown;}
-  
-      std::size_t numberOfValues() const;
-      const std::set<int>& values(const smtk::common::UUID&);
-      virtual void reset();
-      virtual void copyFrom(const smtk::attribute::ItemPtr sourceItem,
-                            smtk::attribute::Item::CopyInfo& info);
+  const_sel_map_it begin() const;
+  const_sel_map_it end() const;
 
-      const_sel_map_it begin() const;
-      const_sel_map_it end() const;
+  static std::string selectMode2String(
+    MeshSelectionMode m);
+  static MeshSelectionMode string2SelectMode(
+    const std::string &s);
 
-     static std::string selectMode2String(
-            MeshSelectionItem::MeshSelectionMode m);
-     static MeshSelectionItem::MeshSelectionMode string2SelectMode(
-            const std::string &s);
+protected:
+  friend class MeshSelectionItemDefinition;
 
-    protected:
-      MeshSelectionItem(Attribute *owningAttribute, int itemPosition);
-      MeshSelectionItem(Item *owningItem, int position, int subGroupPosition);
-      virtual bool setDefinition(smtk::attribute::ConstItemDefinitionPtr vdef);
-      std::map<smtk::common::UUID, std::set<int> >m_selectionValues;
-      MeshSelectionMode m_selectMode;
-      bool m_isCtrlKeyDown;
-    private:
-    };
-  }
-}
+  MeshSelectionItem(Attribute *owningAttribute, int itemPosition);
+  MeshSelectionItem(Item *owningItem, int position, int subGroupPosition);
+  virtual bool setDefinition(smtk::attribute::ConstItemDefinitionPtr vdef);
+  std::map<smtk::common::UUID, std::set<int> >m_selectionValues;
+  MeshSelectionMode m_selectMode;
+  bool m_isCtrlKeyDown;
+};
 
+  } // namespace attribute
+} // namespace smtk
 
-#endif /* __smtk_attribute_MeshSelectionItem_h */
+#endif // __smtk_attribute_MeshSelectionItem_h

--- a/smtk/bridge/discrete/operators/GrowOperator.cxx
+++ b/smtk/bridge/discrete/operators/GrowOperator.cxx
@@ -315,23 +315,23 @@ bool GrowOperator::convertAndResetOutSelection(
 bool GrowOperator::modifyOutSelection(
   const smtk::attribute::MeshSelectionItemPtr& inSelectionItem)
 {
-  MeshSelectionItem::MeshSelectionMode opType = inSelectionItem->meshSelectMode();
+  MeshSelectionMode opType = inSelectionItem->meshSelectMode();
   bool ok = false;
 
   smtk::attribute::MeshSelectionItem::const_sel_map_it mapIt;
   for(mapIt = inSelectionItem->begin(); mapIt != inSelectionItem->end(); ++mapIt)
     {
-    if(opType == MeshSelectionItem::RESET)
+    if(opType == RESET)
       {
       m_outSelection[mapIt->first] = mapIt->second;
       ok = true;
       }
-    else if(opType == MeshSelectionItem::MERGE)
+    else if(opType == MERGE)
       {
       m_outSelection[mapIt->first].insert(mapIt->second.begin(), mapIt->second.end());
       ok = true;
       }
-    else if(opType == MeshSelectionItem::SUBTRACT)
+    else if(opType == SUBTRACT)
       {
       std::set<int> diffSet;
       std::set_difference(m_outSelection[mapIt->first].begin(),
@@ -379,12 +379,12 @@ smtk::model::OperatorResult GrowOperator::operateInternal()
   bool ok = false;
   smtk::attribute::MeshSelectionItem::Ptr inSelectionItem =
      this->specification()->findMeshSelection("selection");
-  MeshSelectionItem::MeshSelectionMode opType = inSelectionItem->meshSelectMode();
+  MeshSelectionMode opType = inSelectionItem->meshSelectMode();
   int numSelValues = inSelectionItem->numberOfValues();
 
   switch(opType)
   {
-    case MeshSelectionItem::ACCEPT:
+    case ACCEPT:
       // convert current outSelection to grow Selection
 /* //TODO: the cached selection seems to be lost during serialization.
       if(m_growCacheModified)
@@ -399,9 +399,9 @@ smtk::model::OperatorResult GrowOperator::operateInternal()
       this->m_splitOp->Operate(modelWrapper, this->m_growSelection.GetPointer());
       ok = this->m_splitOp->GetOperateSucceeded();
       break;
-    case MeshSelectionItem::RESET:
-    case MeshSelectionItem::MERGE:
-    case MeshSelectionItem::SUBTRACT:
+    case RESET:
+    case MERGE:
+    case SUBTRACT:
 
       // if the ctrl key is down or multiple cells are selected from rubber band,
       // only do modification of current grow selection using the input selection.
@@ -426,8 +426,8 @@ smtk::model::OperatorResult GrowOperator::operateInternal()
         std::set<vtkIdType> visModelFaceIds;
         this->findVisibleModelFaces(model, visModelFaceIds, opsession);
         this->m_growOp->SetModelWrapper(modelWrapper);
-        int mode = opType == MeshSelectionItem::RESET ? 0 :
-          (opType == MeshSelectionItem::MERGE ? 1 : 2);
+        int mode = opType == RESET ? 0 :
+          (opType == MERGE ? 1 : 2);
         this->m_growOp->SetGrowMode(mode);
         this->m_growOp->SetFeatureAngle(
           this->specification()->findDouble("feature angle")->value());
@@ -450,7 +450,7 @@ smtk::model::OperatorResult GrowOperator::operateInternal()
         }
 
       break;
-    case MeshSelectionItem::NONE:
+    case NONE:
       this->m_outSelection.clear();
       m_growCacheModified = false;
       ok = true; // stop grow
@@ -469,13 +469,13 @@ smtk::model::OperatorResult GrowOperator::operateInternal()
     {
     switch(opType)
       {
-      case MeshSelectionItem::ACCEPT:
+      case ACCEPT:
         this->writeSplitResult(m_splitOp.GetPointer(),
           modelWrapper, opsession, result);
         break;
-      case MeshSelectionItem::RESET:
-      case MeshSelectionItem::MERGE:
-      case MeshSelectionItem::SUBTRACT:
+      case RESET:
+      case MERGE:
+      case SUBTRACT:
         {
         smtk::attribute::ModelEntityItem::Ptr resultEntities =
           result->findModelEntity("entities");

--- a/smtk/extension/qt/qtMeshSelectionItem.cxx
+++ b/smtk/extension/qt/qtMeshSelectionItem.cxx
@@ -315,23 +315,23 @@ void qtMeshSelectionItem::setSelection(const smtk::common::UUID& entid,
     {
     return;
     }
-  MeshSelectionItem::MeshSelectionMode opType = meshSelectionItem->meshSelectMode();
+  MeshSelectionMode opType = meshSelectionItem->meshSelectMode();
   switch(opType)
   {
-    case MeshSelectionItem::ACCEPT:
+    case ACCEPT:
       meshSelectionItem->setValues(entid, vals);
       this->Internals->uncheckGrowButtons();
       break;
-    case MeshSelectionItem::RESET:
+    case RESET:
       meshSelectionItem->setValues(entid, vals);
       break;
-    case MeshSelectionItem::MERGE:
+    case MERGE:
        meshSelectionItem->unionValues(entid, vals);
        break;
-    case MeshSelectionItem::SUBTRACT:
+    case SUBTRACT:
       meshSelectionItem->removeValues(entid, vals);
       break;
-    case MeshSelectionItem::NONE:
+    case NONE:
       this->Internals->uncheckGrowButtons();
       meshSelectionItem->reset();
       break;
@@ -397,17 +397,17 @@ void qtMeshSelectionItem::onRequestMeshSelection()
 
   this->setUsingCtrlKey(false);
 
-  MeshSelectionItem::MeshSelectionMode selType;
+  MeshSelectionMode selType;
   if(cButton == this->Internals->AcceptButton)
-    selType = MeshSelectionItem::ACCEPT;
+    selType = ACCEPT;
   else if(cButton == this->Internals->GrowButton)
-    selType = MeshSelectionItem::RESET;
+    selType = RESET;
   else if(cButton == this->Internals->GrowPlusButton)
-    selType = MeshSelectionItem::MERGE;
+    selType = MERGE;
   else if(cButton == this->Internals->GrowMinusButton)
-    selType = MeshSelectionItem::SUBTRACT;
+    selType = SUBTRACT;
   else if(cButton == this->Internals->CancelButton)
-    selType = MeshSelectionItem::NONE;
+    selType = NONE;
   else
     {
     std::cerr << "ERROR: Unrecognized button click "
@@ -416,7 +416,7 @@ void qtMeshSelectionItem::onRequestMeshSelection()
     }
 
   meshSelectionItem->setMeshSelectMode(selType);
-  if(selType == MeshSelectionItem::ACCEPT || selType == MeshSelectionItem::NONE)
+  if(selType == ACCEPT || selType == NONE)
     this->Internals->uncheckGrowButtons();
 
   smtk::attribute::ModelEntityItem::Ptr modelEntities =

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -376,7 +376,9 @@
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findMeshSelection', unmatched return type 'smtk::attribute::MeshSelectionItemPtr'"/>
   <suppress-warning text="skipping function 'smtk::model::Operator::findMeshSelection', unmatched return type 'smtk::attribute::MeshSelectionItemPtr'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::findGroup', unmatched return type 'smtk::attribute::ConstGroupItemPtr'"/>
-
+  <suppress-warning text="skipping function 'smtk::attribute::MeshSelectionItem::end', unmatched return type 'smtk::attribute::MeshSelectionItem::const_sel_map_it'"/>
+  <suppress-warning text="skipping function 'smtk::attribute::MeshSelectionItem::copyFrom', unmatched parameter type 'smtk::attribute::Item::CopyInfo&amp;'"/>
+  <suppress-warning text="skipping function 'smtk::attribute::MeshSelectionItem::begin', unmatched return type 'smtk::attribute::MeshSelectionItem::const_sel_map_it'"/>
 
   @EXTRA_TYPESYSTEMS@
 
@@ -1806,6 +1808,10 @@
           </inject-code>
         </add-function>
       </object-type>
+
+      <enum-type name="MeshSelectionMode">
+        <include file-name="smtk/attribute/MeshSelectionItem.h" location="local"/>
+      </enum-type>
 
       <object-type name="ValueItem">
         <include file-name="smtk/attribute/ValueItem.h" location="local" />


### PR DESCRIPTION
Enums should be kept out of classes when possible and
always added to the appropriate `typesystem.xml` file
so that shiboken can wrap methods which use them.