### PR TITLE
Updated operators in discrete session to handle multiple entities.

### DIFF
--- a/smtk/bridge/discrete/operation/vtkSplitOperator.cxx
+++ b/smtk/bridge/discrete/operation/vtkSplitOperator.cxx
@@ -67,6 +67,7 @@ void vtkSplitOperator::Operate(vtkDiscreteModelWrapper* ModelWrapper)
   newFaces->Reset();
   newFaces->SetNumberOfComponents(1);
   newFaces->SetNumberOfTuples(0);
+  this->FaceSplitInfo.clear();
 
   this->OperateSucceeded =
     Face->Split(this->GetFeatureAngle(), this->FaceSplitInfo);

--- a/smtk/bridge/discrete/operators/EntityGroupOperator.h
+++ b/smtk/bridge/discrete/operators/EntityGroupOperator.h
@@ -45,7 +45,7 @@ protected:
   Session* discreteSession() const;
   int fetchCMBCellId(const std::string& parameterName) const;
   int fetchCMBCellId(
-    smtk::attribute::ModelEntityItemPtr entItem, int idx ) const;
+    const smtk::attribute::ModelEntityItemPtr&, int idx ) const;
 
   vtkNew<vtkModelEntityGroupOperator> m_op;
 };

--- a/smtk/bridge/discrete/operators/EntityGroupOperator.sbt
+++ b/smtk/bridge/discrete/operators/EntityGroupOperator.sbt
@@ -11,15 +11,20 @@
         <String Name="Operation" Label="Operation" Version="0" AdvanceLevel="0" NumberOfRequiredValues="1">
           <BriefDescription>operation for the operator</BriefDescription>
           <ChildrenDefinitions>
-            <ModelEntity Name="cell group" NumberOfRequiredValues="1">
+            <ModelEntity Name="modify cell group" NumberOfRequiredValues="1">
               <!-- There seems to be a bug in checking the validity of the entity being set 
               when the membership is group. Skip for now 
               <MembershipMask>group</MembershipMask>  -->
             </ModelEntity>
-            <ModelEntity Name="cell to add" NumberOfRequiredValues="1" Extensible="1">
+            <ModelEntity Name="remove cell group" Extensible="1">
+              <!-- There seems to be a bug in checking the validity of the entity being set 
+              when the membership is group. Skip for now 
+              <MembershipMask>group</MembershipMask>  -->
+            </ModelEntity>
+            <ModelEntity Name="cell to add" Extensible="1">
               <MembershipMask>face|edge|vertex</MembershipMask>
             </ModelEntity>
-            <ModelEntity Name="cell to remove" NumberOfRequiredValues="1" Extensible="1">
+            <ModelEntity Name="cell to remove" Extensible="1">
               <MembershipMask>face|edge|vertex</MembershipMask>
             </ModelEntity>
             <Int Name="entity type" Label="Entity Type:" Version="0" NumberOfRequiredValues="1">
@@ -46,13 +51,13 @@
             <Structure>
               <Value Enum="Remove Group">Remove</Value>
               <Items>
-                <Item>cell group</Item>
+                <Item>remove cell group</Item>
               </Items>
             </Structure>
             <Structure>
               <Value Enum="Modify Group">Modify</Value>
               <Items>
-                <Item>cell group</Item>
+                <Item>modify cell group</Item>
                 <Item>cell to add</Item>
                 <Item>cell to remove</Item>
               </Items>

--- a/smtk/bridge/discrete/operators/MergeOperator.h
+++ b/smtk/bridge/discrete/operators/MergeOperator.h
@@ -46,6 +46,8 @@ protected:
   virtual smtk::model::OperatorResult operateInternal();
   Session* discreteSession() const;
   int fetchCMBCellId(const std::string& parameterName) const;
+  int fetchCMBCellId(
+    const smtk::attribute::ModelEntityItemPtr& entItem, int idx ) const;
 
   vtkNew<vtkMergeOperator> m_op;
 };

--- a/smtk/bridge/discrete/operators/MergeOperator.sbt
+++ b/smtk/bridge/discrete/operators/MergeOperator.sbt
@@ -8,7 +8,7 @@
         <ModelEntity Name="model" NumberOfRequiredValues="1">
            <MembershipMask>model</MembershipMask>
         </ModelEntity>
-        <ModelEntity Name="source cell" NumberOfRequiredValues="1" Extensible="1">
+        <ModelEntity Name="source cell" Extensible="1">
           <MembershipMask>face|edge</MembershipMask>
         </ModelEntity>
 

--- a/smtk/bridge/discrete/operators/SplitFaceOperator.h
+++ b/smtk/bridge/discrete/operators/SplitFaceOperator.h
@@ -37,6 +37,8 @@ protected:
   virtual smtk::model::OperatorResult operateInternal();
   Session* discreteSession() const;
   int fetchCMBFaceId() const;
+  int fetchCMBCellId(
+    const smtk::attribute::ModelEntityItemPtr& entItem, int idx ) const;
 
   vtkNew<vtkSplitOperator> m_op;
 };

--- a/smtk/bridge/discrete/operators/SplitFaceOperator.sbt
+++ b/smtk/bridge/discrete/operators/SplitFaceOperator.sbt
@@ -8,7 +8,7 @@
         <ModelEntity Name="model" NumberOfRequiredValues="1">
           <MembershipMask>model</MembershipMask>
         </ModelEntity>
-        <ModelEntity Name="face to split" NumberOfRequiredValues="1" Extensible="1">
+        <ModelEntity Name="face to split" Extensible="1">
         <MembershipMask>face</MembershipMask>
         </ModelEntity>
         <Double Name="feature angle" NumberOfRequiredValues="1">

--- a/smtk/extension/qt/qtModelEntityItem.cxx
+++ b/smtk/extension/qt/qtModelEntityItem.cxx
@@ -107,7 +107,7 @@ void qtModelEntityItem::addEntityAssociationWidget()
   const ModelEntityItemDefinition* def =
     static_cast<const ModelEntityItemDefinition *>(item->definition().get());
   int n = static_cast<int>(item->numberOfValues());
-  if (!n)
+  if (!n && !def->isExtensible())
     {
     return;
     }

--- a/smtk/extension/qt/qtModelView.h
+++ b/smtk/extension/qt/qtModelView.h
@@ -65,8 +65,6 @@ public:
 public slots:
   void selectEntityItems(const smtk::common::UUIDs& selEntityRefs,
     bool blocksignal = false);
-  virtual void removeFromGroup(const QModelIndex& qidx);
-  virtual void removeSelected();
   void showContextMenu(const QPoint &p);
   void operatorInvoked();
   void toggleEntityVisibility( const QModelIndex& );
@@ -91,13 +89,34 @@ signals:
   void meshSelectionItemCreated(
                  smtk::attribute::qtMeshSelectionItem*,
                  const std::string& opName, const smtk::common::UUID& uuid);
+
+protected slots:
+  virtual void removeEntityGroup(const smtk::model::Model& modelEnt,
+                                 const smtk::model::SessionRef& session,
+                               const QList<smtk::model::Group>& groups);
+  virtual void removeFromEntityGroup(const smtk::model::Model& modelEnt,
+                               const smtk::model::SessionRef& session,
+                               const smtk::model::Group& grp,
+                               const smtk::model::EntityRefs& entities);
+
 protected:
+  // If 'Delete' button is pressed, invoke proper operation if possible.
+  // For example, in discrete session, user can delete a group,
+  // or remove members from a group by selecting them then press delete key.
+  virtual void keyPressEvent(QKeyEvent*);
 
   template<typename T>
   T owningEntityAs(const QModelIndex &idx) const;
+  template<typename T>
+  T owningEntityAs(const DescriptivePhrasePtr &dp) const;
 
+  bool hasSessionOp(const smtk::model::SessionRef& brSession,
+    const std::string& opname);
+  bool hasSessionOp(const QModelIndex& idx,
+    const std::string& opname);
   OperatorPtr getOp(const QModelIndex& idx, const std::string& opname);
-  OperatorPtr getOp(smtk::model::SessionPtr session, const std::string& opname);
+  OperatorPtr getOp(const smtk::model::SessionPtr& brSession, const std::string& opname);
+
   // Description:
   // Support for customized drag-n-drop events
   virtual Qt::DropActions supportedDropActions() const;
@@ -121,6 +140,7 @@ protected:
     bool exactMatch = false);
 
   smtk::model::Group groupParentOfIndex(const QModelIndex& qidx);
+  smtk::model::Group groupParent(const DescriptivePhrasePtr& phrase);
   bool initOperator(smtk::model::OperatorPtr op);
   void initOperatorsDock(
     const std::string& opName, smtk::model::SessionPtr session);


### PR DESCRIPTION
Now in discrete session, the merge and split operators will handle multiple faces on one "Operate". The EntityGroupOp will handle adding and removing multiple entities at one "Operate". The removing is triggered by Delete key on selection, and currently only Group in discrete session will process the "Delete" or "BackSpace" key press.