### PR TITLE
Refactoring color model entity by field data logic

### DIFF
--- a/smtk/extension/qt/qtEntityItemModel.cxx
+++ b/smtk/extension/qt/qtEntityItemModel.cxx
@@ -533,7 +533,7 @@ QIcon QEntityItemModel::lookupIconForEntityFlags(smtk::model::BitFlags flags)
       << (flags & ANY_DIMENSION)
       ;
     }
-  resourceName << ".svg";
+  resourceName << ".png";
   QFile rsrc(resourceName.str().c_str());
   if (!rsrc.exists())
     { // FIXME: Replace with the path of a "generic entity" or "invalid" icon.

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -982,20 +982,25 @@ void qtModelView::changeEntityColor( const QModelIndex& idx)
   OperatorPtr brOp = this->getOp(idx, "set property");
   if(!brOp || !brOp->specification()->isValid())
     return;
-  smtk::model::EntityRefs selentityrefs;
-  this->recursiveSelect(this->getModel()->getItem(idx), selentityrefs,
-    CELL_ENTITY | SHELL_ENTITY  | GROUP_ENTITY |
-    MODEL_ENTITY | INSTANCE_ENTITY | SESSION);
+//  this->recursiveSelect(this->getModel()->getItem(idx), selentityrefs,
+//    CELL_ENTITY | SHELL_ENTITY  | GROUP_ENTITY |
+//    MODEL_ENTITY | INSTANCE_ENTITY | SESSION);
   DescriptivePhrasePtr dp = this->getModel()->getItem(idx);
-  smtk::model::FloatList rgba(4);
-  rgba = dp->relatedColor();
-  QColor currentColor = QColor::fromRgbF(rgba[0], rgba[1], rgba[2]);
-  QColor newColor = QColorDialog::getColor(currentColor, this,
-    "Choose Entity Color", QColorDialog::DontUseNativeDialog);
-  if(newColor.isValid() && newColor != currentColor)
+  if(dp && dp->relatedEntity().isValid())
     {
-    if(this->setEntityColor(selentityrefs, newColor, brOp))
-      this->dataChanged(idx, idx);
+    smtk::model::EntityRefs selentityrefs;
+    selentityrefs.insert(dp->relatedEntity());
+
+    smtk::model::FloatList rgba(4);
+    rgba = dp->relatedColor();
+    QColor currentColor = QColor::fromRgbF(rgba[0], rgba[1], rgba[2]);
+    QColor newColor = QColorDialog::getColor(currentColor, this,
+      "Choose Entity Color", QColorDialog::DontUseNativeDialog);
+    if(newColor.isValid() && newColor != currentColor)
+      {
+      if(this->setEntityColor(selentityrefs, newColor, brOp))
+        this->dataChanged(idx, idx);
+      }
     }
 }
 

--- a/smtk/extension/vtk/vtkModelMultiBlockSource.h
+++ b/smtk/extension/vtk/vtkModelMultiBlockSource.h
@@ -58,7 +58,7 @@ public:
 
   // Description:
   // Functions get string names used to store cell/field data.
-  static const char* GetEntityTagName() { return "Entity UUID"; }
+  static const char* GetEntityTagName() { return "Entity"; }
   static const char* GetGroupTagName() { return "Group"; }
   static const char* GetVolumeTagName() { return "Volume"; }
 


### PR DESCRIPTION
When assigning a color in the tree view, all children of the assigned index got the same color, which should not be the case. Only assigned index (entity) should get the assigned color, and according to what the current selection in "ColorBy" toolbar, the entity representation should only displays with that color, if the ColorBy selection matches its entity type. Other entities will be colored through color transfer function of the representation.
