### PR TITLE
ENH:New UI Infrastructure for Attributes

### DIFF
--- a/smtk/extension/qt/qtAttribute.cxx
+++ b/smtk/extension/qt/qtAttribute.cxx
@@ -78,7 +78,6 @@ qtAttribute::qtAttribute(smtk::attribute::AttributePtr myAttribute, QWidget* p,
 //----------------------------------------------------------------------------
 qtAttribute::~qtAttribute()
 {
-  std::cerr << "Deleting QT Attribute!!!\n";
   // First Clear all the items
   for(int i=0; i < this->m_internals->m_items.count(); i++)
     {
@@ -88,9 +87,6 @@ qtAttribute::~qtAttribute()
   this->m_internals->m_items.clear();
   if (this->m_widget)
     {
-    // Lets make sure we don't get notified for deleting the widget
-    this->m_widget->disconnect(this);
-    std::cerr << "Deleting Widget via Destructor\n";
     delete this->m_widget;
     }
 
@@ -129,7 +125,6 @@ void qtAttribute::createWidget()
   QFrame* attFrame = new QFrame(this->parentWidget());
   attFrame->setFrameShape(QFrame::Box);
   this->m_widget = attFrame;
-  connect(this->m_widget, SIGNAL(destroyed()), this, SLOT(widgetBeingDeleted()));
 
   QVBoxLayout* layout = new QVBoxLayout(this->m_widget);
   layout->setMargin(3);
@@ -217,14 +212,6 @@ smtk::attribute::AttributePtr qtAttribute::attribute()
 QWidget* qtAttribute::parentWidget()
 {
   return this->m_internals->m_parentWidget;
-}
-
-//----------------------------------------------------------------------------
-void qtAttribute::widgetBeingDeleted()
-{
-  // Severe the connection between this object and its widget
-  this->m_widget = NULL;
-  std::cerr << "Widget being deleted\n";
 }
 
 //----------------------------------------------------------------------------

--- a/smtk/extension/qt/qtAttribute.cxx
+++ b/smtk/extension/qt/qtAttribute.cxx
@@ -156,7 +156,7 @@ void qtAttribute::showAdvanceLevelOverlay(bool show)
 }
 
 //----------------------------------------------------------------------------
-void qtAttribute::createBasicLayout()
+void qtAttribute::createBasicLayout(bool includeAssociations)
 {
   //If there is no main widget there is nothing to show
   if (!this->m_widget)
@@ -167,9 +167,9 @@ void qtAttribute::createBasicLayout()
   QLayout* layout = this->m_widget->layout();
   qtItem* qItem = NULL;
   smtk::attribute::AttributePtr att = this->attribute();
-  // If there are model assocication for the attribute, create UI for it.
+  // If there are model assocications for the attribute, create UI for them if requested.
   // This will be the same widget used for ModelEntityItem.
-  if(att->associations())
+  if(includeAssociations && att->associations())
     {
     qItem = this->createItem(att->associations(), this->m_widget,
       this->m_internals->m_view);

--- a/smtk/extension/qt/qtAttribute.cxx
+++ b/smtk/extension/qt/qtAttribute.cxx
@@ -50,64 +50,68 @@ using namespace smtk::attribute;
 class qtAttributeInternals
 {
 public:
-  qtAttributeInternals(smtk::attribute::AttributePtr dataObject, QWidget* p,
-    qtBaseView* viewW)
+  qtAttributeInternals(smtk::attribute::AttributePtr myAttribute, QWidget* p,
+    qtBaseView* myView)
   {
-  this->ParentWidget = p;
-  this->DataObject = dataObject;
-  this->View = viewW;
+  this->m_parentWidget = p;
+  this->m_attribute = myAttribute;
+  this->m_view = myView;
   }
   ~qtAttributeInternals()
   {
   }
- smtk::attribute::WeakAttributePtr DataObject;
- QPointer<QWidget> ParentWidget;
- QList<smtk::attribute::qtItem*> Items;
- QPointer<qtBaseView> View;
+ smtk::attribute::WeakAttributePtr m_attribute;
+ QPointer<QWidget> m_parentWidget;
+ QList<smtk::attribute::qtItem*> m_items;
+ QPointer<qtBaseView> m_view;
 };
 
 //----------------------------------------------------------------------------
-qtAttribute::qtAttribute(smtk::attribute::AttributePtr dataObject, QWidget* p,
-   qtBaseView* view)
+qtAttribute::qtAttribute(smtk::attribute::AttributePtr myAttribute, QWidget* p,
+   qtBaseView* myView)
 {
-  this->Internals  = new qtAttributeInternals(dataObject, p, view);
-  this->Widget = NULL;
-  //this->Internals->DataConnect = NULL;
+  this->m_internals  = new qtAttributeInternals(myAttribute, p, myView);
+  this->m_widget = NULL;
   this->createWidget();
 }
 
 //----------------------------------------------------------------------------
 qtAttribute::~qtAttribute()
 {
-  this->clearItems();
-
-  if (this->Internals)
+  std::cerr << "Deleting QT Attribute!!!\n";
+  // First Clear all the items
+  for(int i=0; i < this->m_internals->m_items.count(); i++)
     {
-    if(this->Internals->ParentWidget && this->Widget
-      && this->Internals->ParentWidget->layout())
-      {
-      this->Internals->ParentWidget->layout()->removeWidget(this->Widget);
-      }
-    delete this->Internals;
+    delete this->m_internals->m_items.value(i);
     }
+  
+  this->m_internals->m_items.clear();
+  if (this->m_widget)
+    {
+    // Lets make sure we don't get notified for deleting the widget
+    this->m_widget->disconnect(this);
+    std::cerr << "Deleting Widget via Destructor\n";
+    delete this->m_widget;
+    }
+
+  delete this->m_internals;
 }
 
 //----------------------------------------------------------------------------
 void qtAttribute::createWidget()
 {
-  if(!this->getObject() || !this->getObject()->numberOfItems())
+  if(!this->attribute() || !this->attribute()->numberOfItems())
     {
     return;
     }
-  this->clearItems();
   int numShowItems = 0;
-  smtk::attribute::AttributePtr att = this->getObject();
+  smtk::attribute::AttributePtr att = this->attribute();
   std::size_t i, n = att->numberOfItems();
-  if(this->Internals->View)
+  if(this->m_internals->m_view)
     {
     for (i = 0; i < n; i++)
       {
-      if(this->Internals->View->displayItem(att->item(static_cast<int>(i))))
+      if(this->m_internals->m_view->displayItem(att->item(static_cast<int>(i))))
         {
         numShowItems++;
         }
@@ -124,64 +128,56 @@ void qtAttribute::createWidget()
 
   QFrame* attFrame = new QFrame(this->parentWidget());
   attFrame->setFrameShape(QFrame::Box);
-  this->Widget = attFrame;
+  this->m_widget = attFrame;
+  connect(this->m_widget, SIGNAL(destroyed()), this, SLOT(widgetBeingDeleted()));
 
-  QVBoxLayout* layout = new QVBoxLayout(this->Widget);
+  QVBoxLayout* layout = new QVBoxLayout(this->m_widget);
   layout->setMargin(3);
-  this->Widget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
-//  QLabel* label = new QLabel(this->getObject()->name().c_str(),
-//    this->parentWidget());
-//  layout->addWidget(label);
-  this->updateItemsData();
+  this->m_widget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
 }
 
 //----------------------------------------------------------------------------
 void qtAttribute::addItem(qtItem* child)
 {
-  if(!this->Internals->Items.contains(child))
+  if(!this->m_internals->m_items.contains(child))
     {
-    this->Internals->Items.append(child);
+    this->m_internals->m_items.append(child);
     }
 }
 
 //----------------------------------------------------------------------------
 QList<qtItem*>& qtAttribute::items() const
 {
-  return this->Internals->Items;
-}
-
-//----------------------------------------------------------------------------
-void qtAttribute::clearItems()
-{
-  for(int i=0; i < this->Internals->Items.count(); i++)
-    {
-    delete this->Internals->Items.value(i);
-    }
-  this->Internals->Items.clear();
+  return this->m_internals->m_items;
 }
 
 //----------------------------------------------------------------------------
 void qtAttribute::showAdvanceLevelOverlay(bool show)
 {
-  for(int i=0; i < this->Internals->Items.count(); i++)
+  for(int i=0; i < this->m_internals->m_items.count(); i++)
     {
-    this->Internals->Items.value(i)->showAdvanceLevelOverlay(show);
+    this->m_internals->m_items.value(i)->showAdvanceLevelOverlay(show);
     }
 }
 
 //----------------------------------------------------------------------------
-void qtAttribute::updateItemsData()
+void qtAttribute::createBasicLayout()
 {
-  this->clearItems();
-  QLayout* layout = this->Widget->layout();
+  //If there is no main widget there is nothing to show
+  if (!this->m_widget)
+    {
+    return;
+    }
+  
+  QLayout* layout = this->m_widget->layout();
   qtItem* qItem = NULL;
-  smtk::attribute::AttributePtr att = this->getObject();
+  smtk::attribute::AttributePtr att = this->attribute();
   // If there are model assocication for the attribute, create UI for it.
   // This will be the same widget used for ModelEntityItem.
   if(att->associations())
     {
-    qItem = this->createItem(att->associations(), this->Widget,
-      this->Internals->View);
+    qItem = this->createItem(att->associations(), this->m_widget,
+      this->m_internals->m_view);
     if(qItem && qItem->widget())
       {
       layout->addWidget(qItem->widget());
@@ -192,8 +188,8 @@ void qtAttribute::updateItemsData()
   std::size_t i, n = att->numberOfItems();
   for (i = 0; i < n; i++)
     {
-    qItem = this->createItem(att->item(static_cast<int>(i)), this->Widget,
-      this->Internals->View);
+    qItem = this->createItem(att->item(static_cast<int>(i)), this->m_widget,
+      this->m_internals->m_view);
     if(qItem && qItem->widget())
       {
       layout->addWidget(qItem->widget());
@@ -204,7 +200,7 @@ void qtAttribute::updateItemsData()
 //----------------------------------------------------------------------------
 void qtAttribute::onRequestEntityAssociation()
 {
-  foreach(qtItem* item, this->Internals->Items)
+  foreach(qtItem* item, this->m_internals->m_items)
     {
     if(qtModelEntityItem* mitem = qobject_cast<qtModelEntityItem*>(item))
       mitem->onRequestEntityAssociation();
@@ -212,15 +208,23 @@ void qtAttribute::onRequestEntityAssociation()
 }
 
 //----------------------------------------------------------------------------
-smtk::attribute::AttributePtr qtAttribute::getObject()
+smtk::attribute::AttributePtr qtAttribute::attribute()
 {
-  return this->Internals->DataObject.lock();
+  return this->m_internals->m_attribute.lock();
 }
 
 //----------------------------------------------------------------------------
 QWidget* qtAttribute::parentWidget()
 {
-  return this->Internals->ParentWidget;
+  return this->m_internals->m_parentWidget;
+}
+
+//----------------------------------------------------------------------------
+void qtAttribute::widgetBeingDeleted()
+{
+  // Severe the connection between this object and its widget
+  this->m_widget = NULL;
+  std::cerr << "Widget being deleted\n";
 }
 
 //----------------------------------------------------------------------------
@@ -236,30 +240,32 @@ qtItem* qtAttribute::createItem(smtk::attribute::ItemPtr item, QWidget* pW,
   switch (item->type())
     {
     case smtk::attribute::Item::ATTRIBUTE_REF: // This is always inside valueItem ???
-      aItem = qtAttribute::createAttributeRefItem(smtk::dynamic_pointer_cast<RefItem>(item), pW, bview, enVectorItemOrient);
+      aItem = new qtAttributeRefItem(smtk::dynamic_pointer_cast<RefItem>(item), pW, bview, enVectorItemOrient);
       break;
     case smtk::attribute::Item::DOUBLE:
     case smtk::attribute::Item::INT:
     case smtk::attribute::Item::STRING:
-      aItem = qtAttribute::createValueItem(smtk::dynamic_pointer_cast<ValueItem>(item), pW, bview, enVectorItemOrient);
+      aItem = new qtInputsItem(smtk::dynamic_pointer_cast<ValueItem>(item), pW, bview, enVectorItemOrient);
       break;
     case smtk::attribute::Item::DIRECTORY:
-      aItem = qtAttribute::createDirectoryItem(smtk::dynamic_pointer_cast<DirectoryItem>(item), pW, bview, enVectorItemOrient);
+      aItem = new qtFileItem(smtk::dynamic_pointer_cast<DirectoryItem>(item), pW, bview, enVectorItemOrient);
       break;
     case smtk::attribute::Item::FILE:
-      aItem = qtAttribute::createFileItem(smtk::dynamic_pointer_cast<FileItem>(item), pW, bview, enVectorItemOrient);
+      aItem = new qtFileItem(smtk::dynamic_pointer_cast<FileItem>(item), pW, bview, enVectorItemOrient);
       break;
     case smtk::attribute::Item::GROUP:
-      aItem = qtAttribute::createGroupItem(smtk::dynamic_pointer_cast<GroupItem>(item), pW, bview, enVectorItemOrient);
+      aItem = new qtGroupItem(smtk::dynamic_pointer_cast<GroupItem>(item), pW, bview, enVectorItemOrient);
       break;
     case smtk::attribute::Item::VOID:
       aItem = new qtVoidItem(smtk::dynamic_pointer_cast<VoidItem>(item), pW, bview);
       break;
     case smtk::attribute::Item::MODEL_ENTITY:
-      aItem = qtAttribute::createModelEntityItem(smtk::dynamic_pointer_cast<ModelEntityItem>(item), pW, bview, enVectorItemOrient);
+      aItem = new qtModelEntityItem(smtk::dynamic_pointer_cast<ModelEntityItem>(item),
+                                     pW, bview, enVectorItemOrient);
       break;
     case smtk::attribute::Item::MESH_SELECTION:
-      aItem = qtAttribute::createMeshSelectionItem(smtk::dynamic_pointer_cast<MeshSelectionItem>(item), pW, bview, enVectorItemOrient);
+      aItem = new qtMeshSelectionItem(smtk::dynamic_pointer_cast<MeshSelectionItem>(item), pW,
+                                      bview, enVectorItemOrient);
       break;
     default:
       //this->m_errorStatus << "Error: Unsupported Item Type: " <<
@@ -267,68 +273,4 @@ qtItem* qtAttribute::createItem(smtk::attribute::ItemPtr item, QWidget* pW,
       break;
     }
   return aItem;
-}
-
-//----------------------------------------------------------------------------
-qtItem* qtAttribute::createAttributeRefItem(
-  smtk::attribute::RefItemPtr item, QWidget* pW, qtBaseView* view,
-  Qt::Orientation enVectorItemOrient)
-{
-  qtItem* returnItem = new qtAttributeRefItem(dynamic_pointer_cast<Item>(item), pW, view, enVectorItemOrient);
-  return returnItem;
-}
-//----------------------------------------------------------------------------
-qtItem* qtAttribute::createDirectoryItem(
-  smtk::attribute::DirectoryItemPtr item, QWidget* pW, qtBaseView* view,
-  Qt::Orientation enVectorItemOrient)
-{
-  qtFileItem* returnItem = new qtFileItem(dynamic_pointer_cast<Item>(item), pW, view, true, enVectorItemOrient);
-  view->uiManager()->onFileItemCreated(returnItem);
-  return returnItem;
-}
-//----------------------------------------------------------------------------
-qtItem* qtAttribute::createFileItem(
-  smtk::attribute::FileItemPtr item, QWidget* pW, qtBaseView* view,
-  Qt::Orientation enVectorItemOrient)
-{
-  qtFileItem* returnItem = new qtFileItem(
-    dynamic_pointer_cast<Item>(item), pW, view, false, enVectorItemOrient);
-  view->uiManager()->onFileItemCreated(returnItem);
-  return returnItem;
-}
-//----------------------------------------------------------------------------
-qtItem* qtAttribute::createModelEntityItem(
-  smtk::attribute::ModelEntityItemPtr item, QWidget* pW, qtBaseView* view,
-  Qt::Orientation enVectorItemOrient)
-{
-  qtModelEntityItem* returnItem = new qtModelEntityItem(item, pW, view, enVectorItemOrient);
-  view->uiManager()->onModelEntityItemCreated(returnItem);
-  return returnItem;
-}
-//----------------------------------------------------------------------------
-qtItem* qtAttribute::createMeshSelectionItem(
-  smtk::attribute::MeshSelectionItemPtr item, QWidget* pW, qtBaseView* view,
-  Qt::Orientation enVectorItemOrient)
-{
-  qtMeshSelectionItem* returnItem = new qtMeshSelectionItem(item, pW, view, enVectorItemOrient);
-  view->uiManager()->onMeshSelectionItemCreated(returnItem);
-  return returnItem;
-}
-
-//----------------------------------------------------------------------------
-qtItem* qtAttribute::createGroupItem(smtk::attribute::GroupItemPtr item,
- QWidget* pW, qtBaseView* view, Qt::Orientation enVectorItemOrient)
-{
-  qtItem* returnItem = new qtGroupItem(dynamic_pointer_cast<Item>(item), pW, view, enVectorItemOrient);
-  return returnItem;
-}
-
-//----------------------------------------------------------------------------
-qtItem* qtAttribute::createValueItem(
-  smtk::attribute::ValueItemPtr item, QWidget* pW, qtBaseView* view,
-  Qt::Orientation enVectorItemOrient)
-{
-    // create the input item for editable type values
-  qtItem* returnItem = new qtInputsItem(dynamic_pointer_cast<Item>(item), pW, view, enVectorItemOrient);
-  return returnItem;
 }

--- a/smtk/extension/qt/qtAttribute.h
+++ b/smtk/extension/qt/qtAttribute.h
@@ -34,49 +34,35 @@ namespace smtk
       qtAttribute(smtk::attribute::AttributePtr, QWidget* parent, qtBaseView* view);
       virtual ~qtAttribute();
 
-      smtk::attribute::AttributePtr getObject();
+      smtk::attribute::AttributePtr attribute();
       QWidget* widget()
-      {return this->Widget;}
+      {return this->m_widget;}
       QWidget* parentWidget();
 
       virtual void addItem(qtItem*);
-      virtual void clearItems();
       QList<qtItem*>& items() const;
       virtual void showAdvanceLevelOverlay(bool show);
 
+      // A basic layout for an attribute
+      void createBasicLayout();
+      
       // create all the items
       static qtItem* createItem(smtk::attribute::ItemPtr item, QWidget* p, qtBaseView* view,
-        Qt::Orientation enVectorItemOrient = Qt::Horizontal);
-      static qtItem* createValueItem(smtk::attribute::ValueItemPtr item, QWidget* p, qtBaseView* view,
-        Qt::Orientation enVectorItemOrient = Qt::Horizontal);
-      static qtItem* createDirectoryItem(smtk::attribute::DirectoryItemPtr item, QWidget* p, qtBaseView* view,
-        Qt::Orientation enVectorItemOrient = Qt::Horizontal);
-      static qtItem* createAttributeRefItem(smtk::attribute::RefItemPtr item, QWidget* p, qtBaseView* view,
-        Qt::Orientation enVectorItemOrient = Qt::Horizontal);
-      static qtItem* createFileItem(smtk::attribute::FileItemPtr item, QWidget* p, qtBaseView* view,
-        Qt::Orientation enVectorItemOrient = Qt::Horizontal);
-      static qtItem* createGroupItem(smtk::attribute::GroupItemPtr item, QWidget* p, qtBaseView* view,
-        Qt::Orientation enVectorItemOrient = Qt::Horizontal);
-      static qtItem* createDiscreteValueItem(smtk::attribute::ValueItemPtr item, QWidget* p, qtBaseView* view,
-        Qt::Orientation enVectorItemOrient = Qt::Horizontal);
-      static qtItem* createModelEntityItem(smtk::attribute::ModelEntityItemPtr item, QWidget* pW, qtBaseView* view,
-        Qt::Orientation enVectorItemOrient = Qt::Horizontal);
-      static qtItem* createMeshSelectionItem(smtk::attribute::MeshSelectionItemPtr item, QWidget* pW, qtBaseView* view,
         Qt::Orientation enVectorItemOrient = Qt::Horizontal);
 
     public slots:
       virtual void onRequestEntityAssociation();
 
     protected slots:
-      virtual void updateItemsData();
-
+      void widgetBeingDeleted();
+      
     protected:
       virtual void createWidget();
 
-      QWidget* Widget;
+      QWidget* m_widget;
     private:
 
-      qtAttributeInternals *Internals;
+      qtAttributeInternals *m_internals;
 
     }; // class
   }; // namespace attribute

--- a/smtk/extension/qt/qtAttribute.h
+++ b/smtk/extension/qt/qtAttribute.h
@@ -46,7 +46,7 @@ namespace smtk
       virtual void showAdvanceLevelOverlay(bool show);
 
       // A basic layout for an attribute
-      void createBasicLayout();
+      void createBasicLayout(bool includeAssociations);
       
       // create all the items
       static qtItem* createItem(smtk::attribute::ItemPtr item, QWidget* p, qtBaseView* view,

--- a/smtk/extension/qt/qtAttribute.h
+++ b/smtk/extension/qt/qtAttribute.h
@@ -14,6 +14,8 @@
 #define __smtk_attribute_qtAttribute_h
 
 #include <QObject>
+#include <QPointer>
+#include <QWidget>
 #include "smtk/extension/qt/Exports.h"
 #include "smtk/PublicPointerDefs.h"
 
@@ -54,12 +56,11 @@ namespace smtk
       virtual void onRequestEntityAssociation();
 
     protected slots:
-      void widgetBeingDeleted();
       
     protected:
       virtual void createWidget();
 
-      QWidget* m_widget;
+      QPointer<QWidget> m_widget;
     private:
 
       qtAttributeInternals *m_internals;

--- a/smtk/extension/qt/qtAttributeRefItem.cxx
+++ b/smtk/extension/qt/qtAttributeRefItem.cxx
@@ -597,7 +597,7 @@ void qtAttributeRefItem::refreshUI(QComboBox* comboBox)
     qtAttribute* currentAtt =
       this->Internals->RefAtts.contains(elementIdx) ?
       this->Internals->RefAtts[elementIdx] : NULL;
-    if(currentAtt && currentAtt->getObject() != attPtr)
+    if(currentAtt && currentAtt->attribute() != attPtr)
       {
       delete currentAtt->widget();
       delete currentAtt;

--- a/smtk/extension/qt/qtAttributeView.cxx
+++ b/smtk/extension/qt/qtAttributeView.cxx
@@ -260,8 +260,8 @@ void qtAttributeView::createWidget( )
   this->Internals->ValuesTable->setSizePolicy(tableSizePolicy);
 
   TopLayout->addWidget(this->Internals->FiltersFrame);
-  TopLayout->addWidget(this->Internals->ListTable);
   TopLayout->addWidget(this->Internals->ButtonsFrame);
+  TopLayout->addWidget(this->Internals->ListTable);
 
   BottomLayout->addWidget(this->Internals->ValuesTable);
   this->Internals->ValuesTable->setVisible(0);
@@ -870,7 +870,9 @@ void qtAttributeView::updateTableWithAttribute(
   this->setFixedLabelWidth(tmpLen);
 
   this->Internals->CurrentAtt = new qtAttribute(att, this->Internals->AttFrame, this);
-  this->Internals->CurrentAtt->createBasicLayout();
+  // By default use the basic layout with no model associations since this class
+  // takes care of it
+  this->Internals->CurrentAtt->createBasicLayout(false);
   this->setFixedLabelWidth(currentLen);
   if(this->Internals->CurrentAtt && this->Internals->CurrentAtt->widget())
     {

--- a/smtk/extension/qt/qtAttributeView.cxx
+++ b/smtk/extension/qt/qtAttributeView.cxx
@@ -861,9 +861,6 @@ void qtAttributeView::updateTableWithAttribute(
 
   if(this->Internals->CurrentAtt && this->Internals->CurrentAtt->widget())
     {
-    this->Internals->AttFrame->layout()->removeWidget(
-      this->Internals->CurrentAtt->widget());
-    delete this->Internals->CurrentAtt->widget();
     delete this->Internals->CurrentAtt;
     }
 
@@ -873,6 +870,7 @@ void qtAttributeView::updateTableWithAttribute(
   this->setFixedLabelWidth(tmpLen);
 
   this->Internals->CurrentAtt = new qtAttribute(att, this->Internals->AttFrame, this);
+  this->Internals->CurrentAtt->createBasicLayout();
   this->setFixedLabelWidth(currentLen);
   if(this->Internals->CurrentAtt && this->Internals->CurrentAtt->widget())
     {

--- a/smtk/extension/qt/qtFileItem.cxx
+++ b/smtk/extension/qt/qtFileItem.cxx
@@ -45,18 +45,38 @@ public:
 };
 
 //----------------------------------------------------------------------------
-qtFileItem::qtFileItem(
-  smtk::attribute::ItemPtr dataObj, QWidget* p, qtBaseView* bview,
-   bool dirOnly, Qt::Orientation enVectorItemOrient)
+qtFileItem::qtFileItem(smtk::attribute::FileItemPtr dataObj, QWidget* p,
+                       qtBaseView* bview, Qt::Orientation enVectorItemOrient)
    : qtItem(dataObj, p, bview)
 {
   this->Internals = new qtFileItemInternals;
-  this->Internals->IsDirectory = dirOnly;
+  this->Internals->IsDirectory = false;
   this->Internals->FileBrowser = NULL;
   this->Internals->VectorItemOrient = enVectorItemOrient;
 
   this->IsLeafItem = true;
   this->createWidget();
+  if (bview)
+    {
+    bview->uiManager()->onFileItemCreated(this);
+    }
+}
+//----------------------------------------------------------------------------
+qtFileItem::qtFileItem(smtk::attribute::DirectoryItemPtr dataObj, QWidget* p,
+                       qtBaseView* bview, Qt::Orientation enVectorItemOrient)
+   : qtItem(dataObj, p, bview)
+{
+  this->Internals = new qtFileItemInternals;
+  this->Internals->IsDirectory = true;
+  this->Internals->FileBrowser = NULL;
+  this->Internals->VectorItemOrient = enVectorItemOrient;
+
+  this->IsLeafItem = true;
+  this->createWidget();
+  if (bview)
+    {
+    bview->uiManager()->onFileItemCreated(this);
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/smtk/extension/qt/qtFileItem.h
+++ b/smtk/extension/qt/qtFileItem.h
@@ -43,8 +43,10 @@ namespace smtk
       Q_OBJECT
 
     public:
-      qtFileItem(smtk::attribute::ItemPtr, QWidget* parent, qtBaseView* bview,
-        bool dirOnly=false, Qt::Orientation enVectorItemOrient = Qt::Horizontal);
+      qtFileItem(smtk::attribute::FileItemPtr, QWidget* parent, qtBaseView* bview,
+                 Qt::Orientation enVectorItemOrient = Qt::Horizontal);
+      qtFileItem(smtk::attribute::DirectoryItemPtr, QWidget* parent, qtBaseView* bview,
+                 Qt::Orientation enVectorItemOrient = Qt::Horizontal);
       virtual ~qtFileItem();
       void enableFileBrowser(bool state=true);
       bool isDirectory();

--- a/smtk/extension/qt/qtInstancedView.cxx
+++ b/smtk/extension/qt/qtInstancedView.cxx
@@ -119,8 +119,7 @@ void qtInstancedView::updateAttributeData()
   smtk::attribute::DefinitionPtr attDef;
   foreach(qtAttribute* qatt, this->Internals->AttInstances)
     {
-    this->Widget->layout()->removeWidget(qatt->widget());
-    delete qatt->widget();
+    delete qatt;
     }
   this->Internals->AttInstances.clear();
 
@@ -188,6 +187,8 @@ void qtInstancedView::updateAttributeData()
       qtAttribute* attInstance = new qtAttribute(atts[i], this->widget(), this);
       if(attInstance)
         {
+        //Without any additional info lets use a basic layout
+        attInstance->createBasicLayout();
         this->Internals->AttInstances.push_back(attInstance);
         if(attInstance->widget())
           {

--- a/smtk/extension/qt/qtInstancedView.cxx
+++ b/smtk/extension/qt/qtInstancedView.cxx
@@ -187,8 +187,9 @@ void qtInstancedView::updateAttributeData()
       qtAttribute* attInstance = new qtAttribute(atts[i], this->widget(), this);
       if(attInstance)
         {
-        //Without any additional info lets use a basic layout
-        attInstance->createBasicLayout();
+        //Without any additional info lets use a basic layout with model associations
+        // if any exists
+        attInstance->createBasicLayout(true);
         this->Internals->AttInstances.push_back(attInstance);
         if(attInstance->widget())
           {

--- a/smtk/extension/qt/qtMeshSelectionItem.cxx
+++ b/smtk/extension/qt/qtMeshSelectionItem.cxx
@@ -110,6 +110,10 @@ qtMeshSelectionItem::qtMeshSelectionItem(
   this->IsLeafItem = true;
   this->Internals->VectorItemOrient = enVectorItemOrient;
   this->createWidget();
+  if (bview)
+    {
+    bview->uiManager()->onMeshSelectionItemCreated(this);
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/smtk/extension/qt/qtModelEntityItem.cxx
+++ b/smtk/extension/qt/qtModelEntityItem.cxx
@@ -54,12 +54,17 @@ public:
 //----------------------------------------------------------------------------
 qtModelEntityItem::qtModelEntityItem(
   smtk::attribute::ItemPtr dataObj, QWidget* p, qtBaseView* bview,
-   Qt::Orientation enVectorItemOrient) : qtItem(dataObj, p, bview)
+   Qt::Orientation enVectorItemOrient)
+  :qtItem(dataObj, p, bview)
 {
   this->Internals = new qtModelEntityItemInternals;
   this->IsLeafItem = true;
   this->Internals->VectorItemOrient = enVectorItemOrient;
   this->createWidget();
+  if (bview)
+    {
+    bview->uiManager()->onModelEntityItemCreated(this);
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/smtk/extension/qt/qtSimpleExpressionView.cxx
+++ b/smtk/extension/qt/qtSimpleExpressionView.cxx
@@ -231,13 +231,13 @@ void qtSimpleExpressionView::createWidget()
   rowButtonLayout->addWidget(this->Internals->AddValueButton);
   rowButtonLayout->addWidget(this->Internals->RemoveValueButton);
 
+  leftLayout->addLayout(copyLayout);//, 2, 0,1,1);
   leftLayout->addWidget(this->Internals->FuncList);//, 0, 0,1,1);
   //leftLayout->addWidget(this->Internals->AddButton);
   leftLayout->addWidget(this->Internals->EditorGroup);//, 1, 0,1,1);
   //leftLayout->addLayout(editorLayout);
-  leftLayout->addLayout(copyLayout);//, 2, 0,1,1);
-  rightLayout->addWidget(this->Internals->FuncTable);//, 0, 1, 2, 1);
   rightLayout->addLayout(rowButtonLayout);//, 2, 1,1,1);
+  rightLayout->addWidget(this->Internals->FuncTable);//, 0, 1, 2, 1);
 
   frame->addWidget(leftFrame);
   frame->addWidget(rightFrame);


### PR DESCRIPTION
Allowing QTViews to take a more active role in creating the UI

Plus some addiitonal clean-up

1. Better matching SMTK Style of m_ and no getXXX methods
2. Removed a bunch of unneeded qtItem creation methods in qtAttribute
3. Added a basic layout method to qtAttribute
4. Fixed memory leak when deleting qtAttribute - now uses a signal to
determine if the object's widget is about to be deleted

Please enter the commit message for your changes. Lines starting