### PR TITLE
Sessions should never modify

### DIFF
--- a/smtk/bridge/cgm/Engines.cxx
+++ b/smtk/bridge/cgm/Engines.cxx
@@ -265,15 +265,6 @@ bool Engines::shutdown()
   return true;
 }
 
-bool Engines::removeBody(Body* body)
-{
-  if(!body)
-    return false;
-  if (GeometryQueryTool::instance())
-    return (GeometryQueryTool::instance()->delete_Body(body) == CUBIT_SUCCESS);
-  return false;
-}
-
-} // namespace cgm
+    } // namespace cgm
   } //namespace bridge
 } // namespace smtk

--- a/smtk/bridge/cgm/Engines.h
+++ b/smtk/bridge/cgm/Engines.h
@@ -45,7 +45,6 @@ public:
   static std::vector<std::string> listEngines();
 
   static bool shutdown();
-  static bool removeBody(Body* body);
 };
 
     } // namespace cgm

--- a/smtk/bridge/cgm/Session.cxx
+++ b/smtk/bridge/cgm/Session.cxx
@@ -320,20 +320,6 @@ smtk::model::SessionInfoBits Session::addCGMEntityToManager(
   return 0;
 }
 
-/**\brief remove a model entity \a entityref that reflect the CGM body.
-  *
-  */
-bool Session::removeModelEntity(
-  const smtk::model::EntityRef& entityref)
-{
-  ToolDataUser* tdu = TDUUID::findEntityById(entityref.entity());
-  Body* body = dynamic_cast<Body*>(tdu);
-  if (body && Engines::removeBody(body))
-    return this->manager()->eraseModel(entityref);
-
-  return false;
-}
-
 /// Given a CGM \a body tagged with \a uid, create a record in \a modelManager for it.
 smtk::model::SessionInfoBits Session::addBodyToManager(
   const smtk::model::Model& entityref,

--- a/smtk/bridge/cgm/Session.h
+++ b/smtk/bridge/cgm/Session.h
@@ -79,7 +79,6 @@ protected:
 
   virtual SessionInfoBits transcribeInternal(
     const smtk::model::EntityRef& entity, SessionInfoBits requestedInfo);
-  virtual bool removeModelEntity(const smtk::model::EntityRef& entity);
 
   SessionInfoBits addCGMEntityToManager(const smtk::model::EntityRef& entity, RefEntity* refEnt, SessionInfoBits requestedInfo);
   SessionInfoBits addCGMEntityToManager(const smtk::model::EntityRef& entity, GroupingEntity* refEnt, SessionInfoBits requestedInfo);

--- a/smtk/model/testing/python/modelCloseModelOp.py
+++ b/smtk/model/testing/python/modelCloseModelOp.py
@@ -29,6 +29,7 @@ class TestModelCloseModelOp(unittest.TestCase):
     SetActiveSession(actSession)
 
     models = None
+    print 'Reading {fname} into {sname}'.format(fname=filename, sname=sessionname)
     # The 'native' session does not have a "read" op
     if sessionname == 'native':
       json = None
@@ -55,15 +56,7 @@ class TestModelCloseModelOp(unittest.TestCase):
     remModels = GetVectorValue(result.findModelEntity('expunged'))
 
     print '%d models closed.' % len(remModels)
-
-    allclosed = True
-    for x in actMgr.findEntitiesOfType(smtk.model.MODEL_ENTITY, True):
-      for rModel in remModels:
-        if x.entity().toString() == rModel.entity().toString():
-          print 'Closing %s has failed ' % x.name()
-          allclosed = False
-
-    return allclosed
+    self.assertEqual(len(models), len(remModels), 'Not all models marked as removed')
 
   def testCloseModelOp(self):
 


### PR DESCRIPTION
This removes methods from the CGM Session and Engine classes that modify modeling entities. Only subclasses of the Operator class should do that.

This also fixes the Python unit test in the event of a failure.