### PR TITLE
Added write operator in discrete session.

### DIFF
--- a/smtk/bridge/discrete/CMakeLists.txt
+++ b/smtk/bridge/discrete/CMakeLists.txt
@@ -121,6 +121,7 @@ set(discreteSessionSrcs
   operators/ReadOperator.cxx
   operators/SplitFaceOperator.cxx
   operators/GrowOperator.cxx
+  operators/WriteOperator.cxx
 )
 
 set(discreteSessionHeaders
@@ -132,6 +133,7 @@ set(discreteSessionHeaders
   operators/ReadOperator.h
   operators/SplitFaceOperator.h
   operators/GrowOperator.h
+  operators/WriteOperator.h
 )
 
 # Normally this would be machine-generated from Session.json
@@ -150,6 +152,7 @@ smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/SplitFaceOperator.sbt" 
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/ImportOperator.sbt" unitOperatorXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/EntityGroupOperator.sbt" unitOperatorXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/GrowOperator.sbt" unitOperatorXML)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/WriteOperator.sbt" unitOperatorXML)
 
 add_library(smtkDiscreteSession ${_module_src} ${discreteSessionSrcs})
 

--- a/smtk/bridge/discrete/Session.cxx
+++ b/smtk/bridge/discrete/Session.cxx
@@ -1317,3 +1317,4 @@ smtkComponentInitMacro(smtk_discrete_create_edges_operator);
 smtkComponentInitMacro(smtk_discrete_import_operator);
 smtkComponentInitMacro(smtk_discrete_entity_group_operator);
 smtkComponentInitMacro(smtk_discrete_grow_operator);
+smtkComponentInitMacro(smtk_discrete_write_operator);

--- a/smtk/bridge/discrete/Session.h
+++ b/smtk/bridge/discrete/Session.h
@@ -120,6 +120,7 @@ protected:
   friend class EntityGroupOperator;
   friend class GrowOperator;
   friend class CreateEdgesOperator;
+  friend class WriteOperator;
 
   Session();
 

--- a/smtk/bridge/discrete/operators/WriteOperator.cxx
+++ b/smtk/bridge/discrete/operators/WriteOperator.cxx
@@ -1,0 +1,116 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+
+#include "WriteOperator.h"
+
+#include "smtk/bridge/discrete/Session.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/FileItem.h"
+#include "smtk/attribute/StringItem.h"
+#include "smtk/attribute/ModelEntityItem.h"
+
+#include "smtk/model/Operator.h"
+#include "smtk/model/Model.h"
+#include "smtk/model/Manager.h"
+
+#include "vtkDiscreteModelWrapper.h"
+#include "vtkModelItem.h"
+#include "vtkModel.h"
+#include <vtksys/SystemTools.hxx>
+
+#include "WriteOperator_xml.h"
+
+// #define SMTK_DISCRETE_SESSION_DEBUG
+
+#if defined(SMTK_DISCRETE_SESSION_DEBUG)
+#include "smtk/io/ExportJSON.h"
+#include "cJSON.h"
+#endif
+
+using namespace smtk::model;
+
+namespace smtk {
+  namespace bridge {
+
+  namespace discrete {
+
+WriteOperator::WriteOperator()
+{
+  this->m_currentversion = 5;
+}
+
+bool WriteOperator::ableToOperate()
+{
+  smtk::model::Model model;
+  bool able2Op =
+    this->ensureSpecification() &&
+    // The SMTK model must be valid
+    (model = this->specification()->findModelEntity("model")
+      ->value().as<smtk::model::Model>()).isValid() &&
+    // The CMB model must exist
+    this->discreteSession()->findModelEntity(model.entity());
+  if(!able2Op)
+    return false;
+
+  std::string filename = this->specification()->findFile("filename")->value();
+  return !filename.empty();
+}
+
+OperatorResult WriteOperator::operateInternal()
+{
+  std::string fname = this->specification()->findFile("filename")->value();
+  if (fname.empty())
+    return this->createResult(OPERATION_FAILED);
+
+  this->m_op->SetFileName(fname.c_str());
+  Session* opsession = this->discreteSession();
+
+  // ableToOperate should have verified that the model exists
+  smtk::model::Model model = this->specification()->
+    findModelEntity("model")->value().as<smtk::model::Model>();
+  vtkDiscreteModelWrapper* modelWrapper =
+    opsession->findModelEntity(model.entity());
+
+  // write the file out.
+  this->m_op->SetVersion(this->m_currentversion);
+  this->m_op->Operate(modelWrapper);
+
+  if (!this->m_op->GetOperateSucceeded())
+    {
+    std::cerr << "Could not write file \"" << fname << "\".\n";
+    return this->createResult(OPERATION_FAILED);
+    }
+
+  OperatorResult result = this->createResult(OPERATION_SUCCEEDED);
+  smtk::attribute::ModelEntityItemPtr models =
+    result->findModelEntity("entities");
+  models->setNumberOfValues(1);
+  models->setValue(0, model);
+
+  return result;
+}
+
+Session* WriteOperator::discreteSession() const
+{
+  return dynamic_cast<Session*>(this->session());
+}
+
+    } // namespace discrete
+  } // namespace bridge
+
+} // namespace smtk
+
+smtkImplementsModelOperator(
+  smtk::bridge::discrete::WriteOperator,
+  discrete_write,
+  "write",
+  WriteOperator_xml,
+  smtk::bridge::discrete::Session);

--- a/smtk/bridge/discrete/operators/WriteOperator.h
+++ b/smtk/bridge/discrete/operators/WriteOperator.h
@@ -1,0 +1,52 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+
+#ifndef __smtk_session_discrete_WriteOperator_h
+#define __smtk_session_discrete_WriteOperator_h
+
+#include "smtk/bridge/discrete/discreteSessionExports.h"
+#include "smtk/model/Operator.h"
+#include "vtkCMBModelWriterBase.h"
+#include "vtkNew.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace discrete {
+
+class Session;
+
+/**\brief Write a CMB discrete model file.
+  *
+  * This requires the file to be of type/extension "cmb".
+  */
+class SMTKDISCRETESESSION_EXPORT WriteOperator : public smtk::model::Operator
+{
+public:
+  smtkTypeMacro(WriteOperator);
+  smtkCreateMacro(WriteOperator);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+  virtual bool ableToOperate();
+
+protected:
+  WriteOperator();
+  virtual smtk::model::OperatorResult operateInternal();
+  Session* discreteSession() const;
+
+  vtkNew<vtkCMBModelWriterBase> m_op;
+  int m_currentversion;
+};
+
+    } // namespace discrete
+  } // namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_discrete_WriteOperator_h

--- a/smtk/bridge/discrete/operators/WriteOperator.sbt
+++ b/smtk/bridge/discrete/operators/WriteOperator.sbt
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the CMB Discrete Model "Read" Operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="write" BaseType="operator">
+      <ItemDefinitions>
+        <ModelEntity Name="model" NumberOfRequiredValues="1">
+          <MembershipMask>model</MembershipMask>
+        </ModelEntity>
+        <File Name="filename" NumberOfRequiredValues="1"
+          ShouldExist="false"
+          FileFilters="Conceptual Model Builder (*.cmb)">
+        </File>
+      </ItemDefinitions>
+    </AttDef>
+    <!-- Result -->
+    <AttDef Type="result(write)" BaseType="result"/>
+  </Definitions>
+</SMTK_AttributeSystem>


### PR DESCRIPTION
This operator will write out a cmb file with a given discrete model. Currently
it only write out one model at a time, but it could potentially write out multiple
cmb files if given multiple models and a base file name or a name for each model.