### PR TITLE
New universal close model operator

### DIFF
--- a/smtk/bridge/cgm/CMakeLists.txt
+++ b/smtk/bridge/cgm/CMakeLists.txt
@@ -21,6 +21,7 @@ set(cgmSrcs
   operators/CreateVertex.cxx
   operators/Read.cxx
   operators/Reflect.cxx
+  operators/RemoveModel.cxx
   operators/Rotate.cxx
   operators/Scale.cxx
   operators/Sweep.cxx
@@ -50,6 +51,7 @@ set(cgmHeaders
   operators/CreateVertex.h
   operators/Read.h
   operators/Reflect.h
+  operators/RemoveModel.h
   operators/Rotate.h
   operators/Scale.h
   operators/Sweep.h
@@ -113,6 +115,7 @@ smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/CreateSphere.sbt" cgmOp
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/CreateVertex.sbt" cgmOperatorXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/Read.sbt" cgmOperatorXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/Reflect.sbt" cgmOperatorXML)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/RemoveModel.sbt" cgmOperatorXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/Rotate.sbt" cgmOperatorXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/Scale.sbt" cgmOperatorXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/Sweep.sbt" cgmOperatorXML)

--- a/smtk/bridge/cgm/Engines.cxx
+++ b/smtk/bridge/cgm/Engines.cxx
@@ -265,6 +265,15 @@ bool Engines::shutdown()
   return true;
 }
 
+bool Engines::removeBody(Body* body)
+{
+  if(!body)
+    return false;
+  if (GeometryQueryTool::instance())
+    return (GeometryQueryTool::instance()->delete_Body(body) == CUBIT_SUCCESS);
+  return false;
+}
+
 } // namespace cgm
   } //namespace bridge
 } // namespace smtk

--- a/smtk/bridge/cgm/Engines.h
+++ b/smtk/bridge/cgm/Engines.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+class Body;
+
 namespace smtk {
   namespace bridge {
     namespace cgm {
@@ -43,6 +45,7 @@ public:
   static std::vector<std::string> listEngines();
 
   static bool shutdown();
+  static bool removeBody(Body* body);
 };
 
     } // namespace cgm

--- a/smtk/bridge/cgm/Session.cxx
+++ b/smtk/bridge/cgm/Session.cxx
@@ -320,6 +320,20 @@ smtk::model::SessionInfoBits Session::addCGMEntityToManager(
   return 0;
 }
 
+/**\brief remove a model entity \a entityref that reflect the CGM body.
+  *
+  */
+bool Session::removeModelEntity(
+  const smtk::model::EntityRef& entityref)
+{
+  ToolDataUser* tdu = TDUUID::findEntityById(entityref.entity());
+  Body* body = dynamic_cast<Body*>(tdu);
+  if (body && Engines::removeBody(body))
+    return this->manager()->eraseModel(entityref);
+
+  return false;
+}
+
 /// Given a CGM \a body tagged with \a uid, create a record in \a modelManager for it.
 smtk::model::SessionInfoBits Session::addBodyToManager(
   const smtk::model::Model& entityref,

--- a/smtk/bridge/cgm/Session.h
+++ b/smtk/bridge/cgm/Session.h
@@ -73,11 +73,13 @@ public:
 
 protected:
   friend class ImportSolid;
+  friend class RemoveModel;
 
   Session();
 
   virtual SessionInfoBits transcribeInternal(
     const smtk::model::EntityRef& entity, SessionInfoBits requestedInfo);
+  virtual bool removeModelEntity(const smtk::model::EntityRef& entity);
 
   SessionInfoBits addCGMEntityToManager(const smtk::model::EntityRef& entity, RefEntity* refEnt, SessionInfoBits requestedInfo);
   SessionInfoBits addCGMEntityToManager(const smtk::model::EntityRef& entity, GroupingEntity* refEnt, SessionInfoBits requestedInfo);

--- a/smtk/bridge/cgm/operators/RemoveModel.cxx
+++ b/smtk/bridge/cgm/operators/RemoveModel.cxx
@@ -63,7 +63,7 @@ smtk::model::OperatorResult RemoveModel::operateInternal()
 #include "RemoveModel_xml.h"
 
 smtkImplementsModelOperator(
-  CGMSMTK_EXPORT,
+  SMTKCGMSESSION_EXPORT,
   smtk::bridge::cgm::RemoveModel,
   cgm_remove_model,
   "remove model",

--- a/smtk/bridge/cgm/operators/RemoveModel.cxx
+++ b/smtk/bridge/cgm/operators/RemoveModel.cxx
@@ -1,0 +1,71 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/bridge/cgm/operators/RemoveModel.h"
+
+#include "smtk/bridge/cgm/Session.h"
+
+#include "smtk/model/CellEntity.h"
+#include "smtk/model/Manager.h"
+#include "smtk/model/Model.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/ModelEntityItem.h"
+
+using namespace smtk::model;
+
+namespace smtk {
+  namespace bridge {
+  namespace cgm {
+
+bool RemoveModel::ableToOperate()
+{
+  if(!this->ensureSpecification())
+    return false;
+  std::size_t numModels = this->associatedEntitiesAs<Models>().size();
+  return numModels > 0;
+}
+
+smtk::model::OperatorResult RemoveModel::operateInternal()
+{
+  // ableToOperate should have verified that model(s) are set
+  bool success = true;
+  EntityRefArray expunged;
+  Models remModels = this->associatedEntitiesAs<Models>();
+  for(Models::iterator it = remModels.begin();
+      it != remModels.end(); ++it)
+    {
+    success = this->cgmSession()->removeModelEntity(*it);
+    if(!success)
+      break;
+    expunged.push_back(*it);
+    }
+
+  OperatorResult result =
+    this->createResult(
+      success ?  OPERATION_SUCCEEDED : OPERATION_FAILED);
+
+  if (success)
+    result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
+  return result;
+}
+
+    }
+  } //namespace model
+} // namespace smtk
+
+#include "RemoveModel_xml.h"
+
+smtkImplementsModelOperator(
+  CGMSMTK_EXPORT,
+  smtk::bridge::cgm::RemoveModel,
+  cgm_remove_model,
+  "remove model",
+  RemoveModel_xml,
+  smtk::bridge::cgm::Session);

--- a/smtk/bridge/cgm/operators/RemoveModel.h
+++ b/smtk/bridge/cgm/operators/RemoveModel.h
@@ -16,7 +16,7 @@ namespace smtk {
   namespace bridge {
     namespace cgm {
 
-class CGMSMTK_EXPORT RemoveModel : public Operator
+class SMTKCGMSESSION_EXPORT RemoveModel : public Operator
 {
 public:
   smtkTypeMacro(RemoveModel);

--- a/smtk/bridge/cgm/operators/RemoveModel.h
+++ b/smtk/bridge/cgm/operators/RemoveModel.h
@@ -1,0 +1,38 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#ifndef __smtk_session_cgm_RemoveModel_h
+#define __smtk_session_cgm_RemoveModel_h
+
+#include "smtk/bridge/cgm/Operator.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace cgm {
+
+class CGMSMTK_EXPORT RemoveModel : public Operator
+{
+public:
+  smtkTypeMacro(RemoveModel);
+  smtkCreateMacro(RemoveModel);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+  virtual bool ableToOperate();
+
+protected:
+  virtual smtk::model::OperatorResult operateInternal();
+
+};
+
+    } //namespace cgm
+  } //namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_discrete_RemoveModel_h

--- a/smtk/bridge/cgm/operators/RemoveModel.sbt
+++ b/smtk/bridge/cgm/operators/RemoveModel.sbt
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the model "CloseModel" Operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="remove model" BaseType="operator" AdvanceLevel="11">
+      <AssociationsDef Name="model(s)" NumberOfRequiredValues="1" Extensible="true">
+        <MembershipMask>model</MembershipMask>
+      </AssociationsDef>
+    </AttDef>
+
+    <!-- Result -->
+    <AttDef Type="result(remove model)" BaseType="result">
+      <!-- The close models are stored in the base result's "expunged" item. -->
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeSystem>

--- a/smtk/bridge/discrete/CMakeLists.txt
+++ b/smtk/bridge/discrete/CMakeLists.txt
@@ -126,6 +126,7 @@ set(discreteSessionSrcs
   operators/SplitFaceOperator.cxx
   operators/GrowOperator.cxx
   operators/WriteOperator.cxx
+  operators/RemoveModel.cxx
 )
 
 set(discreteSessionHeaders
@@ -138,6 +139,7 @@ set(discreteSessionHeaders
   operators/SplitFaceOperator.h
   operators/GrowOperator.h
   operators/WriteOperator.h
+  operators/RemoveModel.h
 )
 
 # Normally this would be machine-generated from Session.json
@@ -157,6 +159,7 @@ smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/ImportOperator.sbt" uni
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/EntityGroupOperator.sbt" unitOperatorXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/GrowOperator.sbt" unitOperatorXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/WriteOperator.sbt" unitOperatorXML)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/RemoveModel.sbt" unitOperatorXML)
 
 add_library(smtkDiscreteSession ${_module_src} ${discreteSessionSrcs})
 

--- a/smtk/bridge/discrete/Session.h
+++ b/smtk/bridge/discrete/Session.h
@@ -121,6 +121,7 @@ protected:
   friend class GrowOperator;
   friend class CreateEdgesOperator;
   friend class WriteOperator;
+  friend class RemoveModel;
 
   Session();
 
@@ -163,6 +164,9 @@ protected:
 
   bool addTessellation(const smtk::model::EntityRef& cellOut, vtkModelGeometricEntity* cellIn);
   bool addProperties(smtk::model::EntityRef& cellOut, vtkModelItem* cellIn, smtk::model::BitFlags props = 0xff);
+
+  // This will remove Model from smtk manager and vtkDiscreteModelWrapper form kernel
+  bool removeModelEntity(const smtk::model::EntityRef& entity);
 
   vtkItemWatcherCommand* m_itemWatcher;
   smtk::common::UUIDGenerator m_idGenerator;

--- a/smtk/bridge/discrete/operators/RemoveModel.cxx
+++ b/smtk/bridge/discrete/operators/RemoveModel.cxx
@@ -1,0 +1,75 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/bridge/discrete/operators/RemoveModel.h"
+
+#include "smtk/bridge/discrete/Session.h"
+
+#include "smtk/model/Manager.h"
+#include "smtk/model/Model.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/ModelEntityItem.h"
+
+using namespace smtk::model;
+
+namespace smtk {
+  namespace bridge {
+  namespace discrete {
+
+bool RemoveModel::ableToOperate()
+{
+  if(!this->ensureSpecification())
+    return false;
+  std::size_t numModels = this->associatedEntitiesAs<Models>().size();
+  return numModels > 0;
+}
+
+smtk::model::OperatorResult RemoveModel::operateInternal()
+{
+  // ableToOperate should have verified that model(s) are set
+  bool success = true;
+  EntityRefArray expunged;
+  Models remModels = this->associatedEntitiesAs<Models>();
+  for(Models::iterator it = remModels.begin();
+      it != remModels.end(); ++it)
+    {
+    success = this->discreteSession()->removeModelEntity(*it);
+    if(!success)
+      break;
+    expunged.push_back(*it);
+    }
+
+  OperatorResult result =
+    this->createResult(
+      success ?  OPERATION_SUCCEEDED : OPERATION_FAILED);
+
+  if (success)
+    result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
+  return result;
+}
+
+Session* RemoveModel::discreteSession() const
+{
+  return dynamic_cast<Session*>(this->session());
+}
+
+    }
+  } //namespace model
+} // namespace smtk
+
+#include "RemoveModel_xml.h"
+
+smtkImplementsModelOperator(
+  SMTKDISCRETESESSION_EXPORT,
+  smtk::bridge::discrete::RemoveModel,
+  discrete_remove_model,
+  "remove model",
+  RemoveModel_xml,
+  smtk::bridge::discrete::Session);

--- a/smtk/bridge/discrete/operators/RemoveModel.h
+++ b/smtk/bridge/discrete/operators/RemoveModel.h
@@ -10,7 +10,7 @@
 #ifndef __smtk_session_discrete_RemoveModel_h
 #define __smtk_session_discrete_RemoveModel_h
 
-#include "smtk/bridge/discrete/discreteSessionExports.h"
+#include "smtk/bridge/discrete/Exports.h"
 #include "smtk/model/Operator.h"
 
 namespace smtk {

--- a/smtk/bridge/discrete/operators/RemoveModel.h
+++ b/smtk/bridge/discrete/operators/RemoveModel.h
@@ -1,0 +1,43 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#ifndef __smtk_session_discrete_RemoveModel_h
+#define __smtk_session_discrete_RemoveModel_h
+
+#include "smtk/bridge/discrete/discreteSessionExports.h"
+#include "smtk/model/Operator.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace discrete {
+
+class Session;
+
+class SMTKDISCRETESESSION_EXPORT RemoveModel : public smtk::model::Operator
+{
+public:
+  smtkTypeMacro(RemoveModel);
+  smtkCreateMacro(RemoveModel);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+  virtual bool ableToOperate();
+
+protected:
+  virtual smtk::model::OperatorResult operateInternal();
+
+  Session* discreteSession() const;
+
+};
+
+    }
+  } //namespace model
+} // namespace smtk
+
+#endif // __smtk_session_discrete_RemoveModel_h

--- a/smtk/bridge/discrete/operators/RemoveModel.sbt
+++ b/smtk/bridge/discrete/operators/RemoveModel.sbt
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the model "CloseModel" Operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="remove model" BaseType="operator" AdvanceLevel="11">
+      <AssociationsDef Name="model(s)" NumberOfRequiredValues="1" Extensible="true">
+        <MembershipMask>model</MembershipMask>
+      </AssociationsDef>
+    </AttDef>
+
+    <!-- Result -->
+    <AttDef Type="result(remove model)" BaseType="result">
+      <!-- The close models are stored in the base result's "expunged" item. -->
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeSystem>

--- a/smtk/extension/qt/qtModelOperationWidget.cxx
+++ b/smtk/extension/qt/qtModelOperationWidget.cxx
@@ -145,7 +145,7 @@ void qtModelOperationWidget::setSession(smtk::model::SessionPtr session)
   this->Internals->OperationCombo->clear();
   if(session)
     {
-    StringList opNames = session->operatorNames();
+    StringList opNames = session->operatorNames(false);
     std::sort(opNames.begin(), opNames.end());
     for(StringList::const_iterator it = opNames.begin();
         it != opNames.end(); ++it)
@@ -203,7 +203,7 @@ bool qtModelOperationWidget::setCurrentOperation(
 
   if(brOp->name() != this->Internals->OperationCombo->currentText().toStdString())
     {
-    StringList opNames = brOp->session()->operatorNames();
+    StringList opNames = brOp->session()->operatorNames(false);
     std::sort(opNames.begin(), opNames.end());
     int idx = std::find(opNames.begin(), opNames.end(), brOp->name()) - opNames.begin();
     this->Internals->OperationCombo->blockSignals(true);
@@ -221,7 +221,7 @@ bool qtModelOperationWidget::setCurrentOperation(
   if(!session)
     return false;
 
-  StringList opNames = session->operatorNames();
+  StringList opNames = session->operatorNames(false);
   std::sort(opNames.begin(), opNames.end());
   int idx = std::find(opNames.begin(), opNames.end(), opName) - opNames.begin();
   if(this->Internals->OperationCombo->currentIndex() != idx)

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -694,7 +694,7 @@ void qtModelView::showContextMenu(const QPoint &p)
   if ((brSession =
     this->owningEntityAs<smtk::model::SessionRef>(idx)).isValid())
     {
-    StringList opNames = brSession.operatorNames();
+    StringList opNames = brSession.operatorNames(false);
     std::sort(opNames.begin(), opNames.end()); 
     for(StringList::const_iterator it = opNames.begin();
         it != opNames.end(); ++it)

--- a/smtk/model/CMakeLists.txt
+++ b/smtk/model/CMakeLists.txt
@@ -42,6 +42,7 @@ set(modelSrcs
   VertexUse.cxx
   Volume.cxx
   VolumeUse.cxx
+  operators/CloseModel.cxx
   operators/SetProperty.cxx
   )
 
@@ -95,10 +96,12 @@ set(modelHeaders
   VertexUse.h
   Volume.h
   VolumeUse.h
+  operators/CloseModel.h
   operators/SetProperty.h
   )
 
 smtk_session_json("${CMAKE_CURRENT_SOURCE_DIR}/DefaultSession.json" defSessionJSON)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/CloseModel.sbt" defOpXML)
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/SetProperty.sbt" defOpXML)
 
 #install the headers

--- a/smtk/model/Session.cxx
+++ b/smtk/model/Session.cxx
@@ -124,7 +124,7 @@ SessionInfoBits Session::allSupportedInformation() const
 }
 
 /// Return a list of names of solid-model operators available.
-StringList Session::operatorNames() const
+StringList Session::operatorNames(bool includeAdvanced) const
 {
   std::vector<smtk::attribute::DefinitionPtr> ops;
   this->m_operatorSys->derivedDefinitions(
@@ -133,7 +133,12 @@ StringList Session::operatorNames() const
   StringList nameList;
   std::vector<smtk::attribute::DefinitionPtr>::iterator it;
   for (it = ops.begin(); it != ops.end(); ++it)
+    {
+    // only show operators that are not advanced
+    if(!includeAdvanced && (*it)->advanceLevel() > 0)
+      continue;
     nameList.push_back((*it)->type());
+    }    
   return nameList;
 }
 

--- a/smtk/model/Session.h
+++ b/smtk/model/Session.h
@@ -308,7 +308,7 @@ public:
 
   virtual SessionInfoBits allSupportedInformation() const;
 
-  StringList operatorNames() const;
+  StringList operatorNames(bool includeAdvanced = true) const;
   virtual OperatorPtr op(const std::string& opName) const;
 
   const DanglingEntities& danglingEntities() const;

--- a/smtk/model/SessionRef.cxx
+++ b/smtk/model/SessionRef.cxx
@@ -51,12 +51,12 @@ Session::Ptr SessionRef::session() const
 /**\brief Return the list of operations this session supports.
   *
   */
-StringList SessionRef::operatorNames() const
+StringList SessionRef::operatorNames(bool includeAdvanced) const
 {
   Session::Ptr brdg = this->session();
   if (!brdg)
     return StringList();
-  return brdg->operatorNames();
+  return brdg->operatorNames(includeAdvanced);
 }
 
 /**\brief Return the smtk::attribute::System holding all the operator definitions.

--- a/smtk/model/SessionRef.h
+++ b/smtk/model/SessionRef.h
@@ -33,7 +33,7 @@ public:
 
   template<typename T> T models() const;
 
-  StringList operatorNames() const;
+  StringList operatorNames(bool includeAdvanced = true) const;
   smtk::attribute::System* opSys() const;
   OperatorDefinition opDef(const std::string& opName) const;
   OperatorPtr op(const std::string& opName) const;

--- a/smtk/model/operators/CloseModel.cxx
+++ b/smtk/model/operators/CloseModel.cxx
@@ -1,0 +1,73 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/model/operators/CloseModel.h"
+
+#include "smtk/model/Session.h"
+
+#include "smtk/model/CellEntity.h"
+#include "smtk/model/Manager.h"
+#include "smtk/model/Model.h"
+#include "smtk/model/Session.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/ModelEntityItem.h"
+
+using namespace smtk::model;
+
+namespace smtk {
+  namespace model {
+
+bool CloseModel::ableToOperate()
+{
+  if(!this->ensureSpecification())
+    return false;
+  smtk::attribute::ModelEntityItem::Ptr modelItem =
+    this->specification()->findModelEntity("model");
+  return modelItem && modelItem->numberOfValues() > 0;
+}
+
+smtk::model::OperatorResult CloseModel::operateInternal()
+{
+  // ableToOperate should have verified that model(s) are set
+  smtk::attribute::ModelEntityItem::Ptr modelItem =
+    this->specification()->findModelEntity("model");
+  EntityRefArray expunged;
+  bool success = true;
+  for (EntityRefArray::const_iterator mit = modelItem->begin();
+    mit != modelItem->end(); ++mit)
+    {
+    if(!this->manager()->eraseModel(*mit))
+      {
+      success = false;
+      break;
+      }
+    expunged.push_back(*mit);
+    }
+
+  OperatorResult result =
+    this->createResult(
+      success ?  OPERATION_SUCCEEDED : OPERATION_FAILED);
+
+  if (success)
+    result->findModelEntity("expunged")->setValues(expunged.begin(), expunged.end());
+  return result;
+}
+
+  } //namespace model
+} // namespace smtk
+
+#include "smtk/model/CloseModel_xml.h"
+
+smtkImplementsModelOperator(
+  smtk::model::CloseModel,
+  close_model,
+  "close model",
+  CloseModel_xml,
+  smtk::model::Session);

--- a/smtk/model/operators/CloseModel.cxx
+++ b/smtk/model/operators/CloseModel.cxx
@@ -38,6 +38,16 @@ smtk::model::OperatorResult CloseModel::operateInternal()
   // ableToOperate should have verified that model(s) are set
   smtk::attribute::ModelEntityItem::Ptr modelItem =
     this->specification()->findModelEntity("model");
+
+  smtk::model::OperatorPtr removeModel = this->session()->op("remove model");
+  if(removeModel)
+    {
+    for (EntityRefArray::const_iterator mit = modelItem->begin();
+      mit != modelItem->end(); ++mit)
+      removeModel->specification()->associateEntity(*mit);
+    return removeModel->operate();
+    }
+
   EntityRefArray expunged;
   bool success = true;
   for (EntityRefArray::const_iterator mit = modelItem->begin();

--- a/smtk/model/operators/CloseModel.cxx
+++ b/smtk/model/operators/CloseModel.cxx
@@ -66,6 +66,7 @@ smtk::model::OperatorResult CloseModel::operateInternal()
 #include "smtk/model/CloseModel_xml.h"
 
 smtkImplementsModelOperator(
+  SMTKCORE_EXPORT,
   smtk::model::CloseModel,
   close_model,
   "close model",

--- a/smtk/model/operators/CloseModel.h
+++ b/smtk/model/operators/CloseModel.h
@@ -1,0 +1,35 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#ifndef __smtk_model_CloseModel_h
+#define __smtk_model_CloseModel_h
+
+#include "smtk/model/Operator.h"
+
+namespace smtk {
+  namespace model {
+
+class SMTKCORE_EXPORT CloseModel : public Operator
+{
+public:
+  smtkTypeMacro(CloseModel);
+  smtkCreateMacro(CloseModel);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+  virtual bool ableToOperate();
+
+protected:
+  virtual smtk::model::OperatorResult operateInternal();
+};
+
+  } //namespace model
+} // namespace smtk
+
+#endif // __smtk_model_CloseModel_h

--- a/smtk/model/operators/CloseModel.sbt
+++ b/smtk/model/operators/CloseModel.sbt
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the model "SetProperty" Operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="close model" BaseType="operator">
+      <ItemDefinitions>
+        <ModelEntity Name="model" NumberOfRequiredValues="0" Extensible="true">
+          <MembershipMask>model</MembershipMask>
+        </ModelEntity>
+      </ItemDefinitions>
+    </AttDef>
+
+    <!-- Result -->
+    <AttDef Type="result(close model)" BaseType="result">
+      <!-- The expunged entities are stored in the base result's "modified" item. -->
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeSystem>

--- a/smtk/model/operators/CloseModel.sbt
+++ b/smtk/model/operators/CloseModel.sbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Description of the model "SetProperty" Operator -->
+<!-- Description of the model "CloseModel" Operator -->
 <SMTK_AttributeSystem Version="2">
   <Definitions>
     <!-- Operator -->
@@ -13,7 +13,7 @@
 
     <!-- Result -->
     <AttDef Type="result(close model)" BaseType="result">
-      <!-- The expunged entities are stored in the base result's "modified" item. -->
+      <!-- The close models are stored in the base result's "expunged" item. -->
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/model/testing/python/CMakeLists.txt
+++ b/smtk/model/testing/python/CMakeLists.txt
@@ -8,6 +8,7 @@ set(smtkModelPythonTests
 set(smtkModelPythonDataTests
   modelAttributes
   modelSetPropertyOp
+  modelCloseModelOp
 )
 
 # Additional tests that require specific bridges

--- a/smtk/model/testing/python/modelCloseModelOp.py
+++ b/smtk/model/testing/python/modelCloseModelOp.py
@@ -1,0 +1,65 @@
+#=============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+#=============================================================================
+"""
+Try running a "universal" operator on an imported model.
+"""
+
+import os
+import sys
+import smtk
+import smtk.testing
+from uuid import uuid4
+import unittest
+
+class TestModelCloseModelOp(unittest.TestCase):
+
+  def testCloseModelOp(self):
+    model_path = os.path.join(smtk.testing.DATA_DIR, 'smtk', 'pyramid.json')
+    print 'Loading %s' % model_path
+
+    status = 0
+    mgr = smtk.model.Manager.create()
+    session = mgr.createSession('native', smtk.model.SessionRef())
+    json = None
+    with open(model_path, 'r') as f:
+      json = f.read()
+
+    self.assertTrue(not json == None, 'Unable to load input file')
+    self.assertTrue(smtk.io.ImportJSON.intoModelManager(json, mgr), 'Unable to parse JSON input file')
+
+    mgr.assignDefaultNames()
+    models = mgr.findEntitiesOfType(smtk.model.MODEL_ENTITY, True)
+    # Assign imported models to current session so they have operators
+    [smtk.model.Model(x).setSession(session) for x in models]
+    print 'Applying operator to %d model(s)' % len(models)
+
+    op = smtk.model.Model(models[0]).op('close model')
+    op.findAsModelEntity('model').setNumberOfValues(1)
+    op.findAsModelEntity('model').setValue(models[0])
+
+    result = op.operate()
+    self.assertEqual(
+        result.findInt('outcome').value(0),
+        smtk.model.OPERATION_SUCCEEDED,
+        'close model operator failed')
+    print 'Checking models'
+    for x in mgr.findEntitiesOfType(smtk.model.MODEL_ENTITY, True):
+      if x.entity().toString() == models[0].entity().toString():
+        print 'Closing %s has failed ' % x.name()
+        status = 1
+        break
+
+    print 'Done'
+
+if __name__ == '__main__':
+  smtk.testing.process_arguments()
+  unittest.main()

--- a/smtk/smtk/simple.py
+++ b/smtk/smtk/simple.py
@@ -443,3 +443,17 @@ def Write(filename, entities = [], **kwargs):
   res = wri.operate()
   PrintResultLog(res)
   return res.findInt('outcome').value(0)
+
+def CloseModel(models = [], **kwargs):
+  """Close a set of models using "close model" operator, which invokes "remove model"
+  in the session internally if the session has it.
+  """
+  sref = GetActiveSession()
+  closeop = sref.op('close model')
+  moditem = closeop.findAsModelEntity('model');
+  SetVectorValue(moditem, models)
+
+  res = closeop.operate()
+  PrintResultLog(res)
+
+  return res


### PR DESCRIPTION
Adding capability to close models individually in sessions. This includes removing the model related records from smtk and the actual model from the modeling kernel.