### PR TITLE
Try using CTest to ignore warnings.

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -1,0 +1,18 @@
+set( CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS 1000 )
+set( CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000 )
+
+##------------------------------------------------------------------------------
+## Ignore warnings in generated code during the build process
+set (CTEST_CUSTOM_WARNING_EXCEPTION
+  ${CTEST_CUSTOM_WARNING_EXCEPTION}
+  "smtk/SMTKCorePython"
+  ".*ClientServer.cxx:[0-9]*:[0-9]*: warning: use of old-style cast"
+  ".*Python/.* warning: declaration of .* shadows a member of 'this' [-Wshadow]"
+  ".*VTK/Wrapping/PythonCore/vtkPythonArgs.h.* warning: use of old-style cast [-Wold-style-cast]"
+)
+
+##------------------------------------------------------------------------------
+## Regular expression for error exceptions during build process
+#set (CTEST_CUSTOM_ERROR_EXCEPTION
+#  ${CTEST_CUSTOM_ERROR_EXCEPTION}
+#)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,12 @@ endif()
 if (SMTK_ENABLE_TESTING)
   enable_testing()
   include(CTest)
+  # Do not report some warnings from generated code to the dashboard:
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/CMake/CTestCustom.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/CTestCustom.cmake" COPYONLY)
 
-  #add the first test which is for checking the copyright
+  # Add a test to check for the copyright statment in all source:
   add_test(NAME CopyrightStatement
     COMMAND ${CMAKE_COMMAND}
         "-DSMTK_SOURCE_DIR=${SMTK_SOURCE_DIR}"


### PR DESCRIPTION
Specifically, ignore warnings in code generated by shiboken and VTK's wrappers.