### PR TITLE
Switch tess

### DIFF
--- a/doc/tutorials/debugging_python_tests/debug.py
+++ b/doc/tutorials/debugging_python_tests/debug.py
@@ -2,9 +2,8 @@
 Verify that our documentation on running unit tests in the interpreter is correct.
 """
 import smtk.testing
-import unittest
 
-class DebugAPythonTest(unittest.TestCase):
+class DebugAPythonTest(smtk.testing.TestCase):
 
     def testDebugReadFile(self):
         import smtk.testing
@@ -37,4 +36,4 @@ class DebugAPythonTest(unittest.TestCase):
 
 if __name__ == '__main__':
   smtk.testing.process_arguments()
-  unittest.main()
+  smtk.testing.main()

--- a/doc/tutorials/debugging_python_tests/index.rst
+++ b/doc/tutorials/debugging_python_tests/index.rst
@@ -31,7 +31,8 @@ For this tutorial, we'll assume the SMTK source is in :file:`/src`.
 Instantiate the test
 ====================
 
-Normally a test is derived from Python's `unittest.TestCase` class,
+Normally a test is derived from `smtk.testing.TestCase` (in turn
+derived from Python's `unittest.TestCase` class),
 whose constructor requires a string argument specifying the name of
 a single test to run.
 Since we want to run the `readTest` method in the interpreter, we'll

--- a/doc/userguide/contributing.rst
+++ b/doc/userguide/contributing.rst
@@ -34,7 +34,7 @@ With that in mind:
   * simulation — aids to exporting simulation input decks in the smtkCore library
   * io — file and string I/O in the smtkCore library, a mix of XML and JSON
   * view — source for providing views of attributes and models in the smtkCore library
-  * session — source for additional libraries that session solid modeling kernels into SMTK
+  * bridge — source for additional libraries that bridge solid modeling kernels into SMTK
   * extensions — source for additional libraries that expose SMTK to other software
 
     * qt — widgets that allow presentation and editing of SMTK models and attributes
@@ -49,8 +49,8 @@ With that in mind:
 * utilities — scripts to aid in the development of SMTK
 
 
-Inside :file:`smtk/`, subdirectories, there are :file:`testing/` and :file:`pythonTesting` directories
-to hold C++ and Python tests, respectively.
+Inside :file:`smtk/`, subdirectories, there are :file:`testing/` directories that
+hold :file:`python/` and :file:`cxx/` directories for Python and C++ tests, respectively.
 
 Code style
 ==========

--- a/smtk/bridge/cgm/testing/python/cgmBooleans.py
+++ b/smtk/bridge/cgm/testing/python/cgmBooleans.py
@@ -13,42 +13,73 @@ import sys
 #=============================================================================
 import smtk
 from smtk.simple import *
+import smtk.testing
 
-mgr = smtk.model.Manager.create()
-sess = mgr.createSession('cgm')
-brg = sess.session()
-print sess
-print brg
-sess.assignDefaultName()
-SetActiveSession(sess)
-print '\n\n%s: type "%s" %s %s' % \
-  (sess.name(), brg.name(), sess.flagSummary(0), brg.sessionId())
-print '  Site: %s' % (sess.site() or 'local')
+class TestCGMBooleans(smtk.testing.TestCase):
 
-# We could evaluate the session tag as JSON, but most of
-# the information is available through methods above that
-# we needed to test:
-sessiontag = sess.tag()
-print '\n'
+  def setUp(self):
+    self.writeJSON = False
+    self.mgr = smtk.model.Manager.create()
+    sess = self.mgr.createSession('cgm')
+    brg = sess.session()
+    print sess
+    print brg
+    sess.assignDefaultName()
+    SetActiveSession(sess)
+    print '\n\n%s: type "%s" %s %s' % \
+      (sess.name(), brg.name(), sess.flagSummary(0), brg.sessionId())
+    print '  Site: %s' % (sess.site() or 'local')
 
-opnames = sess.operatorNames()
+    # We could evaluate the session tag as JSON, but most of
+    # the information is available through methods above that
+    # we needed to test:
+    sessiontag = sess.tag()
+    print '\n'
 
-b0 = CreateBrick(center=[0,0,0])
-Translate(b0, [0, 1.5, 0])
-s0 = CreateSphere(center=[0.5,2.0,0.5], radius=0.5)
-bsuni = Union(bodies=[b0, s0])
+    opnames = sess.operatorNames()
 
-b0 = CreateBrick(center=[0,0,0])
-s0 = CreateSphere(center=[0.5,0.5,0.5], radius=0.5)
-bsint = Intersect(bodies=[b0, s0])
+  def testBooleans(self):
+    b0 = CreateBrick(center=[0,0,0])
+    Translate(b0, [0, 1.5, 0])
+    s0 = CreateSphere(center=[0.5,2.0,0.5], radius=0.5)
+    bsuni = Union(bodies=[b0, s0])
 
-b0 = CreateBrick(center=[0,0,0])
-s0 = CreateSphere(center=[0.5,0.5,0.5], radius=0.5)
-bssub = Subtract(workpiece=b0, tool=s0)
+    b0 = CreateBrick(center=[0,0,0])
+    s0 = CreateSphere(center=[0.5,0.5,0.5], radius=0.5)
+    bsint = Intersect(bodies=[b0, s0])
 
-Translate(bsint, [0.1, 0.1, 0.1])
+    b0 = CreateBrick(center=[0,0,0])
+    s0 = CreateSphere(center=[0.5,0.5,0.5], radius=0.5)
+    bssub = Subtract(workpiece=b0, tool=s0)
 
-json = smtk.io.ExportJSON.fromModelManager(mgr)
-sphFile = open('boolean.json', 'w')
-print >> sphFile, json
-sphFile.close()
+    Translate(bsint, [0.1, 0.1, 0.1])
+
+    if self.haveVTK() and self.haveVTKExtension():
+
+      self.startRenderTest()
+
+      self.addModelToScene(bsuni)
+      self.addModelToScene(bsint)
+      self.addModelToScene(bssub)
+
+      cam = self.renderer.GetActiveCamera()
+      cam.SetFocalPoint(0.125, 0.7, -0.1)
+      cam.SetPosition(2,-1,1)
+      cam.SetViewUp(-1,1,1)
+      self.renderer.ResetCamera()
+      self.renderWindow.Render()
+      # Skip the image match if we don't have a baseline.
+      # This allows the test to succeed even on systems without the test
+      # data but requires a match on systems with the test data.
+      self.assertImageMatchIfFileExists(['baselines', 'cgm', 'booleans.png'])
+      self.interact()
+
+    if self.writeJSON:
+      json = smtk.io.ExportJSON.fromModelManager(self.mgr)
+      sphFile = open('boolean.json', 'w')
+      print >> sphFile, json
+      sphFile.close()
+
+if __name__ == '__main__':
+  smtk.testing.process_arguments()
+  smtk.testing.main()

--- a/smtk/extension/vtk/testing/CMakeLists.txt
+++ b/smtk/extension/vtk/testing/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_subdirectory(cxx)
+
+if(SMTK_ENABLE_PYTHON_WRAPPING AND Shiboken_FOUND)
+  add_subdirectory(python)
+endif()

--- a/smtk/extension/vtk/testing/python/CMakeLists.txt
+++ b/smtk/extension/vtk/testing/python/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(smtkVTKExtPythonTests
+)
+
+# Additional tests that require SMTK_DATA_DIR
+set(smtkVTKExtPythonDataTests
+  displayAnalysisMesh
+)
+
+foreach (test ${smtkVTKExtPythonTests})
+  add_test(${test}Py ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py)
+  set_tests_properties(${test}Py
+    PROPERTIES
+      ENVIRONMENT "PYTHONPATH=${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
+  )
+endforeach()
+
+if (SMTK_DATA_DIR AND EXISTS ${SMTK_DATA_DIR}/ReadMe.mkd)
+  foreach (test ${smtkVTKExtPythonDataTests})
+    add_test(${test}Py
+             ${PYTHON_EXECUTABLE}
+             ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py
+             --data-dir=${SMTK_DATA_DIR})
+    set_tests_properties(${test}Py
+      PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
+    )
+  endforeach()
+endif()

--- a/smtk/extension/vtk/testing/python/displayAnalysisMesh.py
+++ b/smtk/extension/vtk/testing/python/displayAnalysisMesh.py
@@ -50,19 +50,6 @@ class TestDisplayAnalysisMesh(smtk.testing.TestCase):
       self.assertEqual(dtessGen, dgen, 'Unexpected display tessellation generation {dg}'.format(dg=dtessGen))
       self.assertEqual(ameshGen, agen, 'Unexpected analyis mesh generation {ag}'.format(ag=ameshGen))
 
-    def placeInScene(self, msource, **kwargs):
-      tf = vtkTransformFilter()
-      tf.SetTransform(vtkTransform())
-      if 'translate' in kwargs:
-        delta = kwargs['translate']
-        tf.GetTransform().Translate(delta[0], delta[1], delta[2])
-      tf.SetInputConnection(msource.GetOutputPort())
-      ac = vtkActor()
-      mp = vtkCompositePolyDataMapper()
-      ac.SetMapper(mp)
-      mp.SetInputConnection(tf.GetOutputPort())
-      self.renderer.AddActor(ac)
-
     def testSetTessellations(self):
       """Verify that tessellation generation numbers are updated."""
       self.createTessellations(0,0)
@@ -83,8 +70,8 @@ class TestDisplayAnalysisMesh(smtk.testing.TestCase):
       mbs2.ShowAnalysisTessellationOn()
 
       self.startRenderTest()
-      self.placeInScene(mbs1, translate=(-1.5, 0, 0))
-      self.placeInScene(mbs2, translate=(+1.5, 0, 0))
+      self.addToScene(mbs1, translate=(-1.5, 0, 0))
+      self.addToScene(mbs2, translate=(+1.5, 0, 0))
 
       self.renderer.ResetCamera()
       self.renderWindow.Render()
@@ -101,7 +88,7 @@ class TestDisplayAnalysisMesh(smtk.testing.TestCase):
       mbs.ShowAnalysisTessellationOff()
 
       self.startRenderTest()
-      self.placeInScene(mbs)
+      self.addToScene(mbs)
 
       self.renderer.ResetCamera()
       self.renderWindow.Render()

--- a/smtk/extension/vtk/testing/python/displayAnalysisMesh.py
+++ b/smtk/extension/vtk/testing/python/displayAnalysisMesh.py
@@ -1,0 +1,122 @@
+#=============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+#=============================================================================
+
+import os
+import sys
+import smtk
+from smtk.simple import *
+import smtk.testing
+import unittest
+try:
+    from vtkSMTKExtPython import *
+    from vtk import *
+except:
+    pass
+
+class TestDisplayAnalysisMesh(smtk.testing.TestCase):
+    """
+    Create a face with both an analysis and a display tessellation; verify that
+    the multiblock source can display both and that switching the source between
+    the two tessellations works as expected.
+    """
+
+    def setUp(self):
+      self.mgr = smtk.model.Manager.create()
+      sref = self.mgr.createSession('native')
+      SetActiveSession(sref)
+      self.face = self.mgr.addFace()
+      self.model = self.mgr.addModel(3, 3, 'Simple face')
+      self.model.setSession(sref)
+      self.model.addCell(self.face)
+
+    def createTessellations(self, dgen, agen):
+      dtess = smtk.model.Tessellation()
+      amesh = smtk.model.Tessellation()
+      [dtess.addCoords(x[0], x[1], x[2]) for x in [(0,0,0), (2,0,0), (2,2,0), (0,2,0)]]
+      [dtess.addTriangle(ii[0], ii[1], ii[2]) for ii in [(0,1,2), (0,2,3)]]
+      [amesh.addCoords(x[0], x[1], x[2]) for x in [(0,0,0), (1,0.5,0),  (2,0,0), (2,2,0), (1,1.5,0), (0,2,0)]]
+      [amesh.addTriangle(ii[0], ii[1], ii[2]) for ii in [(0,1,4), (0,4,5), (1,2,3), (1,3,4)]]
+      dtessGen = self.face.setTessellation(dtess, 0)
+      ameshGen = self.face.setTessellation(amesh, 1)
+      self.assertEqual(dtessGen, dgen, 'Unexpected display tessellation generation {dg}'.format(dg=dtessGen))
+      self.assertEqual(ameshGen, agen, 'Unexpected analyis mesh generation {ag}'.format(ag=ameshGen))
+
+    def placeInScene(self, msource, **kwargs):
+      tf = vtkTransformFilter()
+      tf.SetTransform(vtkTransform())
+      if 'translate' in kwargs:
+        delta = kwargs['translate']
+        tf.GetTransform().Translate(delta[0], delta[1], delta[2])
+      tf.SetInputConnection(msource.GetOutputPort())
+      ac = vtkActor()
+      mp = vtkCompositePolyDataMapper()
+      ac.SetMapper(mp)
+      mp.SetInputConnection(tf.GetOutputPort())
+      self.renderer.AddActor(ac)
+
+    def testSetTessellations(self):
+      """Verify that tessellation generation numbers are updated."""
+      self.createTessellations(0,0)
+      self.createTessellations(1,1)
+
+    def testDisplayBoth(self):
+      "Draw both tessellations."
+      self.createTessellations(0,0)
+
+      mbs1 = vtkModelMultiBlockSource()
+      mbs1.SetModelManager(self.mgr.pointerAsString())
+      mbs1.SetModelEntityID(str(self.model.entity()))
+      mbs1.ShowAnalysisTessellationOff()
+
+      mbs2 = vtkModelMultiBlockSource()
+      mbs2.SetModelManager(self.mgr.pointerAsString())
+      mbs2.SetModelEntityID(str(self.model.entity()))
+      mbs2.ShowAnalysisTessellationOn()
+
+      self.startRenderTest()
+      self.placeInScene(mbs1, translate=(-1.5, 0, 0))
+      self.placeInScene(mbs2, translate=(+1.5, 0, 0))
+
+      self.renderer.ResetCamera()
+      self.renderWindow.Render()
+      self.assertImageMatch(['baselines', 'vtk', 'both-tess.png'])
+      self.interact()
+
+    def testSwitchingTessellations(self):
+      """Verify that switching tessellations regenerates the VTK source's output."""
+      self.createTessellations(0,0)
+
+      mbs = vtkModelMultiBlockSource()
+      mbs.SetModelManager(self.mgr.pointerAsString())
+      mbs.SetModelEntityID(str(self.model.entity()))
+      mbs.ShowAnalysisTessellationOff()
+
+      self.startRenderTest()
+      self.placeInScene(mbs)
+
+      self.renderer.ResetCamera()
+      self.renderWindow.Render()
+
+      mbs.ShowAnalysisTessellationOn()
+      self.renderWindow.Render()
+      self.assertImageMatch(['baselines', 'vtk', 'analysis-tess.png'])
+      self.interact()
+
+      mbs.ShowAnalysisTessellationOff()
+      self.renderWindow.Render()
+      self.assertImageMatch(['baselines', 'vtk', 'display-tess.png'])
+      self.interact()
+
+
+if __name__ == '__main__':
+  smtk.testing.process_arguments()
+  unittest.main()

--- a/smtk/extension/vtk/vtkModelMultiBlockSource.cxx
+++ b/smtk/extension/vtk/vtkModelMultiBlockSource.cxx
@@ -54,12 +54,24 @@ vtkModelMultiBlockSource::vtkModelMultiBlockSource()
     }
   this->ModelEntityID = NULL;
   this->AllowNormalGeneration = 0;
+  this->ShowAnalysisTessellation = 0;
 }
 
 vtkModelMultiBlockSource::~vtkModelMultiBlockSource()
 {
   this->SetCachedOutput(NULL);
   this->SetModelEntityID(NULL);
+}
+
+void vtkModelMultiBlockSource::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  os << indent << "Model: " << this->ModelMgr.get() << "\n";
+  os << indent << "CachedOutput: " << this->CachedOutput << "\n";
+  os << indent << "ModelEntityID: " << this->ModelEntityID << "\n";
+  os << indent << "AllowNormalGeneration: " << (this->AllowNormalGeneration ? "ON" : "OFF") << "\n";
+  os << indent << "ShowAnalysisTessellation: " << this->ShowAnalysisTessellation << "\n";
 }
 
 /**\brief For Python users, this method is the only way to bridge VTK and SMTK wrappings.
@@ -104,16 +116,6 @@ void vtkModelMultiBlockSource::SetModelManager(const char* pointerAsString)
     {
     vtkWarningMacro("Not setting model manager, errno = " << errno);
     }
-}
-
-void vtkModelMultiBlockSource::PrintSelf(ostream& os, vtkIndent indent)
-{
-  this->Superclass::PrintSelf(os, indent);
-
-  os << indent << "Model: " << this->ModelMgr.get() << "\n";
-  os << indent << "CachedOutput: " << this->CachedOutput << "\n";
-  os << indent << "ModelEntityID: " << this->ModelEntityID << "\n";
-  os << indent << "AllowNormalGeneration: " << this->AllowNormalGeneration << "\n";
 }
 
 /// Set the SMTK model to be displayed.
@@ -171,7 +173,7 @@ void vtkModelMultiBlockSource::Dirty()
  * This color will be assigned to each cell of each block for entities
  * that do not provide a color float-property.
  *
- * Setting the alhpa component of the default color to a
+ * Setting the alpha component of the default color to a
  * negative number will turn off per-cell color array generation
  * to save space.
  *
@@ -183,19 +185,46 @@ void vtkModelMultiBlockSource::Dirty()
  * This color will be assigned to each cell of each block for entities
  * that do not provide a color float-property.
  *
- * Setting the alhpa component of the default color to a
+ * Setting the alpha component of the default color to a
  * negative number will turn off per-cell color array generation
  * to save space.
  *
  * \sa vtkModelMultiBlockSource::GetDefaultColor
  */
 
+/*! \fn vtkModelMultiBlockSource::GetShowAnalysisTessellation()
+ *  \brief Get which tessellation to output.
+ *
+ * The default value is 0 (output the "display" tessellation, which
+ * is not suitable for analysis but generally fast to compute).
+ * A non-zero value indicates the analysis tessellation will be
+ * output if present. If not present, then the display tessellation
+ * will be output.
+ */
+
+/*! \fn vtkModelMultiBlockSource::SetShowAnalysisTessellation(int tess)
+ *  \brief Set which tessellation to output.
+ *
+ * Setting this to a non-zero value will cause the
+ * analysis tessellation (if present) to be output.
+ * Otherwise, the display tessellation is output.
+ *
+ *  \fn vtkModelMultiBlockSource::ShowAnalysisTessellationOn()
+ *  \brief Request the analysis tessellation be shown.
+ *
+ *  \fn vtkModelMultiBlockSource::ShowAnalysisTessellationOff()
+ *  \brief Request the display tessellation be shown.
+ */
+
 static void AddEntityTessToPolyData(
-  const smtk::model::EntityRef& entityref, vtkPoints* pts, vtkPolyData* pd)
+  const smtk::model::EntityRef& entityref, vtkPoints* pts, vtkPolyData* pd,
+  int showAnalysisTessellation)
 {
-  //gotMesh will get Analsyis mesh if it exists, and will fall back
-  //to model tessellation if not.
-  const smtk::model::Tessellation* tess = entityref.gotMesh();
+  // gotMesh fetches Analysis mesh if it exists, falling back
+  // to model tessellation if not.
+  const smtk::model::Tessellation* tess = showAnalysisTessellation ?
+    entityref.gotMesh() :
+    entityref.hasTessellation();
   if (!tess)
     return;
 
@@ -355,7 +384,8 @@ void vtkModelMultiBlockSource::GenerateRepresentationFromModel(
   smtk::model::Entity* entity;
   if (entityref.isValid(&entity))
     {
-    AddEntityTessToPolyData(entityref, pts.GetPointer(), pd);
+    AddEntityTessToPolyData(
+      entityref, pts.GetPointer(), pd, this->ShowAnalysisTessellation);
     // Only create the color array if there is a valid default:
     if (this->DefaultColor[3] >= 0.)
       {
@@ -525,6 +555,10 @@ int vtkModelMultiBlockSource::RequestData(
     vtkErrorMacro("No input model");
     return 0;
     }
+
+  // Destroy the cache if the parameters have changed since it was generated.
+  if (this->CachedOutput && this->GetMTime() > this->CachedOutput->GetMTime())
+    this->SetCachedOutput(NULL);
 
   if (!this->CachedOutput)
     { // Populate a polydata with tessellation information from the model.

--- a/smtk/extension/vtk/vtkModelMultiBlockSource.h
+++ b/smtk/extension/vtk/vtkModelMultiBlockSource.h
@@ -53,6 +53,10 @@ public:
   vtkGetVector4Macro(DefaultColor,double);
   vtkSetVector4Macro(DefaultColor,double);
 
+  vtkGetMacro(ShowAnalysisTessellation,int);
+  vtkSetMacro(ShowAnalysisTessellation,int);
+  vtkBooleanMacro(ShowAnalysisTessellation,int);
+
   vtkGetMacro(AllowNormalGeneration,int);
   vtkSetMacro(AllowNormalGeneration,int);
   vtkBooleanMacro(AllowNormalGeneration,int);
@@ -96,6 +100,7 @@ protected:
   char* ModelEntityID; // Model Entity UUID
 
   int AllowNormalGeneration;
+  int ShowAnalysisTessellation;
   vtkNew<vtkPolyDataNormals> NormalGenerator;
 
 private:

--- a/smtk/model/EntityRef.cxx
+++ b/smtk/model/EntityRef.cxx
@@ -592,6 +592,30 @@ const Tessellation* EntityRef::gotMesh() const
   return NULL;
 }
 
+/**\brief Set the tessellation of the entity, returning its
+  *       generation number (or -1 on failure).
+  *
+  * If \a analysisMesh is non-zero (zero is the default), then
+  * the tessellation is treated as an analysis mesh rather than
+  * a tessellation for display purposes.
+  */
+int EntityRef::setTessellation(const Tessellation* tess, int analysisMesh)
+{
+  ManagerPtr mgr = this->m_manager.lock();
+  if (mgr && !this->m_entity.isNull())
+    {
+    int gen;
+    try {
+      mgr->setTessellation(this->m_entity, *tess, analysisMesh, &gen);
+    } catch (std::string& badIdMsg) {
+      return -1;
+    }
+
+    return gen;
+    }
+  return -1;
+}
+
 /**\brief Remove the tessellation of the entity, returning true
   *       if such a tessellation existed.
   *

--- a/smtk/model/EntityRef.h
+++ b/smtk/model/EntityRef.h
@@ -169,6 +169,7 @@ public:
   const Tessellation* hasTessellation() const;
   const Tessellation* hasAnalysisMesh() const;
   const Tessellation* gotMesh() const; //prefers the analaysis over the display
+  int setTessellation(const Tessellation* tess, int analysisMesh = 0);
   bool removeTessellation(bool removeGen = false);
 
   bool hasAttributes() const;

--- a/smtk/model/Manager.cxx
+++ b/smtk/model/Manager.cxx
@@ -41,11 +41,6 @@
 
 //#include <boost/variant.hpp>
 
-// The name of the integer property used to store Tessellation generation numbers.
-// Starting with "_" indicates internal-use-only.
-// Short (8 bytes or less) means single word comparison suffices on many platforms => fast.
-#define SMTK_TESS_GEN_PROP "_tessgen"
-
 using namespace std;
 using namespace smtk::common;
 

--- a/smtk/model/Manager.h
+++ b/smtk/model/Manager.h
@@ -53,12 +53,17 @@
 
 #include <sstream>
 
-/**\brief The name of an integer property used to store Tessellation generation numbers.
+/**\brief The name of an integer property used to store display Tessellation generation numbers.
   *
   * Starting with "_" indicates internal-use-only.
   * Short (8 bytes or less) means single word comparison suffices on many platforms => fast.
   */
 #define SMTK_TESS_GEN_PROP "_tessgen"
+/**\brief The name of an integer property used to store mesh Tessellation generation numbers.
+  *
+  * \sa SMTK_TESS_GEN_PROP
+  */
+#define SMTK_MESH_GEN_PROP "_meshgen"
 
 namespace smtk {
   namespace model {
@@ -235,7 +240,11 @@ public:
   template<typename Collection>
   Collection entitiesMatchingFlagsAs(BitFlags flags, bool exactMatch = true);
 
-  tess_iter_type setTessellation(const smtk::common::UUID& cellId, const Tessellation& geom);
+  tess_iter_type setTessellation(
+    const smtk::common::UUID& cellId,
+    const Tessellation& geom,
+    int analysis = 0,
+    int* gen = NULL);
   bool removeTessellation(const smtk::common::UUID& cellId, bool removeGen = false);
 
   int arrangeEntity(const smtk::common::UUID& entityId, ArrangementKind, const Arrangement& arr, int index = -1);

--- a/smtk/model/Manager.h
+++ b/smtk/model/Manager.h
@@ -53,6 +53,13 @@
 
 #include <sstream>
 
+/**\brief The name of an integer property used to store Tessellation generation numbers.
+  *
+  * Starting with "_" indicates internal-use-only.
+  * Short (8 bytes or less) means single word comparison suffices on many platforms => fast.
+  */
+#define SMTK_TESS_GEN_PROP "_tessgen"
+
 namespace smtk {
   namespace model {
 

--- a/smtk/model/SimpleModelSubphrases.cxx
+++ b/smtk/model/SimpleModelSubphrases.cxx
@@ -191,7 +191,7 @@ bool SimpleModelSubphrases::shouldOmitProperty(
     ptype == INTEGER_PROPERTY &&
     parent && parent->relatedEntity().isCellEntity())
     {
-    if (pname.find("_tessgen") != std::string::npos)
+    if (pname.find(SMTK_TESS_GEN_PROP) != std::string::npos)
       return true;
     }
   return false;


### PR DESCRIPTION
Provide a method for switching vtkModelMultiBlockSource between analysis and display tessellations.

This also provides extended VTK support for Python tests. You will need to update your SMTK test data repo to get the new baselines.