### PR TITLE
include vtkSMTKDiscreteExtModule.h by full path.

### DIFF
--- a/smtk/bridge/discrete/extension/meshing/cmbFaceMeshHelper.h
+++ b/smtk/bridge/discrete/extension/meshing/cmbFaceMeshHelper.h
@@ -15,7 +15,7 @@
 #ifndef __smtkdiscrete_cmbFaceMeshHelper_h
 #define __smtkdiscrete_cmbFaceMeshHelper_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include <map> // Needed for STL map.
 #include <set> // Needed for STL set.
 #include <list> // Needed for STL list.

--- a/smtk/bridge/discrete/extension/meshing/cmbFaceMesherInterface.h
+++ b/smtk/bridge/discrete/extension/meshing/cmbFaceMesherInterface.h
@@ -17,7 +17,7 @@
 #ifndef __smtkdiscrete_cmbFaceMesherInterface_h
 #define __smtkdiscrete_cmbFaceMesherInterface_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include <string> //for std string
 #include "vtkABI.h"
 

--- a/smtk/bridge/discrete/extension/meshing/vtkCMBMeshServerLauncher.h
+++ b/smtk/bridge/discrete/extension/meshing/vtkCMBMeshServerLauncher.h
@@ -16,7 +16,7 @@
 #ifndef __smtkdiscrete_vtkCMBMeshServerLauncher_h
 #define __smtkdiscrete_vtkCMBMeshServerLauncher_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkObject.h"
 #include "vtkStdString.h" //needed for the HostName
 

--- a/smtk/bridge/discrete/extension/meshing/vtkCMBPrepareForTriangleMesher.h
+++ b/smtk/bridge/discrete/extension/meshing/vtkCMBPrepareForTriangleMesher.h
@@ -126,7 +126,7 @@
 #ifndef __smtkdiscrete_vtkCMBPrepareForTriangleMesher_h
 #define __smtkdiscrete_vtkCMBPrepareForTriangleMesher_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkObject.h"
 #include "smtk/bridge/discrete/extension/meshing/cmbFaceMeshHelper.h"
 

--- a/smtk/bridge/discrete/extension/meshing/vtkCMBTriangleMesher.h
+++ b/smtk/bridge/discrete/extension/meshing/vtkCMBTriangleMesher.h
@@ -27,7 +27,7 @@
 #ifndef __smtkdiscrete_vtkCMBTriangleMesher_h
 #define __smtkdiscrete_vtkCMBTriangleMesher_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 namespace smtk {

--- a/smtk/bridge/discrete/extension/meshing/vtkCMBUniquePointSet.h
+++ b/smtk/bridge/discrete/extension/meshing/vtkCMBUniquePointSet.h
@@ -16,7 +16,7 @@
 #ifndef __smtkdiscrete_vtkCMBUniquePointSet_
 #define __smtkdiscrete_vtkCMBUniquePointSet_
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 
 #include <map>
 #include <vector>

--- a/smtk/bridge/discrete/extension/meshing/vtkDiscoverRegions.h
+++ b/smtk/bridge/discrete/extension/meshing/vtkDiscoverRegions.h
@@ -11,7 +11,7 @@
 #ifndef __smtkdiscrete_vtkDiscoverRegions_h
 #define __smtkdiscrete_vtkDiscoverRegions_h
 
-#include "vtkSMTKDiscreteExtModule.h" // for EXPORT macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 //#define VTK_CELL_REGION_IDS "CellRegionIds"

--- a/smtk/bridge/discrete/extension/meshing/vtkPolylineTriangulator.h
+++ b/smtk/bridge/discrete/extension/meshing/vtkPolylineTriangulator.h
@@ -11,7 +11,7 @@
 #ifndef __smtkdiscrete_vtkPolylineTriangulator_h
 #define __smtkdiscrete_vtkPolylineTriangulator_h
 
-#include "vtkSMTKDiscreteExtModule.h" // for EXPORT macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 namespace smtk {

--- a/smtk/bridge/discrete/extension/meshing/vtkRayIntersectionLocator.h
+++ b/smtk/bridge/discrete/extension/meshing/vtkRayIntersectionLocator.h
@@ -23,7 +23,7 @@
 #ifndef __smtkdiscrete_vtkRayIntersectionLocator_h
 #define __smtkdiscrete_vtkRayIntersectionLocator_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkCellTreeLocator.h"
 #include "vtkVector.h"
 #include <vector> // Needed for public interface.

--- a/smtk/bridge/discrete/extension/meshing/vtkRegionsToLoops.h
+++ b/smtk/bridge/discrete/extension/meshing/vtkRegionsToLoops.h
@@ -11,7 +11,7 @@
 #ifndef __smtkdiscrete_vtkRegionsToLoops_h
 #define __smtkdiscrete_vtkRegionsToLoops_h
 
-#include "vtkSMTKDiscreteExtModule.h" // for EXPORT macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 namespace smtk {

--- a/smtk/bridge/discrete/extension/meshing/vtkSplitPlanarLines.h
+++ b/smtk/bridge/discrete/extension/meshing/vtkSplitPlanarLines.h
@@ -20,7 +20,7 @@
 // There is no guarantee that edge order is preserved, but pedigree IDs are
 // generated to indicate the correspondence between input and output edges.
 
-#include "vtkSMTKDiscreteExtModule.h" // for export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 namespace smtk {

--- a/smtk/bridge/discrete/extension/reader/vtkCMBGeometry2DReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkCMBGeometry2DReader.h
@@ -16,7 +16,7 @@
 #ifndef __smtkdiscrete_vtkCMBGeometry2DReader_h
 #define __smtkdiscrete_vtkCMBGeometry2DReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 namespace smtk {

--- a/smtk/bridge/discrete/extension/reader/vtkCMBGeometryReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkCMBGeometryReader.h
@@ -16,7 +16,7 @@
 #ifndef __smtkdiscrete_CMBGeometryReader_h
 #define __smtkdiscrete_CMBGeometryReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 

--- a/smtk/bridge/discrete/extension/reader/vtkCMBMapReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkCMBMapReader.h
@@ -16,7 +16,7 @@
 #ifndef __smtkdiscrete_vtkCMBMapReader_h
 #define __smtkdiscrete_vtkCMBMapReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 class vtkIntArray;

--- a/smtk/bridge/discrete/extension/reader/vtkCMBMeshReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkCMBMeshReader.h
@@ -56,7 +56,7 @@
 #ifndef __smtkdiscrete_vtkCMBMeshReader_h
 #define __smtkdiscrete_vtkCMBMeshReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkUnstructuredGridAlgorithm.h"
 
 class vtkDoubleArray;

--- a/smtk/bridge/discrete/extension/reader/vtkCMBSTLReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkCMBSTLReader.h
@@ -15,7 +15,7 @@
 #ifndef __smtkdiscrete_vtkCMBSTLReader_h
 #define __smtkdiscrete_vtkCMBSTLReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 namespace smtk {

--- a/smtk/bridge/discrete/extension/reader/vtkCUBITReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkCUBITReader.h
@@ -16,7 +16,7 @@
 #ifndef __smtkdiscrete_CUBITReader_h
 #define __smtkdiscrete_CUBITReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 

--- a/smtk/bridge/discrete/extension/reader/vtkDataSetRegionSurfaceFilter.h
+++ b/smtk/bridge/discrete/extension/reader/vtkDataSetRegionSurfaceFilter.h
@@ -19,7 +19,7 @@
 #ifndef __smtkdiscrete_vtkDataSetRegionSurfaceFilter_h
 #define __smtkdiscrete_vtkDataSetRegionSurfaceFilter_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkDataSetSurfaceFilter.h"
 
 class vtkCharArray;

--- a/smtk/bridge/discrete/extension/reader/vtkExtractRegionEdges.h
+++ b/smtk/bridge/discrete/extension/reader/vtkExtractRegionEdges.h
@@ -18,7 +18,7 @@
 #ifndef __smtkdiscrete_vtkExtractRegionEdges_h
 #define __smtkdiscrete_vtkExtractRegionEdges_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 namespace smtk {

--- a/smtk/bridge/discrete/extension/reader/vtkGMSSolidReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkGMSSolidReader.h
@@ -16,7 +16,7 @@
 #ifndef __smtkdiscrete_vtkGMSSolidReader_h
 #define __smtkdiscrete_vtkGMSSolidReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkMultiBlockDataSetAlgorithm.h"
 
 class vtkCellArray;

--- a/smtk/bridge/discrete/extension/reader/vtkGMSTINReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkGMSTINReader.h
@@ -16,7 +16,7 @@
 #ifndef __smtkdiscrete_vtkGMSTINReader_h
 #define __smtkdiscrete_vtkGMSTINReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkMultiBlockDataSetAlgorithm.h"
 
 class vtkCellArray;

--- a/smtk/bridge/discrete/extension/reader/vtkLIDARReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkLIDARReader.h
@@ -20,7 +20,7 @@
 #ifndef __smtkdiscrete_LIDARReader_h
 #define __smtkdiscrete_LIDARReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 #include "vtkSmartPointer.h"
 

--- a/smtk/bridge/discrete/extension/reader/vtkPolyFileReader.h
+++ b/smtk/bridge/discrete/extension/reader/vtkPolyFileReader.h
@@ -11,7 +11,7 @@
 #ifndef __smtkdiscrete_vtkPolyFileReader_h
 #define __smtkdiscrete_vtkPolyFileReader_h
 
-#include "vtkSMTKDiscreteExtModule.h" // For export macro
+#include "smtk/bridge/discrete/extension/vtkSMTKDiscreteExtModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
 


### PR DESCRIPTION
When external projects include discrete extension headers we can properly
find the export header properly.