### PR TITLE
Add APIs to automatically associate operator model entity item with selection

### DIFF
--- a/smtk/extension/qt/qtAttribute.cxx
+++ b/smtk/extension/qt/qtAttribute.cxx
@@ -204,6 +204,15 @@ void qtAttribute::updateItemsData()
       }
     }
 }
+//----------------------------------------------------------------------------
+void qtAttribute::onRequestEntityAssociation()
+{
+  foreach(qtItem* item, this->Internals->Items)
+    {
+    if(qtModelEntityItem* mitem = qobject_cast<qtModelEntityItem*>(item))
+      mitem->onRequestEntityAssociation();
+    }
+}
 
 //----------------------------------------------------------------------------
 smtk::attribute::AttributePtr qtAttribute::getObject()

--- a/smtk/extension/qt/qtAttribute.h
+++ b/smtk/extension/qt/qtAttribute.h
@@ -64,6 +64,9 @@ namespace smtk
       static qtItem* createMeshSelectionItem(smtk::attribute::MeshSelectionItemPtr item, QWidget* pW, qtBaseView* view,
         Qt::Orientation enVectorItemOrient = Qt::Horizontal);
 
+    public slots:
+      virtual void onRequestEntityAssociation();
+
     protected slots:
       virtual void updateItemsData();
 

--- a/smtk/extension/qt/qtBaseView.h
+++ b/smtk/extension/qt/qtBaseView.h
@@ -63,6 +63,8 @@ namespace smtk
       virtual void showAdvanceLevelOverlay(bool val)
       { m_advOverlayVisible = val;}
 
+      virtual void requestModelEntityAssociation() {;}
+
     protected slots:
       virtual void updateAttributeData() {;}
 

--- a/smtk/extension/qt/qtInstancedView.cxx
+++ b/smtk/extension/qt/qtInstancedView.cxx
@@ -161,3 +161,12 @@ void qtInstancedView::showAdvanceLevelOverlay(bool show)
     }
   this->qtBaseView::showAdvanceLevelOverlay(show);
 }
+
+//----------------------------------------------------------------------------
+void qtInstancedView::requestModelEntityAssociation()
+{
+  foreach(qtAttribute* att, this->Internals->AttInstances)
+    {
+    att->onRequestEntityAssociation();
+    }
+}

--- a/smtk/extension/qt/qtInstancedView.h
+++ b/smtk/extension/qt/qtInstancedView.h
@@ -34,6 +34,7 @@ namespace smtk
 
     public slots:
       virtual void showAdvanceLevelOverlay(bool show);
+      virtual void requestModelEntityAssociation();
 
     protected:
       virtual void updateAttributeData();

--- a/smtk/extension/qt/qtModelEntityItem.h
+++ b/smtk/extension/qt/qtModelEntityItem.h
@@ -40,6 +40,7 @@ namespace smtk
 
     public slots:
       void setOutputOptional(int);
+      virtual void onRequestEntityAssociation();
 
     signals:
       void requestEntityAssociation();
@@ -48,7 +49,6 @@ namespace smtk
 
     protected slots:
       virtual void updateItemData();
-      virtual void onRequestEntityAssociation();
       virtual void popupViewItemSelected();
       virtual void clearEntityAssociations();
 

--- a/smtk/extension/qt/qtModelOperationWidget.cxx
+++ b/smtk/extension/qt/qtModelOperationWidget.cxx
@@ -12,7 +12,7 @@
 
 #include "smtk/extension/qt/qtUIManager.h"
 #include "smtk/extension/qt/qtAttribute.h"
-#include "smtk/extension/qt/qtBaseView.h"
+#include "smtk/extension/qt/qtInstancedView.h"
 #include "smtk/extension/qt/qtModelEntityItem.h"
 
 #include "smtk/attribute/Attribute.h"
@@ -53,7 +53,7 @@ public:
   smtk::model::OperatorPtr opPtr;
   QPointer<qtUIManager> opUiManager;
   QPointer<QFrame> opUiParent;
-  QPointer<qtBaseView> opUiView;
+  QPointer<qtInstancedView> opUiView;
   };
 
   smtk::model::Session::WeakPtr CurrentSession;
@@ -188,7 +188,9 @@ bool qtModelOperationWidget::setCurrentOperation(
   QObject::connect(uiManager, SIGNAL(meshSelectionItemCreated(smtk::attribute::qtMeshSelectionItem*)),
     this, SLOT(onMeshSelectionItemCreated(smtk::attribute::qtMeshSelectionItem*)));
 
-  qtBaseView* theView = uiManager->initializeView(opParent, instanced, false);
+  qtInstancedView* theView = qobject_cast<qtInstancedView*>(
+    uiManager->initializeView(opParent, instanced, false));
+  theView->requestModelEntityAssociation();
   qtModelOperationWidgetInternals::OperatorInfo opInfo;
   opInfo.opPtr = brOp;
   opInfo.opUiParent = opParent;
@@ -230,6 +232,7 @@ bool qtModelOperationWidget::setCurrentOperation(
 
   if(this->Internals->OperatorMap.contains(opName))
     {
+    this->Internals->OperatorMap[opName].opUiView->requestModelEntityAssociation();
     this->Internals->OperationsLayout->setCurrentWidget(
       this->Internals->OperatorMap[opName].opUiParent);
     return true;

--- a/smtk/extension/qt/qtModelView.h
+++ b/smtk/extension/qt/qtModelView.h
@@ -60,7 +60,8 @@ public:
     const QMap<smtk::model::SessionPtr, smtk::common::UUIDs>& brEntities,
     const QColor& clr);
   void currentSelectionByMask(
-    smtk::model::EntityRefs& selentityrefs, const BitFlags& entityFlags);
+    smtk::model::EntityRefs& selentityrefs, const BitFlags& entityFlags,
+    bool searchUp = false);
   virtual void updateWithOperatorResult(
     const smtk::model::SessionRef& sref, const OperatorResult& result);
 
@@ -111,6 +112,9 @@ protected:
   T owningEntityAs(const QModelIndex &idx) const;
   template<typename T>
   T owningEntityAs(const DescriptivePhrasePtr &dp) const;
+  void owningEntitiesByMask (
+    smtk::model::DescriptivePhrasePtr inDp,
+    smtk::model::EntityRefs& selentityrefs, BitFlags entityFlags);
 
   bool hasSessionOp(const smtk::model::SessionRef& brSession,
     const std::string& opname);


### PR DESCRIPTION
When a model operator's UI is launched, we want the ModelEntityItem(s) in
the operator specifiction to be automatically associated with the current selection
in the modelView, if the entity flags match with the item's entity mask. If we did not
find any suitable matches in the children of the selected entities, we will also search
the parents. For example, if a Face is selected, but the ModelEnityItem is requiring a model,
we will search up the tree and associated the item with the model owning the face.