### PR TITLE
Targeted update in model tree view after model operations

### DIFF
--- a/smtk/PublicPointerDefs.h
+++ b/smtk/PublicPointerDefs.h
@@ -195,6 +195,11 @@ namespace smtk
     typedef smtk::weak_ptr< smtk::model::Operator >                WeakOperatorPtr;
     typedef std::set< smtk::model::OperatorPtr >                   Operators;
     typedef smtk::shared_ptr< smtk::model::RemoteOperator >        RemoteOperatorPtr;
+#ifndef SHIBOKEN_SKIP
+    typedef smtk::model::OperatorPtr                             (*OperatorConstructor)();
+    typedef std::pair<std::string,OperatorConstructor>             StaticOperatorInfo;
+    typedef std::map<std::string,StaticOperatorInfo>               OperatorConstructors;
+#endif
     typedef smtk::shared_ptr< smtk::model::Entity >                EntityPtr;
     typedef smtk::weak_ptr< smtk::model::Entity >                  WeakEntityPtr;
     typedef smtk::shared_ptr< smtk::model::Arrangement >           ArrangementPtr;

--- a/smtk/attribute/ModelEntityItem.h
+++ b/smtk/attribute/ModelEntityItem.h
@@ -71,6 +71,9 @@ public:
           break;
           }
       }
+    // Enable or disable the item if it is optional.
+    if (ok)
+      this->setIsEnabled(num > 0 ? true : false);
     return ok;
     }
   bool appendValue(const smtk::model::EntityRef& val);

--- a/smtk/bridge/cgm/operators/BooleanIntersection.cxx
+++ b/smtk/bridge/cgm/operators/BooleanIntersection.cxx
@@ -141,7 +141,7 @@ smtk::model::OperatorResult BooleanIntersection::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(cgmBodiesOut, result);
+  this->addEntitiesToResult(cgmBodiesOut, result, MODIFIED);
   result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
 
   return result;

--- a/smtk/bridge/cgm/operators/BooleanIntersection.sbt
+++ b/smtk/bridge/cgm/operators/BooleanIntersection.sbt
@@ -47,7 +47,7 @@
     <!-- Result -->
     <AttDef Type="result(intersection)" BaseType="result">
       <ItemDefinitions>
-        <!-- The united body (or bodies) is return in the base result's "entities" item. -->
+        <!-- The united body (or bodies) is return in the base result's "modified" item. -->
       </ItemDefinitions>
     </AttDef>
   </Definitions>

--- a/smtk/bridge/cgm/operators/BooleanSubtraction.cxx
+++ b/smtk/bridge/cgm/operators/BooleanSubtraction.cxx
@@ -88,7 +88,7 @@ smtk::model::OperatorResult BooleanSubtraction::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(cgmBodiesOut, result);
+  this->addEntitiesToResult(cgmBodiesOut, result, MODIFIED);
   result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
 
   return result;

--- a/smtk/bridge/cgm/operators/BooleanSubtraction.sbt
+++ b/smtk/bridge/cgm/operators/BooleanSubtraction.sbt
@@ -60,7 +60,7 @@
     <!-- Result -->
     <AttDef Type="result(subtraction)" BaseType="result">
       <ItemDefinitions>
-        <!-- The united body (or bodies) is return in the base result's "entities" item. -->
+        <!-- The united body (or bodies) is return in the base result's "modified" item. -->
       </ItemDefinitions>
     </AttDef>
   </Definitions>

--- a/smtk/bridge/cgm/operators/BooleanUnion.cxx
+++ b/smtk/bridge/cgm/operators/BooleanUnion.cxx
@@ -79,7 +79,7 @@ smtk::model::OperatorResult BooleanUnion::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(cgmBodiesOut, result);
+  this->addEntitiesToResult(cgmBodiesOut, result, MODIFIED);
   result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
 
   return result;

--- a/smtk/bridge/cgm/operators/BooleanUnion.sbt
+++ b/smtk/bridge/cgm/operators/BooleanUnion.sbt
@@ -16,7 +16,7 @@
     <!-- Result -->
     <AttDef Type="result(union)" BaseType="result">
       <ItemDefinitions>
-        <!-- The united body (or bodies) is return in the base result's "entities" item. -->
+        <!-- The united body (or bodies) is return in the base result's "modified" item. -->
       </ItemDefinitions>
     </AttDef>
   </Definitions>

--- a/smtk/bridge/cgm/operators/Copy.cxx
+++ b/smtk/bridge/cgm/operators/Copy.cxx
@@ -104,7 +104,7 @@ smtk::model::OperatorResult Copy::operateInternal()
 
   DLIList<RefEntity*> cgmEntitiesOut;
   cgmEntitiesOut.push(cgmOut);
-  this->addEntitiesToResult(cgmEntitiesOut, result);
+  this->addEntitiesToResult(cgmEntitiesOut, result, MODIFIED);
   // Nothing to expunge.
 
   return result;

--- a/smtk/bridge/cgm/operators/Copy.sbt
+++ b/smtk/bridge/cgm/operators/Copy.sbt
@@ -21,7 +21,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(copy)" BaseType="result">
-      <!-- The translated entities are stored in the base result's "entities" item. -->
+      <!-- The translated entities are stored in the base result's "created" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/operators/CreateBody.cxx
+++ b/smtk/bridge/cgm/operators/CreateBody.cxx
@@ -133,7 +133,7 @@ smtk::model::OperatorResult CreateBody::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(cgmBodies, result);
+  this->addEntitiesToResult(cgmBodies, result, CREATED);
   result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
 
   return result;

--- a/smtk/bridge/cgm/operators/CreateBrick.cxx
+++ b/smtk/bridge/cgm/operators/CreateBrick.cxx
@@ -115,7 +115,7 @@ smtk::model::OperatorResult CreateBrick::operateInternal()
 
   DLIList<Body*> cgmBodiesOut;
   cgmBodiesOut.push(cgmBody);
-  this->addEntitiesToResult(cgmBodiesOut, result);
+  this->addEntitiesToResult(cgmBodiesOut, result, CREATED);
   // Nothing to expunge.
 
   return result;

--- a/smtk/bridge/cgm/operators/CreateBrick.sbt
+++ b/smtk/bridge/cgm/operators/CreateBrick.sbt
@@ -82,7 +82,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(create brick)" BaseType="result">
-      <!-- The brick created is stored in the base result's "entities" item. -->
+      <!-- The brick created is stored in the base result's "created" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/operators/CreateCylinder.cxx
+++ b/smtk/bridge/cgm/operators/CreateCylinder.cxx
@@ -78,7 +78,7 @@ smtk::model::OperatorResult CreateCylinder::operateInternal()
 
   DLIList<Body*> cgmBodiesOut;
   cgmBodiesOut.push(cgmBody);
-  this->addEntitiesToResult(cgmBodiesOut, result);
+  this->addEntitiesToResult(cgmBodiesOut, result, CREATED);
   // Nothing to expunge.
 
   return result;

--- a/smtk/bridge/cgm/operators/CreateCylinder.sbt
+++ b/smtk/bridge/cgm/operators/CreateCylinder.sbt
@@ -22,7 +22,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(create cylinder)" BaseType="result">
-      <!-- The cylinder created is stored in the base result's "entities" item. -->
+      <!-- The cylinder created is stored in the base result's "created" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/operators/CreateEdge.cxx
+++ b/smtk/bridge/cgm/operators/CreateEdge.cxx
@@ -109,7 +109,7 @@ smtk::model::OperatorResult CreateEdge::operateInternal()
 
   DLIList<RefEdge*> cgmEdgesOut;
   cgmEdgesOut.push(cgmEdge);
-  this->addEntitiesToResult(cgmEdgesOut, result);
+  this->addEntitiesToResult(cgmEdgesOut, result, CREATED);
   // Nothing to expunge.
 
   return result;

--- a/smtk/bridge/cgm/operators/CreateFace.cxx
+++ b/smtk/bridge/cgm/operators/CreateFace.cxx
@@ -90,7 +90,7 @@ smtk::model::OperatorResult CreateFace::operateInternal()
 
   DLIList<RefFace*> cgmFacesOut;
   cgmFacesOut.push(cgmFace);
-  this->addEntitiesToResult(cgmFacesOut, result);
+  this->addEntitiesToResult(cgmFacesOut, result, CREATED);
   result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
 
   return result;

--- a/smtk/bridge/cgm/operators/CreatePrism.cxx
+++ b/smtk/bridge/cgm/operators/CreatePrism.cxx
@@ -78,7 +78,7 @@ smtk::model::OperatorResult CreatePrism::operateInternal()
 
   DLIList<Body*> cgmEntitiesOut;
   cgmEntitiesOut.push(cgmBody);
-  this->addEntitiesToResult(cgmEntitiesOut, result);
+  this->addEntitiesToResult(cgmEntitiesOut, result, CREATED);
   // Nothing to expunge.
 
   return result;

--- a/smtk/bridge/cgm/operators/CreatePrism.sbt
+++ b/smtk/bridge/cgm/operators/CreatePrism.sbt
@@ -22,7 +22,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(create prism)" BaseType="result">
-      <!-- The prism created is stored in the base result's "entities" item. -->
+      <!-- The prism created is stored in the base result's "created" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/operators/CreateSphere.cxx
+++ b/smtk/bridge/cgm/operators/CreateSphere.cxx
@@ -85,7 +85,7 @@ smtk::model::OperatorResult CreateSphere::operateInternal()
 
   DLIList<Body*> cgmEntitiesOut;
   cgmEntitiesOut.push(cgmBody);
-  this->addEntitiesToResult(cgmEntitiesOut, result);
+  this->addEntitiesToResult(cgmEntitiesOut, result, CREATED);
   // Nothing to expunge.
 
   return result;

--- a/smtk/bridge/cgm/operators/CreateSphere.sbt
+++ b/smtk/bridge/cgm/operators/CreateSphere.sbt
@@ -18,7 +18,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(create sphere)" BaseType="result">
-      <!-- The sphere created is stored in the base result's "entities" item. -->
+      <!-- The sphere created is stored in the base result's "created" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/operators/CreateVertex.cxx
+++ b/smtk/bridge/cgm/operators/CreateVertex.cxx
@@ -68,7 +68,7 @@ smtk::model::OperatorResult CreateVertex::operateInternal()
 
   DLIList<RefVertex*> cgmEntitiesOut;
   cgmEntitiesOut.push(cgmVert);
-  this->addEntitiesToResult(cgmEntitiesOut, result);
+  this->addEntitiesToResult(cgmEntitiesOut, result, CREATED);
   // Nothing to expunge.
 
   return result;

--- a/smtk/bridge/cgm/operators/Read.cxx
+++ b/smtk/bridge/cgm/operators/Read.cxx
@@ -114,11 +114,11 @@ smtk::model::OperatorResult Read::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(imported, result);
+  this->addEntitiesToResult(imported, result, CREATED);
 
   // Set name and url property on each top-level output
   smtk::attribute::ModelEntityItem::Ptr resultModels =
-    result->findModelEntity("entities");
+    result->findModelEntity("created");
   std::string modelName = filename.substr(0, filename.find_last_of("."));
   std::size_t prefix = modelName.find_last_of("/");
   if (prefix != std::string::npos)

--- a/smtk/bridge/cgm/operators/Reflect.cxx
+++ b/smtk/bridge/cgm/operators/Reflect.cxx
@@ -86,7 +86,7 @@ smtk::model::OperatorResult Reflect::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(cgmEntitiesOut, result);
+  this->addEntitiesToResult(cgmEntitiesOut, result, MODIFIED);
   // Nothing expunged.
 
   return result;

--- a/smtk/bridge/cgm/operators/Reflect.sbt
+++ b/smtk/bridge/cgm/operators/Reflect.sbt
@@ -35,7 +35,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(reflect)" BaseType="result">
-      <!-- The translated body (or bodies) are stored in the base result's "entities" item. -->
+      <!-- The reflected body (or bodies) are stored in the base result's "modified" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/operators/Rotate.cxx
+++ b/smtk/bridge/cgm/operators/Rotate.cxx
@@ -96,7 +96,7 @@ smtk::model::OperatorResult Rotate::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(cgmEntitiesOut, result);
+  this->addEntitiesToResult(cgmEntitiesOut, result, MODIFIED);
   // Nothing expunged.
 
   return result;

--- a/smtk/bridge/cgm/operators/Rotate.sbt
+++ b/smtk/bridge/cgm/operators/Rotate.sbt
@@ -23,7 +23,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(rotate)" BaseType="result">
-      <!-- The rotated body (or bodies) are stored in the base result's "entities" item. -->
+      <!-- The rotated body (or bodies) are stored in the base result's "modified" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/operators/Scale.cxx
+++ b/smtk/bridge/cgm/operators/Scale.cxx
@@ -98,7 +98,7 @@ smtk::model::OperatorResult Scale::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(cgmEntitiesOut, result);
+  this->addEntitiesToResult(cgmEntitiesOut, result, MODIFIED);
   // Nothing expunged.
 
   return result;

--- a/smtk/bridge/cgm/operators/Scale.sbt
+++ b/smtk/bridge/cgm/operators/Scale.sbt
@@ -62,7 +62,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(scale)" BaseType="result">
-      <!-- The translated body (or bodies) are stored in the base result's "entities" item. -->
+      <!-- The translated body (or bodies) are stored in the base result's "modified" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/operators/Sweep.cxx
+++ b/smtk/bridge/cgm/operators/Sweep.cxx
@@ -206,7 +206,7 @@ smtk::model::OperatorResult Sweep::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(cgmResults, result);
+  this->addEntitiesToResult(cgmResults, result, CREATED);
   result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
 
   return result;

--- a/smtk/bridge/cgm/operators/Sweep.sbt
+++ b/smtk/bridge/cgm/operators/Sweep.sbt
@@ -179,7 +179,7 @@
     <!-- Result -->
     <AttDef Type="result(sweep)" BaseType="result">
       <ItemDefinitions>
-        <!-- The swept body (or bodies) is returned in the base result's "entities" item. -->
+        <!-- The swept body (or bodies) is returned in the base result's "created" item. -->
       </ItemDefinitions>
     </AttDef>
   </Definitions>

--- a/smtk/bridge/cgm/operators/Translate.cxx
+++ b/smtk/bridge/cgm/operators/Translate.cxx
@@ -85,7 +85,7 @@ smtk::model::OperatorResult Translate::operateInternal()
   smtk::model::OperatorResult result = this->createResult(
     smtk::model::OPERATION_SUCCEEDED);
 
-  this->addEntitiesToResult(cgmEntitiesOut, result);
+  this->addEntitiesToResult(cgmEntitiesOut, result, MODIFIED);
   // Nothing expunged.
 
   return result;

--- a/smtk/bridge/cgm/operators/Translate.sbt
+++ b/smtk/bridge/cgm/operators/Translate.sbt
@@ -15,7 +15,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(translate)" BaseType="result">
-      <!-- The translated body (or bodies) are stored in the base result's "entities" item. -->
+      <!-- The translated body (or bodies) are stored in the base result's "modified" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/cgm/testing/cxx/test-operators.cxx
+++ b/smtk/bridge/cgm/testing/cxx/test-operators.cxx
@@ -166,7 +166,7 @@ int main (int argc, char* argv[])
     std::cerr << "Sphere Fail\n";
     return 1;
     }
-  Model sphere = result->findModelEntity("entities")->value();
+  Model sphere = result->findModelEntity("created")->value();
 
   op = brg->op("create prism");
   op->findDouble("height")->setValue(opts.prismHeight());
@@ -179,7 +179,7 @@ int main (int argc, char* argv[])
     std::cerr << "Prism Fail\n";
     return 1;
     }
-  Model prism = result->findModelEntity("entities")->value();
+  Model prism = result->findModelEntity("created")->value();
 
   Models operands;
   operands.push_back(sphere);
@@ -202,7 +202,7 @@ int main (int argc, char* argv[])
     return 1;
     }
 
-  smtk::attribute::ModelEntityItem::Ptr bodies = result->findModelEntity("entities");
+  smtk::attribute::ModelEntityItem::Ptr bodies = result->findModelEntity("modified");
   std::cout << "Created " << bodies->value().flagSummary() << "\n";
   std::cout << "   with " << bodies->value().as<Model>().cells().size() << " cells\n";
   //std::ofstream json("/tmp/sphere.json");

--- a/smtk/bridge/cgm/testing/python/cgmCreateBrick.py
+++ b/smtk/bridge/cgm/testing/python/cgmCreateBrick.py
@@ -20,7 +20,7 @@ ov.setDiscreteIndex(0)
 ctr = cb.findAsDouble('center')
 cb.findAsDouble('width').setValue(0.5)
 res = cb.operate()
-brick = res.findModelEntity('entities').value(0)
+brick = res.findModelEntity('created').value(0)
 
 def sumCond(itm, idx):
   print itm.name(), '=', idx
@@ -45,20 +45,20 @@ ext = cb.findAsDouble('extension')
 setAxis(ext,[2, 3, .2])
 sumCond(ov,1)
 r2 = cb.operate()
-b2 = r2.findModelEntity('entities').value(0)
+b2 = r2.findModelEntity('created').value(0)
 
 uop = sref.op('union')
 uop.associateEntity(brick)
 uop.associateEntity(b2)
 r3 = uop.operate()
-ubod = r3.findModelEntity('entities').value(0)
+ubod = r3.findModelEntity('modified').value(0)
 
 top = sref.op('translate')
 top.associateEntity(ubod)
 off = top.findAsDouble('offset')
 setAxis(off, [8., 3., 7.])
 r4 = top.operate()
-b4 = r4.findModelEntity('entities').value(0)
+b4 = r4.findModelEntity('modified').value(0)
 
 json = smtk.io.ExportJSON.fromModelManager(mgr)
 sphFile = open('/tmp/brickly2.json', 'w')

--- a/smtk/bridge/cgm/testing/python/cgmSolidModeling.py
+++ b/smtk/bridge/cgm/testing/python/cgmSolidModeling.py
@@ -43,13 +43,13 @@ cs1.findAsDouble('center').setValue(1, 0.2)
 cs1.findAsDouble('center').setValue(2, 0.2)
 
 res = cs1.operate()
-sph = res.findModelEntity('entities').value(0)
+sph = res.findModelEntity('created').value(0)
 
 cs2 = sref.op('create sphere')
 cs2.findAsDouble('radius').setValue(0.5)
 cs2.findAsDouble('center').setValue(0, 0.9)
 res2 = cs2.operate()
-sph2 = res2.findModelEntity('entities').value(0)
+sph2 = res2.findModelEntity('created').value(0)
 
 print 'Operators that can associate with ' + sph2.flagSummary(1) + ' include\n  %s' % \
   '\n  '.join(sref.operatorsForAssociation(sph2.entityFlags()))
@@ -61,7 +61,7 @@ res = u1.operate()
 # You will see:
 #    Updated volume(s): 2
 #    Destroyed volume(s): 1
-su = res.findModelEntity('entities').value(0)
+su = res.findModelEntity('modified').value(0)
 # Note that su has same UUID as sph2
 
 

--- a/smtk/bridge/cgm/testing/python/cgmTransforms.py
+++ b/smtk/bridge/cgm/testing/python/cgmTransforms.py
@@ -37,10 +37,10 @@ ov = cb.findAsInt('construction method')
 ov.setDiscreteIndex(0)
 cb.findAsDouble('width').setValue(0.5)
 r1 = cb.operate()
-brick1 = r1.findModelEntity('entities').value(0)
+brick1 = r1.findModelEntity('created').value(0)
 
 r2 = cb.operate()
-brick2 = r2.findModelEntity('entities').value(0)
+brick2 = r2.findModelEntity('created').value(0)
 
 #json = smtk.io.ExportJSON.fromModelManager(mgr)
 #jsonFile = open('/tmp/skirb1.json', 'w')
@@ -52,7 +52,7 @@ tr.associateEntity(brick2)
 off = tr.findAsDouble('offset')
 setVector(off, [.5, 0., 0.])
 r3 = tr.operate()
-brick3 = r3.findModelEntity('entities').value(0)
+brick3 = r3.findModelEntity('modified').value(0)
 
 
 if not brick3 or brick3.entity() != brick2.entity():
@@ -68,7 +68,7 @@ setVector(ctr, [.5, 0., 0.])
 setVector(axs, [.3333, .6667, 0.6667])
 ang.setValue(0, 60.0)
 r4 = ro.operate()
-brick4 = r4.findModelEntity('entities').value(0)
+brick4 = r4.findModelEntity('modified').value(0)
 
 
 if not brick4 or brick4.entity() != brick3.entity():
@@ -79,14 +79,14 @@ un = sref.op('union')
 un.associateEntity(brick1)
 un.associateEntity(brick4)
 r5 = un.operate()
-brick5 = r5.findModelEntity('entities').value(0)
+brick5 = r5.findModelEntity('modified').value(0)
 
 sc = sref.op('scale')
 sc.associateEntity(brick5)
 sc.findAsInt('scale factor type').setDiscreteIndex(0)
 sc.findAsDouble('scale factor').setValue(3.0)
 r6 = sc.operate()
-brick6 = r6.findModelEntity('entities').value(0)
+brick6 = r6.findModelEntity('modified').value(0)
 
 #json = smtk.io.ExportJSON.fromModelManager(mgr)
 #jsonFile = open('/tmp/skirb4.json', 'w')

--- a/smtk/bridge/discrete/operators/CreateEdgesOperator.cxx
+++ b/smtk/bridge/discrete/operators/CreateEdgesOperator.cxx
@@ -92,10 +92,7 @@ OperatorResult CreateEdgesOperator::operateInternal()
   //       use the session to translate them and store
   //       them in the OperatorResult (well, a subclass).
 
-  smtk::attribute::ModelEntityItemPtr models =
-    result->findModelEntity("entities");
-  models->setNumberOfValues(1);
-  models->setValue(0, this->specification()->findModelEntity("model")->value());
+  this->addEntityToResult(result, inModel, MODIFIED);
 
   return result;
 }

--- a/smtk/bridge/discrete/operators/EntityGroupOperator.cxx
+++ b/smtk/bridge/discrete/operators/EntityGroupOperator.cxx
@@ -207,14 +207,16 @@ OperatorResult EntityGroupOperator::operateInternal()
         result->findModelEntity("entities");
       entities->setNumberOfValues(1);
       entities->setValue(0, bgroup);
-
-    // Adding the new group to the "new entities" item, as a convenient method
-    // to get newly created group from result. This group is also listed in the
-    // "entities" item.
-      smtk::attribute::ModelEntityItem::Ptr newEntities =
-        result->findModelEntity("new entities");
-      newEntities->setNumberOfValues(1);
-      newEntities->setValue(0, bgroup);
+     if(optype == "Create")
+       {
+       // Adding the new group to the "new entities" item, as a convenient method
+       // to get newly created group from result. This group is also listed in the
+       // "entities" item.
+       smtk::attribute::ModelEntityItem::Ptr newEntities =
+          result->findModelEntity("new entities");
+       newEntities->setNumberOfValues(1);
+       newEntities->setValue(0, bgroup);
+       }
       }
     if(optype == "Remove" && grpsRemoved.size() > 0)
       {

--- a/smtk/bridge/discrete/operators/EntityGroupOperator.cxx
+++ b/smtk/bridge/discrete/operators/EntityGroupOperator.cxx
@@ -203,20 +203,10 @@ OperatorResult EntityGroupOperator::operateInternal()
     if(bgroup.isValid())
       {
       // Return the created or modified group.
-      smtk::attribute::ModelEntityItem::Ptr entities =
-        result->findModelEntity("entities");
-      entities->setNumberOfValues(1);
-      entities->setValue(0, bgroup);
-     if(optype == "Create")
-       {
-       // Adding the new group to the "new entities" item, as a convenient method
-       // to get newly created group from result. This group is also listed in the
-       // "entities" item.
-       smtk::attribute::ModelEntityItem::Ptr newEntities =
-          result->findModelEntity("new entities");
-       newEntities->setNumberOfValues(1);
-       newEntities->setValue(0, bgroup);
-       }
+      if(optype == "Create")
+        this->addEntityToResult(result, bgroup, CREATED);
+      else if(optype == "Modify")
+        this->addEntityToResult(result, bgroup, MODIFIED);
       }
     if(optype == "Remove" && grpsRemoved.size() > 0)
       {

--- a/smtk/bridge/discrete/operators/EntityGroupOperator.sbt
+++ b/smtk/bridge/discrete/operators/EntityGroupOperator.sbt
@@ -16,15 +16,15 @@
               when the membership is group. Skip for now 
               <MembershipMask>group</MembershipMask>  -->
             </ModelEntity>
-            <ModelEntity Name="remove cell group" Extensible="1" NumberOfRequiredValues="1">
+            <ModelEntity Name="remove cell group" Extensible="1" NumberOfRequiredValues="0">
               <!-- There seems to be a bug in checking the validity of the entity being set 
               when the membership is group. Skip for now 
               <MembershipMask>group</MembershipMask>  -->
             </ModelEntity>
-            <ModelEntity Name="cell to add" Extensible="1">
+            <ModelEntity Name="cell to add" NumberOfRequiredValues="0" Extensible="1">
               <MembershipMask>face|edge|vertex</MembershipMask>
             </ModelEntity>
-            <ModelEntity Name="cell to remove" Extensible="1">
+            <ModelEntity Name="cell to remove" NumberOfRequiredValues="0" Extensible="1">
               <MembershipMask>face|edge|vertex</MembershipMask>
             </ModelEntity>
             <Int Name="entity type" Label="Entity Type:" Version="0" NumberOfRequiredValues="1">

--- a/smtk/bridge/discrete/operators/EntityGroupOperator.sbt
+++ b/smtk/bridge/discrete/operators/EntityGroupOperator.sbt
@@ -16,7 +16,7 @@
               when the membership is group. Skip for now 
               <MembershipMask>group</MembershipMask>  -->
             </ModelEntity>
-            <ModelEntity Name="remove cell group" Extensible="1">
+            <ModelEntity Name="remove cell group" Extensible="1" NumberOfRequiredValues="1">
               <!-- There seems to be a bug in checking the validity of the entity being set 
               when the membership is group. Skip for now 
               <MembershipMask>group</MembershipMask>  -->

--- a/smtk/bridge/discrete/operators/EntityGroupOperator.sbt
+++ b/smtk/bridge/discrete/operators/EntityGroupOperator.sbt
@@ -70,8 +70,6 @@
     <!-- Result -->
     <AttDef Type="result(entity group)" BaseType="result">
       <ItemDefinitions>
-        <ModelEntity Name="new entities" NumberOfRequiredValues="0" Extensible="1">
-        </ModelEntity>
       </ItemDefinitions>
     </AttDef>
   </Definitions>

--- a/smtk/bridge/discrete/operators/GrowOperator.sbt
+++ b/smtk/bridge/discrete/operators/GrowOperator.sbt
@@ -22,9 +22,6 @@
     <!-- Result -->
     <AttDef Type="result(grow)" BaseType="result">
       <ItemDefinitions>
-        <ModelEntity Name="new entities" NumberOfRequiredValues="0" Extensible="1">
-          <MembershipMask>face</MembershipMask>
-        </ModelEntity>
         <MeshSelection Name="selection">
         </MeshSelection>
       </ItemDefinitions>

--- a/smtk/bridge/discrete/operators/ImportOperator.cxx
+++ b/smtk/bridge/discrete/operators/ImportOperator.cxx
@@ -291,11 +291,7 @@ OperatorResult ImportOperator::operateInternal()
   smtk::model::EntityRef modelEntity(this->manager(), modelId);
 
   OperatorResult result = this->createResult(OPERATION_SUCCEEDED);
-
-  smtk::attribute::ModelEntityItemPtr models =
-    result->findModelEntity("entities");
-  models->setNumberOfValues(1);
-  models->setValue(0, modelEntity);
+  this->addEntityToResult(result, modelEntity, CREATED);
 
 /*
 //#include "smtk/io/ExportJSON.h"

--- a/smtk/bridge/discrete/operators/MergeOperator.cxx
+++ b/smtk/bridge/discrete/operators/MergeOperator.cxx
@@ -126,10 +126,7 @@ OperatorResult MergeOperator::operateInternal()
     // Return the list of entities that were created
     // so that remote sessions can track what records
     // need to be re-fetched.
-    smtk::attribute::ModelEntityItem::Ptr resultEntities =
-      result->findModelEntity("entities");
-    resultEntities->setNumberOfValues(1);
-    resultEntities->setValue(0, c);
+    this->addEntityToResult(result, c, MODIFIED);
 
     smtk::attribute::ModelEntityItem::Ptr removedEntities =
       result->findModelEntity("expunged");

--- a/smtk/bridge/discrete/operators/MergeOperator.sbt
+++ b/smtk/bridge/discrete/operators/MergeOperator.sbt
@@ -8,7 +8,7 @@
         <ModelEntity Name="model" NumberOfRequiredValues="1">
            <MembershipMask>model</MembershipMask>
         </ModelEntity>
-        <ModelEntity Name="source cell" Extensible="1">
+        <ModelEntity Name="source cell" NumberOfRequiredValues="0" Extensible="1">
           <MembershipMask>face|edge</MembershipMask>
         </ModelEntity>
 

--- a/smtk/bridge/discrete/operators/ReadOperator.cxx
+++ b/smtk/bridge/discrete/operators/ReadOperator.cxx
@@ -85,7 +85,7 @@ OperatorResult ReadOperator::operateInternal()
 
   OperatorResult result = this->createResult(OPERATION_SUCCEEDED);
   smtk::attribute::ModelEntityItemPtr models =
-    result->findModelEntity("entities");
+    result->findModelEntity("created");
   models->setNumberOfValues(1);
   models->setValue(0, modelEntity);
 

--- a/smtk/bridge/discrete/operators/SplitFaceOperator.cxx
+++ b/smtk/bridge/discrete/operators/SplitFaceOperator.cxx
@@ -155,33 +155,31 @@ OperatorResult SplitFaceOperator::operateInternal()
   if (ok)
     {
 
-    // Return the list of entities that were created
+    // Return the list of entities that were split, "modified" item in result,
     // so that remote sessions can track what records
     // need to be re-fetched.
-    smtk::attribute::ModelEntityItem::Ptr resultEntities =
-      result->findModelEntity("entities");
-    resultEntities->setNumberOfValues(
-      totNewFaces + sourceItem->numberOfValues());
-    // Adding "new faces" to the "new entities" item, as a convenient method
-    // to get newly created faces from result. This list is also in the
-    // "entities" item.
-    smtk::attribute::ModelEntityItem::Ptr newEntities =
-      result->findModelEntity("new entities");
-    newEntities->setNumberOfValues(totNewFaces);
+    // Adding new faces to the "created" item, as a convenient method
+    // to get newly created faces from result. 
 
-    int totIdx = 0;
-    int newIdx = 0;
+    smtk::model::EntityRefArray modEnts;
+    smtk::model::EntityRefArray newEnts;
     std::map<smtk::model::Face, std::set<smtk::model::Face> >::const_iterator it;
     std::set<smtk::model::Face>::const_iterator nit;
     for(it=splitfacemaps.begin(); it!=splitfacemaps.end(); ++it)
       {
-      resultEntities->setValue(totIdx++, it->first);
+      modEnts.push_back(it->first);
       for (nit = it->second.begin(); nit != it->second.end(); ++nit)
         {
-        newEntities->setValue(newIdx++, *nit);
-        resultEntities->setValue(totIdx++, *nit);
+        newEnts.push_back(*nit);
         }
       }
+
+    // Return the created and/or modified faces.
+    if(newEnts.size() > 0)
+      this->addEntitiesToResult(result, newEnts, CREATED);
+    if(modEnts.size() > 0)
+      this->addEntitiesToResult(result, modEnts, MODIFIED);
+
     }
 
   return result;

--- a/smtk/bridge/discrete/operators/SplitFaceOperator.sbt
+++ b/smtk/bridge/discrete/operators/SplitFaceOperator.sbt
@@ -23,9 +23,6 @@
     <!-- Result -->
     <AttDef Type="result(split face)" BaseType="result">
       <ItemDefinitions>
-        <ModelEntity Name="new entities" NumberOfRequiredValues="0" Extensible="1">
-          <MembershipMask>face</MembershipMask>
-        </ModelEntity>
       </ItemDefinitions>
     </AttDef>
   </Definitions>

--- a/smtk/bridge/discrete/operators/SplitFaceOperator.sbt
+++ b/smtk/bridge/discrete/operators/SplitFaceOperator.sbt
@@ -8,7 +8,7 @@
         <ModelEntity Name="model" NumberOfRequiredValues="1">
           <MembershipMask>model</MembershipMask>
         </ModelEntity>
-        <ModelEntity Name="face to split" Extensible="1">
+        <ModelEntity Name="face to split" NumberOfRequiredValues="0" Extensible="1">
         <MembershipMask>face</MembershipMask>
         </ModelEntity>
         <Double Name="feature angle" NumberOfRequiredValues="1">

--- a/smtk/bridge/discrete/operators/WriteOperator.cxx
+++ b/smtk/bridge/discrete/operators/WriteOperator.cxx
@@ -90,10 +90,8 @@ OperatorResult WriteOperator::operateInternal()
     }
 
   OperatorResult result = this->createResult(OPERATION_SUCCEEDED);
-  smtk::attribute::ModelEntityItemPtr models =
-    result->findModelEntity("entities");
-  models->setNumberOfValues(1);
-  models->setValue(0, model);
+  // The model was not modified while writing cmb file.
+  // this->addEntityToResult(result, model, MODIFIED);
 
   return result;
 }

--- a/smtk/bridge/discrete/testing/cxx/SessionTest.cxx
+++ b/smtk/bridge/discrete/testing/cxx/SessionTest.cxx
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
     return 1;
     }
 
-  smtk::model::Model model = opresult->findModelEntity("entities")->value();
+  smtk::model::Model model = opresult->findModelEntity("created")->value();
   manager->assignDefaultNames(); // should force transcription of every entity, but doesn't yet.
 
   smtk::model::DescriptivePhrase::Ptr dit;

--- a/smtk/bridge/exodus/ReadOperator.cxx
+++ b/smtk/bridge/exodus/ReadOperator.cxx
@@ -79,11 +79,11 @@ smtk::model::OperatorResult ReadOperator::operateInternal()
   smtk::attribute::ModelEntityItem::Ptr resultModels =
     result->findModelEntity("model");
   resultModels->setValue(smtkModelOut);
-  smtk::attribute::ModelEntityItem::Ptr entities =
-    result->findModelEntity("entities");
-  entities->setNumberOfValues(1);
-  entities->setValue(smtkModelOut);
-  entities->setIsEnabled(true);
+  smtk::attribute::ModelEntityItem::Ptr created =
+    result->findModelEntity("created");
+  created->setNumberOfValues(1);
+  created->setValue(smtkModelOut);
+  created->setIsEnabled(true);
 
   // The side and node sets now exist; go through
   // and use the Exodus reader's private information

--- a/smtk/bridge/remote/RemusConnection.cxx
+++ b/smtk/bridge/remote/RemusConnection.cxx
@@ -14,6 +14,8 @@
 #include "smtk/io/ImportJSON.h"
 #include "smtk/io/ExportJSON.h"
 
+#include "smtk/model/Operator.h"
+
 #include "smtk/attribute/Attribute.h"
 #include "smtk/attribute/IntItem.h"
 #include "smtk/attribute/FileItem.h"

--- a/smtk/bridge/remote/testing/cxx/integrationRemoteSession.cxx
+++ b/smtk/bridge/remote/testing/cxx/integrationRemoteSession.cxx
@@ -14,6 +14,7 @@
 #include "smtk/AutoInit.h"
 
 #include "smtk/model/Manager.h"
+#include "smtk/model/Operator.h"
 
 #include "smtk/attribute/Attribute.h"
 #include "smtk/attribute/IntItem.h"
@@ -125,7 +126,7 @@ int main(int argc, char* argv[])
     strout = "unknown"; break;
     }
   std::cout << "Read file? " << strout << " (" << readResult->findInt("outcome")->value() << ")\n";
-  std::cout << "Output model is " << readResult->findModelEntity("entities")->value() << "\n";
+  std::cout << "Output model is " << readResult->findModelEntity("created")->value() << "\n";
 
   opnames = bconn->operatorNames(sessionId);
   std::cout << "Operators for session \"" << sessionId << "\":\n";

--- a/smtk/extension/qt/qtCheckItemComboBox.cxx
+++ b/smtk/extension/qt/qtCheckItemComboBox.cxx
@@ -9,6 +9,7 @@
 //=========================================================================
 #include "smtk/extension/qt/qtCheckItemComboBox.h"
 
+#include "smtk/attribute/Attribute.h"
 #include "smtk/attribute/ModelEntityItem.h"
 #include "smtk/attribute/ModelEntityItemDefinition.h"
 #include "smtk/attribute/System.h"

--- a/smtk/extension/qt/qtEntityItemModel.cxx
+++ b/smtk/extension/qt/qtEntityItemModel.cxx
@@ -17,6 +17,8 @@
 #include "smtk/model/StringData.h"
 #include "smtk/model/SubphraseGenerator.h"
 
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/ModelEntityItem.h"
 #include <QtCore/QDir>
 #include <QtCore/QDirIterator>
 #include <QtCore/QFile>

--- a/smtk/extension/qt/qtEntityItemModel.h
+++ b/smtk/extension/qt/qtEntityItemModel.h
@@ -128,9 +128,8 @@ protected:
   virtual void removeChildPhrases(
     const DescriptivePhrasePtr& pDphr, const std::vector< std::pair<DescriptivePhrasePtr, int> >& cDphrs,
     const QModelIndex& topIndex);
-  virtual void addToDirectParentPhrases(
-    const DescriptivePhrasePtr& parntDp, const EntityRef& ent,
-    std::map<DescriptivePhrasePtr,  EntityRefs>& changedPhrases);
+  virtual void updateChildPhrases(
+    const DescriptivePhrasePtr& phrase, const QModelIndex& topIndex);
   virtual void findDirectParentPhrases(
     const DescriptivePhrasePtr& parntDp, const EntityRef& ent,
     std::map<DescriptivePhrasePtr,  std::vector< std::pair<DescriptivePhrasePtr, int> > >& changedPhrases,

--- a/smtk/extension/qt/qtEntityItemModel.h
+++ b/smtk/extension/qt/qtEntityItemModel.h
@@ -98,17 +98,18 @@ public:
 
   void rebuildSubphrases(const QModelIndex& qidx);
 
-/**\brief Update the descriptive phrase \a startPhr, given an op result \a result.
+/**\brief Update the subphrases of \a sessIdx, given an op result \a result.
   *
-  * From David Thompson: The method would find the owning model and session of each
-  * entity listed in the result and (being careful to call areSubphrasesBuilt()
-  * before calling subphrases() on each descriptive phrase) descend the root
-  * until it finds the item's proper place in the tree. At that point,
-  * updateWithOperatorResult() would trigger callbacks before and after inserting
-  * new DescriptivePhrase(s) into the tree.
+  * The method with update the children and grandchildren of the given top level
+  * index (sessIdx). It will change only those indices that are affected by
+  * the operation. For example, split a model face will only add the new
+  * faces to the parent of input/source face that was split. Other indices under
+  * the top level index will not be affected.
   */
   virtual void updateWithOperatorResult(
-    const DescriptivePhrasePtr& startPhr, const OperatorResult& result);
+    const QModelIndex& sessIdx,
+    const OperatorResult& result);
+
 signals:
   void phraseTitleChanged(const QModelIndex&);
 
@@ -130,10 +131,16 @@ protected:
     const QModelIndex& topIndex);
   virtual void updateChildPhrases(
     const DescriptivePhrasePtr& phrase, const QModelIndex& topIndex);
-  virtual void findDirectParentPhrases(
-    const DescriptivePhrasePtr& parntDp, const EntityRef& ent,
-    std::map<DescriptivePhrasePtr,  std::vector< std::pair<DescriptivePhrasePtr, int> > >& changedPhrases,
-    bool onlyBuilt);
+  virtual void findDirectParentPhrasesForAdd(
+          const DescriptivePhrasePtr& parntDp,
+          const smtk::attribute::ModelEntityItemPtr& newEnts,
+          std::map<DescriptivePhrasePtr,
+            std::vector< std::pair<DescriptivePhrasePtr, int> > >& changedPhrases);
+  virtual void findDirectParentPhrasesForRemove(
+          const DescriptivePhrasePtr& parntDp,
+          const smtk::attribute::ModelEntityItemPtr& remEnts,
+          std::map<DescriptivePhrasePtr,
+            std::vector< std::pair<DescriptivePhrasePtr, int> > >& changedPhrases);
 };
 
 /**\brief Iterate over all expanded entries in the tree.

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -100,6 +100,9 @@ qtModelView::qtModelView(QWidget* p)
   QObject::connect(qmodel,
                    SIGNAL(phraseTitleChanged(const QModelIndex&)),
                    this, SLOT(changeEntityName(const QModelIndex&)), Qt::QueuedConnection);
+  QObject::connect(qmodel,
+                   SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)),
+                   this, SLOT(dataChanged(const QModelIndex&, const QModelIndex&)), Qt::QueuedConnection);
 
 }
 
@@ -1160,6 +1163,26 @@ void qtModelView::changeEntityName( const QModelIndex& idx)
 
   attrib->associateEntity(dp->relatedEntity());
   emit this->operationRequested(brOp);
+}
+//-----------------------------------------------------------------------------
+void qtModelView::updateWithOperatorResult(
+    const smtk::model::SessionRef& sref, const OperatorResult& result)
+{
+  smtk::model::QEntityItemModel* qmodel =
+    dynamic_cast<smtk::model::QEntityItemModel*>(this->model());
+  QModelIndex top = this->rootIndex();
+  for (int row = 0; row < qmodel->rowCount(top); ++row)
+    {
+    QModelIndex cIdx = qmodel->index(row, 0, top);
+    DescriptivePhrasePtr dp = qmodel->getItem(cIdx);
+    if(dp && (dp->relatedEntity() == sref))
+      {
+      qmodel->updateWithOperatorResult(dp, result);
+      return;
+      }
+    }
+  std::cerr
+      << "No session phrase found for session: " << sref.name() << std::endl;
 }
 
 //-----------------------------------------------------------------------------

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -19,9 +19,12 @@
 #include "smtk/model/StringData.h"
 
 #include "smtk/extension/qt/qtEntityItemDelegate.h"
+
 #include "smtk/model/EntityPhrase.h"
 #include "smtk/model/EntityListPhrase.h"
+#include "smtk/model/Operator.h"
 #include "smtk/model/SessionRef.h"
+
 #include "smtk/attribute/Attribute.h"
 #include "smtk/attribute/DoubleItem.h"
 #include "smtk/attribute/IntItem.h"

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -1176,11 +1176,11 @@ void qtModelView::updateWithOperatorResult(
   QModelIndex top = this->rootIndex();
   for (int row = 0; row < qmodel->rowCount(top); ++row)
     {
-    QModelIndex cIdx = qmodel->index(row, 0, top);
-    DescriptivePhrasePtr dp = qmodel->getItem(cIdx);
+    QModelIndex sessIdx = qmodel->index(row, 0, top);
+    DescriptivePhrasePtr dp = qmodel->getItem(sessIdx);
     if(dp && (dp->relatedEntity() == sref))
       {
-      qmodel->updateWithOperatorResult(dp, result);
+      qmodel->updateWithOperatorResult(sessIdx, result);
       return;
       }
     }

--- a/smtk/extension/qt/qtModelView.h
+++ b/smtk/extension/qt/qtModelView.h
@@ -61,6 +61,8 @@ public:
     const QColor& clr);
   void currentSelectionByMask(
     smtk::model::EntityRefs& selentityrefs, const BitFlags& entityFlags);
+  virtual void updateWithOperatorResult(
+    const smtk::model::SessionRef& sref, const OperatorResult& result);
 
 public slots:
   void selectEntityItems(const smtk::common::UUIDs& selEntityRefs,

--- a/smtk/io/ExportJSON.cxx
+++ b/smtk/io/ExportJSON.cxx
@@ -484,7 +484,9 @@ int ExportJSON::forOperatorResult(OperatorResult res, cJSON* entRec)
 {
   cJSON_AddItemToObject(entRec, "name", cJSON_CreateString(res->type().c_str()));
   cJSON_AddAttributeSpec(entRec, "result", "resultXML", res);
-  EntityRefs ents = res->modelEntitiesAs<EntityRefs>("entities");
+  EntityRefs ents = res->modelEntitiesAs<EntityRefs>("created");
+  EntityRefs mdfs = res->modelEntitiesAs<EntityRefs>("modified");
+  ents.insert(mdfs.begin(), mdfs.end());
   if (!ents.empty())
     {
     // If the operator reports new/modified entities, transcribe the affected models.

--- a/smtk/model/DescriptivePhrase.cxx
+++ b/smtk/model/DescriptivePhrase.cxx
@@ -62,6 +62,20 @@ int DescriptivePhrase::argFindChild(const DescriptivePhrase* child) const
   return -1;
 }
 
+/// Return the index of the given EntityRef in this instance's subphrases (or -1).
+int DescriptivePhrase::argFindChild(const EntityRef& child) const
+{
+  int i = 0;
+  DescriptivePhrases::const_iterator it;
+  for (it = this->m_subphrases.begin(); it != this->m_subphrases.end(); ++it, ++i)
+    {
+    if (it->get()->relatedEntity() == child)
+      return i;
+    }
+  return -1;
+}
+
+
 /// Return the index of this phrase in its parent instance's subphrases (or -1).
 int DescriptivePhrase::indexInParent() const
 {

--- a/smtk/model/DescriptivePhrase.h
+++ b/smtk/model/DescriptivePhrase.h
@@ -92,6 +92,7 @@ public:
   virtual bool areSubphrasesBuilt() const                      { return this->m_subphrasesBuilt; }
   virtual void markDirty(bool dirty = true)                    { this->m_subphrasesBuilt = !dirty; }
   virtual int argFindChild(const DescriptivePhrase* child) const;
+  virtual int argFindChild(const EntityRef& child) const;
   int indexInParent() const;
 
   virtual EntityRef relatedEntity() const                         { return EntityRef(); }
@@ -107,10 +108,11 @@ public:
 
   unsigned int phraseId() const                                { return this->m_phraseId; }
 
+  SubphraseGeneratorPtr findDelegate();
+
 protected:
   DescriptivePhrase();
 
-  SubphraseGeneratorPtr findDelegate();
   void buildSubphrases();
 
   WeakDescriptivePhrasePtr m_parent;

--- a/smtk/model/Operator.cxx
+++ b/smtk/model/Operator.cxx
@@ -103,7 +103,7 @@ OperatorResult Operator::operate()
       assignNamesItem->isEnabled() &&
       assignNamesItem->value() != 0)
       {
-      ModelEntityItem::Ptr thingsToName = result->findModelEntity("entities");
+      ModelEntityItem::Ptr thingsToName = result->findModelEntity("created");
       EntityRefArray::const_iterator it;
       for (it = thingsToName->begin(); it != thingsToName->end(); ++it)
         {
@@ -473,6 +473,16 @@ OperatorOutcome stringToOutcome(const std::string& oc)
  *
  * Subclasses must implement this method.
  */
+
+/**\brief Add an entity to an operator's result attribute.
+  *
+  * See Operator::addEntitiesToResult() for details.
+  */
+void Operator::addEntityToResult(OperatorResult res, const EntityRef& ent, ResultEntityOrigin gen)
+{
+  EntityRefArray tmp(1,ent);
+  this->addEntitiesToResult(res, tmp, gen);
+}
 
   } // model namespace
 } // smtk namespace

--- a/smtk/model/Session.cxx
+++ b/smtk/model/Session.cxx
@@ -296,15 +296,19 @@ void Session::initializeOperatorSystem(const OperatorConstructors* opList)
 
   Definition::Ptr resultdefn = this->m_operatorSys->createDefinition("result");
   IntItemDefinition::Ptr outcomeDefn = IntItemDefinition::New("outcome");
-  ModelEntityItemDefinition::Ptr entoutDefn = ModelEntityItemDefinition::New("entities");
+  ModelEntityItemDefinition::Ptr entcreDefn = ModelEntityItemDefinition::New("created");
+  ModelEntityItemDefinition::Ptr entmodDefn = ModelEntityItemDefinition::New("modified");
   ModelEntityItemDefinition::Ptr entremDefn = ModelEntityItemDefinition::New("expunged");
 
   StringItemDefinition::Ptr logDefn = StringItemDefinition::New("log");
   outcomeDefn->setNumberOfRequiredValues(1);
   outcomeDefn->setIsOptional(false);
-  entoutDefn->setNumberOfRequiredValues(0);
-  entoutDefn->setIsOptional(true);
-  entoutDefn->setIsExtensible(true);
+  entcreDefn->setNumberOfRequiredValues(0);
+  entcreDefn->setIsOptional(true);
+  entcreDefn->setIsExtensible(true);
+  entmodDefn->setNumberOfRequiredValues(0);
+  entmodDefn->setIsOptional(true);
+  entmodDefn->setIsExtensible(true);
   entremDefn->setNumberOfRequiredValues(0);
   entremDefn->setIsOptional(true);
   entremDefn->setIsExtensible(true);
@@ -314,7 +318,8 @@ void Session::initializeOperatorSystem(const OperatorConstructors* opList)
   logDefn->setIsOptional(true);
 
   resultdefn->addItemDefinition(outcomeDefn);
-  resultdefn->addItemDefinition(entoutDefn);
+  resultdefn->addItemDefinition(entcreDefn);
+  resultdefn->addItemDefinition(entmodDefn);
   resultdefn->addItemDefinition(entremDefn);
   resultdefn->addItemDefinition(logDefn);
 

--- a/smtk/model/Session.h
+++ b/smtk/model/Session.h
@@ -11,6 +11,7 @@
 #define __smtk_model_Session_h
 /*! \file */
 
+#include "smtk/AutoInit.h"
 #include "smtk/SystemConfig.h"
 #include "smtk/SharedPtr.h"
 #include "smtk/SharedFromThis.h"
@@ -22,7 +23,6 @@
 
 #include "smtk/model/SessionRegistrar.h"
 #include "smtk/model/EntityRef.h"
-#include "smtk/model/Operator.h"
 
 namespace smtk {
   namespace model {

--- a/smtk/model/SessionRef.cxx
+++ b/smtk/model/SessionRef.cxx
@@ -12,11 +12,12 @@
 #include "smtk/attribute/Definition.h"
 #include "smtk/attribute/System.h"
 
-#include "smtk/model/SessionRegistrar.h"
+#include "smtk/model/Arrangement.h"
 #include "smtk/model/CellEntity.h"
 #include "smtk/model/Model.h"
 #include "smtk/model/Manager.h"
-#include "smtk/model/Arrangement.h"
+#include "smtk/model/Operator.h"
+#include "smtk/model/SessionRegistrar.h"
 
 namespace smtk {
   namespace model {

--- a/smtk/model/SubphraseGenerator.cxx
+++ b/smtk/model/SubphraseGenerator.cxx
@@ -33,6 +33,10 @@
 
 namespace smtk {
   namespace model {
+SubphraseGenerator::SubphraseGenerator()
+{
+  m_directlimit = 4;
+}
 
 /**\brief Return a list of descriptive phrases that elaborate upon \a src.
   *
@@ -57,7 +61,17 @@ DescriptivePhrases SubphraseGenerator::subphrases(DescriptivePhrase::Ptr src)
   */
 int SubphraseGenerator::directLimit() const
 {
-  return 4;
+  return m_directlimit;
+}
+
+bool SubphraseGenerator::setDirectLimit(int val)
+{
+  if(val > 0)
+    {
+    this->m_directlimit = val;
+    return true;
+    }
+  return false;
 }
 
 /**\brief Should the property of the given type and name be omitted from presentation?

--- a/smtk/model/SubphraseGenerator.h
+++ b/smtk/model/SubphraseGenerator.h
@@ -43,11 +43,12 @@ public:
 
   virtual DescriptivePhrases subphrases(DescriptivePhrase::Ptr src);
   virtual int directLimit() const;
+  virtual bool setDirectLimit(int val);
   virtual bool shouldOmitProperty(
     DescriptivePhrase::Ptr parent, PropertyType ptype, const std::string& pname) const;
 
 protected:
-  SubphraseGenerator() { }
+  SubphraseGenerator();
 
   void instancesOfEntity(DescriptivePhrase::Ptr src, const EntityRef& ent, DescriptivePhrases& result);
   void attributesOfEntity(DescriptivePhrase::Ptr src, const EntityRef& ent, DescriptivePhrases& result);
@@ -85,6 +86,8 @@ protected:
 
   template<typename T>
   void addEntityPhrases(const T& ents, DescriptivePhrase::Ptr parent, int limit, DescriptivePhrases& result);
+
+  int m_directlimit;
 };
 
 template<typename T>

--- a/smtk/model/operators/SetProperty.cxx
+++ b/smtk/model/operators/SetProperty.cxx
@@ -80,7 +80,7 @@ smtk::model::OperatorResult SetProperty::operateInternal()
   // modified so that remote sessions can track what records
   // need to be re-fetched.
   smtk::attribute::ModelEntityItem::Ptr resultEntities =
-    result->findModelEntity("entities");
+    result->findModelEntity("modified");
 
   int numEntitiesOut = static_cast<int>(entities.size());
   resultEntities->setNumberOfValues(numEntitiesOut);

--- a/smtk/model/operators/SetProperty.sbt
+++ b/smtk/model/operators/SetProperty.sbt
@@ -38,7 +38,7 @@
     </AttDef>
     <!-- Result -->
     <AttDef Type="result(set property)" BaseType="result">
-      <!-- The modified entities are stored in the base result's "entities" item. -->
+      <!-- The modified entities are stored in the base result's "modified" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/smtk/simple.py
+++ b/smtk/smtk/simple.py
@@ -121,7 +121,7 @@ def CreateSphere(**args):
     SetVectorValue(cc, args['center'])
   res = cs.operate()
   PrintResultLog(res)
-  sph = res.findModelEntity('entities').value(0)
+  sph = res.findModelEntity('created').value(0)
   return sph
 
 def CreateCylinder(**args):
@@ -161,7 +161,7 @@ def CreateCylinder(**args):
     cs.findAsDouble('height').setValue(args['height'])
   res = cs.operate()
   PrintResultLog(res)
-  cyl = res.findModelEntity('entities').value(0)
+  cyl = res.findModelEntity('created').value(0)
   return cyl
 
 def CreateBrick(**args):
@@ -210,7 +210,7 @@ def CreateBrick(**args):
     SetVectorValue(cb.findAsDouble('center'), ctrVal)
   res = cb.operate()
   PrintResultLog(res)
-  brick = res.findModelEntity('entities').value(0)
+  brick = res.findModelEntity('created').value(0)
   return brick
 
 def Intersect(bodies, **args):
@@ -233,7 +233,7 @@ def Intersect(bodies, **args):
     op.associateEntity(bodies)
   res = op.operate()
   PrintResultLog(res)
-  return res.findModelEntity('entities').value(0)
+  return res.findModelEntity('modified').value(0)
 
 def Union(bodies, **args):
   """Compute the boolean union of a set of bodies.
@@ -255,7 +255,7 @@ def Union(bodies, **args):
     op.associateEntity(bodies)
   res = op.operate()
   PrintResultLog(res)
-  return res.findModelEntity('entities').value(0)
+  return res.findModelEntity('modified').value(0)
 
 def Subtract(workpiece, tool, **args):
   """Perform a boolean subtraction of the tool from the workpiece.
@@ -288,7 +288,7 @@ def Subtract(workpiece, tool, **args):
 
   res = op.operate()
   PrintResultLog(res)
-  return res.findModelEntity('entities').value(0)
+  return res.findModelEntity('modified').value(0)
 
 def Translate(bodies, vec):
   """Translate the body (or list of bodies) along the given vector."""
@@ -301,7 +301,7 @@ def Translate(bodies, vec):
   SetVectorValue(top.findAsDouble('offset'),vec)
   res = top.operate()
   PrintResultLog(res)
-  return GetVectorValue(res.findModelEntity('entities'))
+  return GetVectorValue(res.findModelEntity('modified'))
 
 def CreateVertex(pt, **kwargs):
   """Create a vertex given point coordinates.
@@ -315,7 +315,7 @@ def CreateVertex(pt, **kwargs):
   SetVectorValue(x, pt)
   res = crv.operate()
   PrintResultLog(res)
-  return res.findModelEntity('entities').value(0)
+  return res.findModelEntity('created').value(0)
 
 def CreateEdge(verts, curve_type = CurveType.LINE, **kwargs):
   """Create an edge from a pair of vertices.
@@ -333,7 +333,7 @@ def CreateEdge(verts, curve_type = CurveType.LINE, **kwargs):
     c.setValue(0, kwargs['color'])
   res = cre.operate()
   PrintResultLog(res)
-  return res.findModelEntity('entities').value(0)
+  return res.findModelEntity('created').value(0)
 
 def CreateFace(edges, surface_type = SurfaceType.PLANAR, **kwargs):
   """Create a face from a set of edges.
@@ -348,7 +348,7 @@ def CreateFace(edges, surface_type = SurfaceType.PLANAR, **kwargs):
     c.setValue(0, kwargs['color'])
   res = crf.operate()
   PrintResultLog(res)
-  return res.findModelEntity('entities').value(0)
+  return res.findModelEntity('created').value(0)
 
 def CreateBody(ents, **kwargs):
   """Create a set of bodies from a set of cells.
@@ -370,7 +370,7 @@ def CreateBody(ents, **kwargs):
     c.setValue(0, kwargs['keep_inputs'])
   res = crb.operate()
   PrintResultLog(res)
-  bodies = res.findModelEntity('entities')
+  bodies = res.findModelEntity('created')
   return [bodies.value(i) for i in range(bodies.numberOfValues())]
 
 def Sweep(stuffToSweep, method = SweepType.EXTRUDE, **kwargs):
@@ -417,7 +417,7 @@ def Sweep(stuffToSweep, method = SweepType.EXTRUDE, **kwargs):
       angl = swp.findAsInt('handedness').setValue(0, kwargs['handedness'])
   res = swp.operate()
   PrintResultLog(res)
-  return res.findModelEntity('entities').value(0)
+  return res.findModelEntity('created').value(0)
 
 def Read(filename, **kwargs):
   """Read entities from an file (in the native modeling kernel format).
@@ -429,7 +429,7 @@ def Read(filename, **kwargs):
     rdr.findAsString('filetype').setValue(0, kwargs['filetype'])
   res = rdr.operate()
   PrintResultLog(res)
-  return GetVectorValue(res.findModelEntity('entities'))
+  return GetVectorValue(res.findModelEntity('created'))
 
 def Write(filename, entities = [], **kwargs):
   """Write a set of entities to an file (in the native modeling kernel format).

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -57,6 +57,7 @@
   <suppress-warning text="skipping function 'smtk::attribute::ModelEntityItem::setValues', unmatched parameter type 'I'"/>
   <suppress-warning text="skipping function 'smtk::attribute::ModelEntityItem::end', unmatched return type 'smtk::attribute::ModelEntityItem::const_iterator'"/>
   <suppress-warning text="skipping function 'smtk::attribute::ModelEntityItem::begin', unmatched return type 'smtk::attribute::ModelEntityItem::const_iterator'"/>
+  <suppress-warning text="skipping function 'smtk::model::Operator::addEntitiesToResult', unmatched parameter type 'T const&amp;'"/>
 
   <!-- Return a list.  For now we will ignore the iterators-->
   <suppress-warning text="skipping function 'smtk::model::Item::beginAssociatedAttributes', unmatched return type 'smtk::model::Item::const_iterator'"/>
@@ -1019,6 +1020,7 @@
 
       <object-type name="Operator">
         <include file-name="smtk/model/Operator.h" location="local"/>
+        <enum-type name="ResultEntityOrigin" />
       </object-type>
 
       <object-type name="AttributeAssignments">


### PR DESCRIPTION
The model tree view was rebuilt whenever an model operation was finished. This causes the tree to be closed, and user loses the state of the tree view, which is very annoying to say at least. This commit brings in a couple things to fix this behavior.
1. (by @vibraphone Pull Request #116 ) Added "Modified" and "Created" model entity item in operator result, to replace "entities", so that the UI can do things differently based on different return types.
2. I updated the operators in Discrete session to integrate changes above.
3. More UI logic is added to update the tree according to the returned operation results. Basically, the tree is searched first to figure out where the result entities (modified and/or created) should be, and only relevant tree indices are updated with the result.