### PR TITLE
Remove boost/uuid/uuid.hpp from shiboken processing

### DIFF
--- a/smtk/common/UUID.h
+++ b/smtk/common/UUID.h
@@ -18,7 +18,9 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored"-Wshadow"
 #endif
+#ifndef SHIBOKEN_SKIP
 #include <boost/uuid/uuid.hpp>
+#endif
 #ifndef _MSC_VER
 #  pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Was causing Shiboken to crash when building on Ubuntu 14.04