### PR TITLE
Link model tree view text edting with SetOperator

### DIFF
--- a/smtk/extension/qt/qtEntityItemModel.cxx
+++ b/smtk/extension/qt/qtEntityItemModel.cxx
@@ -348,6 +348,9 @@ bool QEntityItemModel::setData(const QModelIndex& idx, const QVariant& value, in
       {
       std::string sval = value.value<QString>().toStdString();
       didChange = phrase->setTitle(sval);
+      // if data did get changed, we need to emit the signal
+      if(didChange)
+        emit this->phraseTitleChanged(idx);
       }
     else if (role == SubtitleTextRole && phrase->isSubtitleMutable())
       {

--- a/smtk/extension/qt/qtEntityItemModel.h
+++ b/smtk/extension/qt/qtEntityItemModel.h
@@ -97,6 +97,9 @@ public:
 
   void subphrasesUpdated(const QModelIndex& qidx);
 
+signals:
+  void phraseTitleChanged(const QModelIndex&);
+
 protected:
   smtk::model::DescriptivePhrasePtr m_root;
   bool m_deleteOnRemoval; // remove UUIDs from mesh when they are removed from the list?

--- a/smtk/extension/qt/qtModelView.h
+++ b/smtk/extension/qt/qtModelView.h
@@ -71,6 +71,7 @@ public slots:
   void operatorInvoked();
   void toggleEntityVisibility( const QModelIndex& );
   void changeEntityColor( const QModelIndex&);
+  void changeEntityName( const QModelIndex& idx);
   void onEntitiesExpunged(
     const smtk::model::EntityRefs& expungedEnts);
   bool requestOperation(


### PR DESCRIPTION
When user edits text in the model tree view to change entity names,
the UI changes need to be linked with SetOperator to change entity names
on the server. Otherwise the changes will be lost once entites are
refeched from the server after certain operations. The same logic applies
to color and visibility changes.