### PR TITLE
Entity-Attribute association method changes and color-by Attribute UI components for CMB

### DIFF
--- a/smtk/attribute/Attribute.cxx
+++ b/smtk/attribute/Attribute.cxx
@@ -281,7 +281,7 @@ smtk::attribute::AttributePtr Attribute::pointer() const
 void Attribute::removeAllAssociations()
 {
   smtk::model::ManagerPtr modelMgr = this->modelManager();
-  if (modelMgr)
+  if (modelMgr && this->m_associations)
     {
     smtk::model::EntityRefArray::const_iterator it;
     for (it = this->m_associations->begin(); it != this->m_associations->end(); ++it)

--- a/smtk/attribute/Attribute.cxx
+++ b/smtk/attribute/Attribute.cxx
@@ -280,18 +280,18 @@ smtk::attribute::AttributePtr Attribute::pointer() const
   */
 void Attribute::removeAllAssociations()
 {
+  smtk::model::ManagerPtr modelMgr = this->modelManager();
+  if (modelMgr)
+    {
+    smtk::model::EntityRefArray::const_iterator it;
+    for (it = this->m_associations->begin(); it != this->m_associations->end(); ++it)
+      {
+      modelMgr->disassociateAttribute(this->system(), this->m_id, it->entity(), false);
+      }
+    }
+
   if (this->m_associations)
     this->m_associations->reset();
-
-  smtk::model::ManagerPtr modelMgr = this->modelManager();
-  if (!modelMgr)
-    return;
-  smtk::model::UUIDsToAttributeAssignments::iterator it;
-  for(it = modelMgr->attributeAssignments().begin();
-      it != modelMgr->attributeAssignments().end() ; ++it)
-    {
-    it->second.disassociateAttribute(this->id());
-    }
 }
 
 /**\brief Is the model \a entity associated with this attribute?

--- a/smtk/attribute/System.cxx
+++ b/smtk/attribute/System.cxx
@@ -464,16 +464,7 @@ smtk::attribute::ConstDefinitionPtr System::findIsUniqueBaseClass(
 //----------------------------------------------------------------------------
 void System::setRefModelManager(smtk::model::ManagerPtr refModelMgr)
 {
-  smtk::model::ManagerPtr curManager = this->m_refModelMgr.lock();
-  if (curManager && curManager != refModelMgr)
-    {
-    curManager->setAttributeSystem(NULL, false);
-    }
   this->m_refModelMgr = refModelMgr;
-  if (refModelMgr && this->m_refModelMgr.lock()->attributeSystem() != this)
-    {
-    refModelMgr->setAttributeSystem(this, false);
-    }
 }
 //----------------------------------------------------------------------------
 void

--- a/smtk/attribute/testing/cxx/attributeAssociationTest.cxx
+++ b/smtk/attribute/testing/cxx/attributeAssociationTest.cxx
@@ -69,7 +69,7 @@ int main()
 
   smtk::model::Vertex v0 = modelMgr->addVertex();
   smtk::model::Vertex v1 = modelMgr->addVertex();
-  v0.associateAttribute(att->id());
+  v0.associateAttribute(att->system(), att->id());
   test(
     att->associatedModelEntityIds().count(v0.entity()) == 1,
     "Could not associate a vertex to an attribute.");
@@ -84,23 +84,23 @@ int main()
     !v1.hasAttributes(),
     "Disassociating a non-existent attribute appears to associate it.");
 
-  v1.associateAttribute(att->id());
+  v1.associateAttribute(att->system(), att->id());
   att->removeAllAssociations();
   test(
     att->associatedModelEntityIds().empty(),
     "Removing all attribute associations did not empty association list.");
 
   smtk::model::Vertex v2 = modelMgr->addVertex();
-  v0.associateAttribute(att->id());
-  v1.associateAttribute(att->id());
+  v0.associateAttribute(att->system(), att->id());
+  v1.associateAttribute(att->system(), att->id());
   test(
-    v2.associateAttribute(att->id()) == false,
+    v2.associateAttribute(att->system(), att->id()) == false,
     "Should not have been able to associate more than 2 entities.");
 
   att->removeAllAssociations();
   smtk::model::Edge e0 = modelMgr->addEdge();
   test(
-    e0.associateAttribute(att->id()) == false,
+    e0.associateAttribute(att->system(), att->id()) == false,
     "Should not have been able to associate entity of wrong type.");
 
   // ----
@@ -110,12 +110,6 @@ int main()
   test(
     sys.refModelManager() == auxModelManager,
     "Attribute system's modelMgr not changed.");
-  test(
-    auxModelManager->attributeSystem() == &sys,
-    "Second model manager's attribute system not changed.");
-  test(
-    modelMgr->attributeSystem() == NULL,
-    "Original model manager's attribute system not reset.");
 
   return 0;
 }

--- a/smtk/bridge/discrete/extension/reader/vtkGDALRasterPolydataWrapper.cxx
+++ b/smtk/bridge/discrete/extension/reader/vtkGDALRasterPolydataWrapper.cxx
@@ -152,9 +152,6 @@ int vtkGDALRasterPolydataWrapper::RequestData(vtkInformation* vtkNotUsed(request
     return 0;
     }
 
-  int zone = this->Reader->zone();
-  bool isNorth = this->Reader->isNorth();
-
   if (this->LimitReadToBounds)
     {
     this->ReadBBox.Reset();
@@ -249,7 +246,7 @@ int vtkGDALRasterPolydataWrapper::RequestData(vtkInformation* vtkNotUsed(request
 //-----------------------------------------------------------------------------
 int vtkGDALRasterPolydataWrapper::RequestInformation(vtkInformation * vtkNotUsed(request),
                                             vtkInformationVector **vtkNotUsed(inputVector),
-                                            vtkInformationVector *outputVector)
+                                            vtkInformationVector * vtkNotUsed(outputVector))
 {
   if(FileName.empty()) return 0;
   this->Reader->UpdateInformation();

--- a/smtk/bridge/discrete/operators/EdgeOperator.cxx
+++ b/smtk/bridge/discrete/operators/EdgeOperator.cxx
@@ -454,6 +454,6 @@ smtkImplementsModelOperator(
   SMTKDISCRETESESSION_EXPORT,
   smtk::bridge::discrete::EdgeOperator,
   discrete_split_edge,
-  "split edge",
+  "modify edge",
   EdgeOperator_xml,
   smtk::bridge::discrete::Session);

--- a/smtk/bridge/discrete/operators/EdgeOperator.sbt
+++ b/smtk/bridge/discrete/operators/EdgeOperator.sbt
@@ -3,7 +3,7 @@
 <SMTK_AttributeSystem Version="2">
   <Definitions>
     <!-- Operator -->
-    <AttDef Type="split edge" BaseType="operator">
+    <AttDef Type="modify edge" BaseType="operator">
       <ItemDefinitions>
         <ModelEntity Name="model" NumberOfRequiredValues="1">
           <MembershipMask>model</MembershipMask>
@@ -14,7 +14,7 @@
       </ItemDefinitions>
     </AttDef>
     <!-- Result -->
-    <AttDef Type="result(split edge)" BaseType="result">
+    <AttDef Type="result(modify edge)" BaseType="result">
     </AttDef>
   </Definitions>
 </SMTK_AttributeSystem>

--- a/smtk/bridge/discrete/operators/MergeOperator.cxx
+++ b/smtk/bridge/discrete/operators/MergeOperator.cxx
@@ -184,6 +184,6 @@ smtkImplementsModelOperator(
   SMTKDISCRETESESSION_EXPORT,
   smtk::bridge::discrete::MergeOperator,
   discrete_merge,
-  "merge",
+  "merge face",
   MergeOperator_xml,
   smtk::bridge::discrete::Session);

--- a/smtk/bridge/discrete/operators/MergeOperator.sbt
+++ b/smtk/bridge/discrete/operators/MergeOperator.sbt
@@ -3,7 +3,7 @@
 <SMTK_AttributeSystem Version="2">
   <Definitions>
     <!-- Operator -->
-    <AttDef Type="merge" BaseType="operator">
+    <AttDef Type="merge face" BaseType="operator">
       <ItemDefinitions>
         <ModelEntity Name="model" NumberOfRequiredValues="1">
            <MembershipMask>model</MembershipMask>
@@ -18,7 +18,7 @@
       </ItemDefinitions>
     </AttDef>
     <!-- Result -->
-    <AttDef Type="result(merge)" BaseType="result">
+    <AttDef Type="result(merge face)" BaseType="result">
       <ItemDefinitions>
       </ItemDefinitions>
     </AttDef>

--- a/smtk/bridge/discrete/testing/python/discreteSplitEdge.py
+++ b/smtk/bridge/discrete/testing/python/discreteSplitEdge.py
@@ -134,8 +134,8 @@ class TestDiscreteSplitEdge(smtk.testing.TestCase):
     # Find the edges to split for this given model
     splits = findSplits(mod)
 
-    spl = GetActiveSession().op('split edge')
-    self.assertIsNotNone(spl, 'Missing split edge operator.')
+    spl = GetActiveSession().op('modify edge')
+    self.assertIsNotNone(spl, 'Missing modify edge operator.')
     SetVectorValue(spl.findAsModelEntity('model'), [mod,])
     sel = spl.specification().findMeshSelection('selection')
     sel.setModifyMode(smtk.attribute.ACCEPT)

--- a/smtk/extension/qt/CMakeLists.txt
+++ b/smtk/extension/qt/CMakeLists.txt
@@ -4,6 +4,7 @@ include(${QT_USE_FILE})
 set(QAttrLibSrcs
   qtUIManager.cxx
   qtAttribute.cxx
+  qtAttributeDisplay.cxx
   qtBaseView.cxx
   qtCheckItemComboBox.cxx
   qtEntityItemDelegate.cxx
@@ -46,6 +47,7 @@ set(QAttrLibUIs
 set(QAttrLibHeaders
   qtUIManager.h
   qtAttribute.h
+  qtAttributeDisplay.h
   qtBaseView.h
   qtCheckItemComboBox.h
   qtEntityItemDelegate.h

--- a/smtk/extension/qt/qtAssociationWidget.cxx
+++ b/smtk/extension/qt/qtAssociationWidget.cxx
@@ -749,14 +749,12 @@ void qtAssociationWidget::onDomainAssociationChanged()
     return;
     }
 
-  smtk::model::AttributeAssignments atts = domainItem.attributes();
-  atts.attributes().clear(); //detach all attributes
+  domainItem.disassociateAllAttributes(attSystem, uid); //detach all attributes
 
   if(combo->currentText().isEmpty())
     {
     return;
     }
-
 
   QString attName = combo->currentText();
   AttributePtr attPtr = attSystem->findAttribute(attName.toStdString());

--- a/smtk/extension/qt/qtAssociationWidget.cxx
+++ b/smtk/extension/qt/qtAssociationWidget.cxx
@@ -762,7 +762,7 @@ void qtAssociationWidget::onDomainAssociationChanged()
   AttributePtr attPtr = attSystem->findAttribute(attName.toStdString());
   if(attPtr)
     {
-    domainItem.associateAttribute(attPtr->id());
+    domainItem.associateAttribute(attSystem, attPtr->id());
     emit this->attAssociationChanged();
     }
   else

--- a/smtk/extension/qt/qtAttributeDisplay.cxx
+++ b/smtk/extension/qt/qtAttributeDisplay.cxx
@@ -328,7 +328,7 @@ void qtAttributeDisplay::initSelectPropCombo(
         }
       }
     }
-  int prevIdx = this->Internals->PropDefsCombo->findText(currentItemName);
+  int prevIdx = this->Internals->SelectPropCombo->findText(currentItemName);
   this->Internals->SelectPropCombo->setCurrentIndex(prevIdx >= 0 ? prevIdx : 0);
   this->Internals->SelectPropCombo->blockSignals(false);
 }

--- a/smtk/extension/qt/qtAttributeDisplay.cxx
+++ b/smtk/extension/qt/qtAttributeDisplay.cxx
@@ -1,0 +1,524 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+
+#include "smtk/extension/qt/qtAttributeDisplay.h"
+
+#include "smtk/extension/qt/qtUIManager.h"
+#include "smtk/extension/qt/qtTableWidget.h"
+#include "smtk/extension/qt/qtItem.h"
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/Definition.h"
+#include "smtk/attribute/ItemDefinition.h"
+#include "smtk/attribute/System.h"
+#include "smtk/attribute/ValueItem.h"
+#include "smtk/attribute/ValueItemDefinition.h"
+#include "smtk/model/AttributeAssignments.h"
+#include "smtk/model/Manager.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QGridLayout>
+#include <QTableWidgetItem>
+#include <QVariant>
+#include <QPushButton>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QKeyEvent>
+#include <QModelIndex>
+#include <QModelIndexList>
+#include <QMessageBox>
+#include <QPointer>
+#include <QBrush>
+#include <QColorDialog>
+#include <QHeaderView>
+#include <QStandardItem>
+#include <QStandardItemModel>
+#include <QStyleOptionViewItem>
+
+#include <iostream>
+#include <set>
+using namespace smtk::attribute;
+
+//----------------------------------------------------------------------------
+class qtAttributeDisplayInternals
+{
+public:
+
+  const QList<smtk::attribute::DefinitionPtr> getCurrentDefs(
+    const std::string& strCategory) const
+  {
+
+    if(this->AttDefMap.keys().contains(strCategory))
+      {
+      return this->AttDefMap[strCategory];
+      }
+    return this->AllAssignedDefs;
+  }
+  qtTableWidget* ValuesTable;
+
+  QFrame* FiltersFrame;
+
+  // <category, AttDefinitions>
+  QMap<std::string, QList<smtk::attribute::DefinitionPtr> > AttDefMap;
+
+  // All definitions list
+  QList<smtk::attribute::DefinitionPtr> AllAssignedDefs;
+
+  // For filtering the attribute properties by combobox.
+  QPointer<QCheckBox> FilterByCheck;
+  QPointer<QComboBox> ShowCategoryCombo;
+  QPointer<QComboBox> PropDefsCombo;
+  QPointer<QComboBox> SelectPropCombo;
+
+  QPointer<smtk::attribute::qtUIManager> UIManager;
+  QPointer<QStandardItemModel> PropComboModel;
+
+};
+
+//----------------------------------------------------------------------------
+qtAttributeDisplay::
+qtAttributeDisplay(QWidget* p, smtk::attribute::qtUIManager* uiman) : QWidget(p)
+{
+  this->Internals = new qtAttributeDisplayInternals;
+  this->Internals->UIManager = uiman;
+  this->createWidget( );
+}
+
+//----------------------------------------------------------------------------
+qtAttributeDisplay::~qtAttributeDisplay()
+{
+  delete this->Internals;
+}
+
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::createWidget( )
+{
+  if(!this->Internals->UIManager)
+    {
+    return;
+    }
+
+  QVBoxLayout* thislayout = new QVBoxLayout(this);
+
+  QSizePolicy sizeFixedPolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  // create a filter-frame with Category-combo
+  this->Internals->FiltersFrame = new QFrame(this);
+  QGridLayout* filterLayout = new QGridLayout(this->Internals->FiltersFrame);
+  filterLayout->setMargin(0);
+  this->Internals->FiltersFrame->setSizePolicy(sizeFixedPolicy);
+/*
+  QFrame* BottomFrame = new QFrame(this);
+  this->Internals->BottomFrame = BottomFrame;
+  QVBoxLayout* BottomLayout = new QVBoxLayout(BottomFrame);
+  BottomLayout->setMargin(0);
+  BottomFrame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+*/
+  const System* attSys = this->Internals->UIManager->attSystem();
+
+  this->Internals->FilterByCheck = new QCheckBox(this->Internals->FiltersFrame);
+  this->Internals->FilterByCheck->setText("Show by Category: ");
+  this->Internals->FilterByCheck->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  this->Internals->ShowCategoryCombo = new QComboBox(this->Internals->FiltersFrame);
+  std::set<std::string>::const_iterator it;
+  const std::set<std::string> &cats = attSys->categories();
+  for (it = cats.begin(); it != cats.end(); it++)
+    {
+    this->Internals->ShowCategoryCombo->addItem(it->c_str());
+    }
+  this->Internals->ShowCategoryCombo->setEnabled(false);
+
+  int layoutcol = 0;
+  if(this->Internals->ShowCategoryCombo->count() == 0)
+    {
+    this->Internals->FilterByCheck->setVisible(0);
+    this->Internals->ShowCategoryCombo->setVisible(0);
+    }
+  else
+    {
+    filterLayout->addWidget(this->Internals->FilterByCheck, 0, layoutcol++);
+    filterLayout->addWidget(this->Internals->ShowCategoryCombo, 0, layoutcol++);
+    }
+  QObject::connect(this->Internals->FilterByCheck,
+    SIGNAL(stateChanged(int)), this, SLOT(enableShowBy(int)));
+
+  this->Internals->PropDefsCombo = new QComboBox(this->Internals->FiltersFrame);
+//  this->Internals->PropDefsCombo->setVisible(false);
+  this->Internals->PropDefsCombo->setToolTip("Select definition to filter attributes");
+  filterLayout->addWidget(this->Internals->PropDefsCombo, 0, layoutcol++);
+  QObject::connect(this->Internals->PropDefsCombo,  SIGNAL(currentIndexChanged(int)),
+    this, SLOT(onAttributeDefSelected()), Qt::QueuedConnection);
+
+  this->Internals->SelectPropCombo = new QComboBox(this->Internals->FiltersFrame);
+  this->Internals->SelectPropCombo->setToolTip("Select properties");
+  this->Internals->PropComboModel = new QStandardItemModel();
+  this->Internals->SelectPropCombo->setModel(
+    this->Internals->PropComboModel);
+  QObject::connect(this->Internals->SelectPropCombo,  SIGNAL(currentIndexChanged(int)),
+    this, SLOT(onFieldSelected()), Qt::QueuedConnection);
+  filterLayout->addWidget(this->Internals->SelectPropCombo, 0, layoutcol);
+
+  this->Internals->AttDefMap.clear();
+
+/*
+  QSizePolicy tableSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  // Attribute table
+  this->Internals->ValuesTable = new qtTableWidget(this);
+  this->Internals->ValuesTable->setVisible(false);
+  this->Internals->ValuesTable->setSizePolicy(tableSizePolicy);
+  BottomLayout->addWidget(this->Internals->ValuesTable);
+  this->Internals->ValuesTable->horizontalHeader()->setResizeMode(
+    QHeaderView::ResizeToContents);
+  this->Internals->ValuesTable->verticalHeader()->setResizeMode(
+    QHeaderView::ResizeToContents);
+  this->Internals->ValuesTable->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);
+  QObject::connect(this->Internals->ValuesTable,
+    SIGNAL(itemChanged (QTableWidgetItem *)),
+    this, SLOT(onAttributeValueChanged(QTableWidgetItem * )));
+  this->Internals->ValuesTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+  this->Internals->ValuesTable->setSelectionMode(QAbstractItemView::SingleSelection);
+*/
+
+  thislayout->addWidget(this->Internals->FiltersFrame);
+//  this->addWidget(BottomFrame);
+
+  QObject::connect(this->Internals->ShowCategoryCombo,
+    SIGNAL(currentIndexChanged(int)), this, SLOT(onShowCategory()));
+
+//  if(this->parentWidget()->layout())
+//    {
+//    this->parentWidget()->layout()->addWidget(this);
+//    }
+
+  this->getDefinitionsWithAssociations();
+}
+
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::enableShowBy(int enable)
+{
+  this->Internals->ShowCategoryCombo->setEnabled(enable);
+  this->onShowCategory();
+}
+
+//-----------------------------------------------------------------------------
+smtk::attribute::ItemPtr qtAttributeDisplay::getAttributeItemFromItem(
+  QTableWidgetItem * item)
+{
+  Item* rawPtr = item ?
+    static_cast<Item*>(item->data(Qt::UserRole).value<void *>()) : NULL;
+  return rawPtr ? rawPtr->pointer() : smtk::attribute::ItemPtr();
+}
+/*
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::updateTableWithProperties()
+{
+  this->Internals->ValuesTable->blockSignals(true);
+  this->Internals->ValuesTable->clear();
+  this->Internals->ValuesTable->setRowCount(0);
+  this->Internals->ValuesTable->setColumnCount(0);
+
+  Definition* rawPtr = static_cast<Definition*>(
+    this->Internals->PropDefsCombo->itemData(
+    this->Internals->PropDefsCombo->currentIndex(), Qt::UserRole).value<void *>());
+  if(!rawPtr)
+    {
+    this->Internals->ValuesTable->blockSignals(false);
+    return;
+    }
+
+  std::vector<smtk::attribute::AttributePtr> result;
+  System *attSystem = rawPtr->pointer()->system();
+  attSystem->findAttributes(rawPtr->pointer(), result);
+  if(result.size() == 0)
+    {
+    this->Internals->ValuesTable->blockSignals(false);
+    return;
+    }
+
+  // create column headers
+  QTableWidget* vtWidget = this->Internals->ValuesTable;
+  vtWidget->setColumnCount(1);
+  vtWidget->setHorizontalHeaderItem(0, new QTableWidgetItem("Property"));
+
+  std::vector<smtk::attribute::AttributePtr>::iterator it;
+  int j = 1;
+  for (it=result.begin(); it!=result.end(); ++it)
+    {
+    if(!this->Internals->AttSelections.contains((*it)->name()) ||
+       this->Internals->AttSelections[(*it)->name()] == Qt::Unchecked)
+      {
+      continue;
+      }
+    this->insertTableColumn(vtWidget, j, (*it)->name().c_str(),
+      rawPtr->pointer()->advanceLevel());
+    j++;
+    }
+
+  for(int r=1; r<this->Internals->SelectPropCombo->count(); r++)
+    {
+    QStandardItem* current = this->Internals->checkablePropComboModel->item(r);
+    if(current && current->checkState() == Qt::Checked)
+      {
+      Item* irawPtr =
+        static_cast<Item*>(current->data(Qt::UserRole).value<void *>());
+      if(irawPtr)
+        {
+        smtk::attribute::ItemPtr attItem =
+          irawPtr ? irawPtr->pointer() : smtk::attribute::ItemPtr();
+        smtk::attribute::AttributePtr att = attItem->attribute();
+        this->addComparativeProperty(current, att->definition());
+        }
+      }
+    }
+
+  this->Internals->ValuesTable->blockSignals(false);
+  this->Internals->ValuesTable->resizeColumnsToContents();
+  this->Internals->ValuesTable->resizeRowsToContents();
+}
+*/
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::onShowCategory()
+{
+  bool useCategory = this->Internals->FilterByCheck->isChecked();
+  this->onShowCategory(useCategory ?
+    this->Internals->ShowCategoryCombo->currentText().toStdString() : "");
+}
+
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::onShowCategory(const std::string& strCategory)
+{
+  this->Internals->SelectPropCombo->blockSignals(true);
+  this->Internals->PropDefsCombo->blockSignals(true);
+  this->Internals->SelectPropCombo->clear();
+  this->Internals->PropDefsCombo->clear();
+  this->Internals->SelectPropCombo->blockSignals(false);
+  this->Internals->PropDefsCombo->blockSignals(false);
+
+  this->getDefinitionsWithAssociations();
+  if(!this->Internals->AllAssignedDefs.size())
+    {
+    return;
+    }
+
+  this->Internals->PropDefsCombo->blockSignals(true);
+
+  QList<smtk::attribute::DefinitionPtr> currentDefs =
+    this->Internals->getCurrentDefs(strCategory);
+  foreach (attribute::DefinitionPtr attDef, currentDefs)
+    {
+    if(!attDef->isAbstract())
+      {
+      std::string txtDef = attDef->label().empty() ?
+        attDef->type() : attDef->label();
+      this->Internals->PropDefsCombo->addItem(
+        QString::fromUtf8(txtDef.c_str()));
+      QVariant vdata;
+      vdata.setValue(static_cast<void*>(attDef.get()));
+      int idx = this->Internals->PropDefsCombo->count()-1;
+      this->Internals->PropDefsCombo->setItemData(idx, vdata, Qt::UserRole);
+      }
+    }
+
+//  this->Internals->PropDefsCombo->setVisible(!viewAtt);
+  if(this->Internals->PropDefsCombo->count() > 0)
+    {
+    this->Internals->PropDefsCombo->setCurrentIndex(0);
+    this->initSelectionFilters();
+    }
+
+  this->Internals->PropDefsCombo->blockSignals(false);
+//  this->updateTableWithProperties();
+}
+
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::initSelectionFilters()
+{
+//  this->Internals->ValuesTable->setVisible(1);
+
+  Definition* rawPtr = static_cast<Definition*>(
+    this->Internals->PropDefsCombo->itemData(
+    this->Internals->PropDefsCombo->currentIndex(), Qt::UserRole).value<void *>());
+  if(!rawPtr)
+    return;
+
+  this->initSelectPropCombo(rawPtr->pointer());
+  this->onFieldSelected();
+  //  this->updateTableWithProperties();
+}
+
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::initSelectPropCombo(
+  smtk::attribute::DefinitionPtr attDef)
+{
+  this->Internals->SelectPropCombo->blockSignals(true);
+  this->Internals->SelectPropCombo->clear();
+//  this->Internals->SelectPropCombo->init();
+//  this->Internals->PropComboModel->disconnect();
+  // Adding an entry "Attribute" for the case that we just
+  // want the fact that the attribute existence, not an item value
+  QStandardItem* item = new QStandardItem;
+  item->setText("Attribute");
+  this->Internals->PropComboModel->insertRow(0, item);
+ 
+  if(!attDef)
+    {
+    this->Internals->SelectPropCombo->setCurrentIndex(0);
+    this->Internals->SelectPropCombo->blockSignals(false);
+    return;
+    }
+  std::vector<smtk::attribute::AttributePtr> result;
+  System *attSystem = attDef->system();
+  attSystem->findAttributes(attDef, result);
+  if(result.size() == 0)
+    {
+    this->Internals->SelectPropCombo->setCurrentIndex(0);
+    this->Internals->SelectPropCombo->blockSignals(false);
+    return;
+    }
+
+  smtk::attribute::AttributePtr childData = result[0];
+  // Now lets process its items
+  std::size_t i, n = childData->numberOfItems();
+  int row=1;
+  for (i = 0; i < n; i++)
+    {
+    smtk::attribute::ItemPtr attItem = childData->item(static_cast<int>(i));
+    if(this->Internals->UIManager->passItemCategoryCheck(
+        attItem->definition()) /*&&
+      this->Internals->UIManager->passAdvancedCheck(
+      attItem->advanceLevel()) */)
+      {
+      // No User data, not editable
+      std::string strItemLabel = attItem->label().empty() ? attItem->name() : attItem->label();
+      std::string keyName = childData->definition()->type() + strItemLabel;
+      QStandardItem* item = new QStandardItem;
+      item->setText(strItemLabel.c_str());
+
+      QVariant vdata;
+      vdata.setValue(static_cast<void*>(attItem.get()));
+      item->setData(vdata, Qt::UserRole);
+      this->Internals->PropComboModel->insertRow(row++, item);
+      if(attItem->advanceLevel())
+        {
+        item->setFont(this->Internals->UIManager->advancedFont());
+        }
+      }
+    }
+
+  this->Internals->SelectPropCombo->setCurrentIndex(0);
+  this->Internals->SelectPropCombo->blockSignals(false);
+}
+
+
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::onFieldSelected()
+{
+   Definition* rawPtr = static_cast<Definition*>(
+    this->Internals->PropDefsCombo->itemData(
+    this->Internals->PropDefsCombo->currentIndex(), Qt::UserRole).value<void *>());
+  if(!rawPtr)
+    return;
+
+  Item* irawPtr = NULL;
+  int selrow = this->Internals->SelectPropCombo->currentIndex();
+  if(selrow >= 0)
+    {
+    QStandardItem* item = this->Internals->PropComboModel->item(selrow);
+    irawPtr = static_cast<Item*>(item->data(Qt::UserRole).value<void *>());
+    }
+
+  emit this->attributeFieldSelected(rawPtr->pointer()->type().c_str(),
+    irawPtr ? irawPtr->pointer()->name().c_str() : "");
+
+/*
+  if(rawPtr)
+    {
+    this->Internals->ValuesTable->blockSignals(true);
+    smtk::attribute::ItemPtr attItem = rawPtr->pointer();
+    smtk::attribute::AttributePtr att = attItem->attribute();
+    if(item->checkState() == Qt::Checked)
+      {
+      this->addComparativeProperty(item, att->definition());
+      }
+    else
+      {
+      this->removeComparativeProperty(item->text());
+      }
+
+    this->Internals->ValuesTable->blockSignals(false);
+    this->Internals->ValuesTable->resizeColumnsToContents();
+    this->Internals->ValuesTable->resizeRowsToContents();
+    }
+*/
+}
+
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::onAttributeDefSelected()
+{
+  this->initSelectionFilters();
+  //this->updateTableWithProperties();
+}
+
+//----------------------------------------------------------------------------
+void qtAttributeDisplay::getDefinitionsWithAssociations()
+{
+  if(!this->Internals->UIManager)
+    return;
+
+  smtk::attribute::System *attsys = this->Internals->UIManager->attSystem();
+  this->Internals->AllAssignedDefs.clear();
+  this->Internals->AttDefMap.clear();
+
+  std::vector<smtk::attribute::AttributePtr> atts;
+  attsys->attributes(atts);
+  if(atts.size() == 0)
+    return;
+
+#ifndef _MSC_VER
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
+  smtk::model::ManagerPtr modelManager = attsys->refModelManager();
+  if(!modelManager)
+    return;
+  smtk::model::UUIDsToAttributeAssignments::const_iterator it;
+  for(it = modelManager->attributeAssignments().begin();
+      it != modelManager->attributeAssignments().end() ; ++it)
+    {
+    smtk::model::AttributeSet associatedAtts = it->second.attributes();
+    typedef smtk::model::AttributeSet::const_iterator cit;
+    for (cit i = associatedAtts.begin(); i != associatedAtts.end(); ++i)
+      {
+      smtk::attribute::AttributePtr attPtr = attsys->findAttribute( (*i) );
+      if(attPtr)
+        {
+        smtk::attribute::DefinitionPtr attDef = attPtr->definition();
+        if(!this->Internals->AllAssignedDefs.contains(attDef))
+          this->Internals->AllAssignedDefs.push_back(attDef);
+
+        const std::set<std::string> &cats = attsys->categories();
+        std::set<std::string>::const_iterator catit;
+        for(catit = cats.begin(); catit != cats.end(); ++catit)
+          {
+          if(attDef->isMemberOf(*catit) &&
+            !this->Internals->AttDefMap[*catit].contains(attDef))
+            {
+            this->Internals->AttDefMap[*catit].push_back(attDef);
+            }
+          }
+        }
+      }
+    }
+
+#ifndef _MSC_VER
+#  pragma GCC diagnostic pop
+#endif
+}

--- a/smtk/extension/qt/qtAttributeDisplay.cxx
+++ b/smtk/extension/qt/qtAttributeDisplay.cxx
@@ -481,44 +481,29 @@ void qtAttributeDisplay::getDefinitionsWithAssociations()
   if(atts.size() == 0)
     return;
 
-#ifndef _MSC_VER
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wshadow"
-#endif
-
-  smtk::model::ManagerPtr modelManager = attsys->refModelManager();
-  if(!modelManager)
+  if(!attsys->refModelManager())
     return;
-  smtk::model::UUIDsToAttributeAssignments::const_iterator it;
-  for(it = modelManager->attributeAssignments().begin();
-      it != modelManager->attributeAssignments().end() ; ++it)
-    {
-    smtk::model::AttributeSet associatedAtts = it->second.attributes();
-    typedef smtk::model::AttributeSet::const_iterator cit;
-    for (cit i = associatedAtts.begin(); i != associatedAtts.end(); ++i)
-      {
-      smtk::attribute::AttributePtr attPtr = attsys->findAttribute( (*i) );
-      if(attPtr)
-        {
-        smtk::attribute::DefinitionPtr attDef = attPtr->definition();
-        if(!this->Internals->AllAssignedDefs.contains(attDef))
-          this->Internals->AllAssignedDefs.push_back(attDef);
 
-        const std::set<std::string> &cats = attsys->categories();
-        std::set<std::string>::const_iterator catit;
-        for(catit = cats.begin(); catit != cats.end(); ++catit)
-          {
-          if(attDef->isMemberOf(*catit) &&
-            !this->Internals->AttDefMap[*catit].contains(attDef))
-            {
-            this->Internals->AttDefMap[*catit].push_back(attDef);
-            }
-          }
+  std::vector<smtk::attribute::AttributePtr>::const_iterator it;
+  for(it = atts.begin(); it != atts.end(); ++it)
+    {
+    if((*it)->associatedModelEntityIds().size() == 0)
+      {
+      continue;
+      }
+    smtk::attribute::DefinitionPtr attDef = (*it)->definition();
+    if(!this->Internals->AllAssignedDefs.contains(attDef))
+      this->Internals->AllAssignedDefs.push_back(attDef);
+
+    const std::set<std::string> &cats = attsys->categories();
+    std::set<std::string>::const_iterator catit;
+    for(catit = cats.begin(); catit != cats.end(); ++catit)
+      {
+      if(attDef->isMemberOf(*catit) &&
+        !this->Internals->AttDefMap[*catit].contains(attDef))
+        {
+        this->Internals->AttDefMap[*catit].push_back(attDef);
         }
       }
     }
-
-#ifndef _MSC_VER
-#  pragma GCC diagnostic pop
-#endif
 }

--- a/smtk/extension/qt/qtAttributeDisplay.h
+++ b/smtk/extension/qt/qtAttributeDisplay.h
@@ -1,0 +1,73 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+// .NAME qtAttributeDisplay - display controls for entity associated Attribute
+// .SECTION Description
+// .SECTION See Also
+// qtSection
+
+#ifndef __smtk_attribute_qtAttributeDisplay_h
+#define __smtk_attribute_qtAttributeDisplay_h
+
+#include <QWidget>
+#include "smtk/extension/qt/Exports.h"
+#include "smtk/PublicPointerDefs.h"
+
+#include <QMap>
+
+class QTableWidgetItem;
+class qtAttributeDisplayInternals;
+
+namespace smtk
+{
+  namespace attribute
+  {
+
+    class qtUIManager;
+
+    class SMTKQTEXT_EXPORT qtAttributeDisplay : public QWidget
+    {
+      Q_OBJECT
+
+    public:
+      qtAttributeDisplay(QWidget* p, smtk::attribute::qtUIManager* uiman);
+      virtual ~qtAttributeDisplay();
+
+    public slots:
+      void onShowCategory();
+      void onShowCategory(const std::string& strCategory);
+      void onAttributeDefSelected();
+      void onFieldSelected();
+      virtual void getDefinitionsWithAssociations();
+
+    signals:
+      void attColorChanged();
+      void attributeFieldSelected(const QString& attdeftype,
+        const QString& itemname);
+
+    protected slots:
+      void enableShowBy(int enable);
+
+    protected:
+      virtual void createWidget( );
+      smtk::attribute::ItemPtr getAttributeItemFromItem(QTableWidgetItem * item);
+
+      void initSelectionFilters();
+      void initSelectPropCombo(smtk::attribute::DefinitionPtr attDef);
+
+    private:
+
+      qtAttributeDisplayInternals *Internals;
+
+    }; // class
+  }; // namespace attribute
+}; // namespace smtk
+
+
+#endif

--- a/smtk/extension/qt/qtAttributeDisplay.h
+++ b/smtk/extension/qt/qtAttributeDisplay.h
@@ -58,8 +58,9 @@ namespace smtk
       virtual void createWidget( );
       smtk::attribute::ItemPtr getAttributeItemFromItem(QTableWidgetItem * item);
 
-      void initSelectionFilters();
-      void initSelectPropCombo(smtk::attribute::DefinitionPtr attDef);
+      void initSelectionFilters(const QString& currentItemName="");
+      void initSelectPropCombo(smtk::attribute::DefinitionPtr attDef,
+                               const QString& currentItemName="");
 
     private:
 

--- a/smtk/extension/vtk/vtkModelMultiBlockSource.cxx
+++ b/smtk/extension/vtk/vtkModelMultiBlockSource.cxx
@@ -283,7 +283,7 @@ static void AddEntityTessToPolyData(
 
 /// Add customized block info.
 /// Mapping from UUID to block id
-/// Field data arrays
+/// 'Volume' field array to color by volume
 static void internal_AddBlockInfo(smtk::model::ManagerPtr manager,
   const smtk::model::EntityRef& entityref, const smtk::model::EntityRef& bordantCell,
   const vtkIdType& blockId,
@@ -303,46 +303,7 @@ static void internal_AddBlockInfo(smtk::model::ManagerPtr manager,
   smtk::model::EntityRefs vols;
   if(bordantCell.isValid() && bordantCell.isVolume())
     vols.insert(bordantCell);
-/*
-  EntityRef embIn = entityref.embeddedIn();
-  if(embIn.isValid() && embIn.isVolume())
-      vols.insert(embIn);
-  else
-    {
-    while(embIn.isValid())
-      {
-      embIn = embIn.embeddedIn();
-      if(embIn.isValid() && embIn.isVolume())
-        {
-        vols.insert(embIn);
-        break;
-        }
-      }
-    }
-*/
-/*
-  if(entityref.isEdge())
-    {
-    smtk::model::Edge eg = entityref.as<smtk::model::Edge>();
-    for(smtk::model::EdgeUses::iterator it = eg.edgeUses().begin();
-        it != eg.edgeUses().end(); ++it)
-      {
-      if((*it).faceUse().isValid())
-        vols.push_back((*it).faceUse().volume());
-      }
-    }
-  else if(entityref.isFace())
-    {
-    //vols = entityref.as<smtk::model::Face>().volumes(); // not working yet
-    smtk::model::FaceUse fUse = entityref.as<smtk::model::Face>().negativeUse();
-    if(fUse.isValid())
-      vols.push_back(fUse.volume());
-    fUse = entityref.as<smtk::model::Face>().positiveUse();
-    if(fUse.isValid())
-      vols.push_back(fUse.volume());
-    }
-*/
-  if(vols.size())
+ if(vols.size())
     {
     // Add volume UUID to fieldData
     vtkNew<vtkStringArray> volArray;
@@ -356,22 +317,6 @@ static void internal_AddBlockInfo(smtk::model::ManagerPtr manager,
       }
     volArray->SetName(vtkModelMultiBlockSource::GetVolumeTagName());
     poly->GetFieldData()->AddArray(volArray.GetPointer());
-    }
-
-  // Add group UUID to fieldData
-  vtkNew<vtkStringArray> groupArray;
-  groupArray->SetNumberOfComponents(1);
-  int na = entityref.numberOfArrangementsOfKind(SUBSET_OF);
-  if(na > 0)
-    {
-    groupArray->SetNumberOfTuples(na);
-    for (int i = 0; i < na; ++i)
-      {
-      groupArray->SetValue(i,
-        entityref.relationFromArrangement(SUBSET_OF, i, 0).entity().toString());
-      }
-    groupArray->SetName(vtkModelMultiBlockSource::GetGroupTagName());
-    poly->GetFieldData()->AddArray(groupArray.GetPointer());
     }
 }
 

--- a/smtk/extension/vtk/vtkModelMultiBlockSource.h
+++ b/smtk/extension/vtk/vtkModelMultiBlockSource.h
@@ -66,6 +66,7 @@ public:
   static const char* GetEntityTagName() { return "Entity"; }
   static const char* GetGroupTagName() { return "Group"; }
   static const char* GetVolumeTagName() { return "Volume"; }
+  static const char* GetAttributeTagName() { return "Attribute"; }
 
 protected:
   vtkModelMultiBlockSource();

--- a/smtk/io/XmlDocV1Parser.cxx
+++ b/smtk/io/XmlDocV1Parser.cxx
@@ -2382,11 +2382,11 @@ void XmlDocV1Parser::processViews(xml_node &root)
   if (node)
     {
     smtk::common::View::Component comp = rootView->details().addChild("AdvancedFontEffects");
-    if(xml_attribute txtatt = node.attribute("Bold"))
+    if(node.attribute("Bold"))
       {
       comp.setAttribute("Bold", "t");
       }
-    if(xml_attribute txtatt = node.attribute("Italic"))
+    if(node.attribute("Italic"))
       {
       comp.setAttribute("Italic", "t");
       }

--- a/smtk/model/AttributeListPhrase.cxx
+++ b/smtk/model/AttributeListPhrase.cxx
@@ -42,7 +42,7 @@ std::string AttributeListPhrase::title()
 {
   std::ostringstream message;
   DescriptivePhrases::size_type sz =
-    this->m_attributes.empty() ? this->m_entity.attributes().attributes().size() : this->m_attributes.size();
+    this->m_attributes.empty() ? this->m_entity.attributes().size() : this->m_attributes.size();
   message << sz << " " << (sz == 1 ? "attribute" : "attributes");
   return message.str();
 }

--- a/smtk/model/EntityRef.cxx
+++ b/smtk/model/EntityRef.cxx
@@ -678,19 +678,28 @@ bool EntityRef::disassociateAttribute(smtk::attribute::System* sys,
   return mgr->disassociateAttribute(sys, attribId, this->m_entity, reverse);
 }
 
-/**\brief Does the entityref have any attributes associated with it?
+/**\brief Remove all attribute association form this entityref
   */
-AttributeAssignments& EntityRef::attributes()
+bool EntityRef::disassociateAllAttributes(smtk::attribute::System* sys,
+   const smtk::common::UUID& fromEntity, bool reverse)
 {
-  ManagerPtr mgr = this->m_manager.lock();
-  return mgr->attributeAssignments()[this->m_entity];
+  AttributeSet atts = this->attributes();
+  AttributeSet::const_iterator it;
+  bool res = true;
+  for(it = atts.begin(); it != atts.end(); ++it)
+    {
+    if(!this->disassociateAttribute(sys, *it, reverse))
+      res = false;
+    }
+  return res;
 }
+
 /**\brief Does the entityref have any attributes associated with it?
   */
 AttributeSet EntityRef::attributes() const
 {
   ManagerPtr mgr = this->m_manager.lock();
-  return mgr->attributeAssignments()[this->m_entity].attributes();
+  return mgr->attributeAssignments().find(this->m_entity)->second.attributes();
 }
 ///@}
 

--- a/smtk/model/EntityRef.cxx
+++ b/smtk/model/EntityRef.cxx
@@ -13,6 +13,7 @@
 #include "smtk/model/DefaultSession.h"
 #include "smtk/model/Entity.h"
 #include "smtk/model/Events.h"
+#include "smtk/model/Group.h"
 #include "smtk/model/Manager.h"
 #include "smtk/model/Model.h"
 #include "smtk/model/Tessellation.h"
@@ -661,18 +662,20 @@ bool EntityRef::hasAttributes() const
 
 /**\brief Does the entityref have any attributes associated with it?
   */
-bool EntityRef::associateAttribute(const smtk::common::UUID &attribId)
+bool EntityRef::associateAttribute(smtk::attribute::System* sys,
+                                   const smtk::common::UUID &attribId)
 {
   ManagerPtr mgr = this->m_manager.lock();
-  return mgr->associateAttribute(attribId, this->m_entity);
+  return mgr->associateAttribute(sys, attribId, this->m_entity);
 }
 
 /**\brief Does the entityref have any attributes associated with it?
   */
-bool EntityRef::disassociateAttribute(const smtk::common::UUID &attribId, bool reverse)
+bool EntityRef::disassociateAttribute(smtk::attribute::System* sys,
+                                      const smtk::common::UUID &attribId, bool reverse)
 {
   ManagerPtr mgr = this->m_manager.lock();
-  return mgr->disassociateAttribute(attribId, this->m_entity, reverse);
+  return mgr->disassociateAttribute(sys, attribId, this->m_entity, reverse);
 }
 
 /**\brief Does the entityref have any attributes associated with it?
@@ -1093,6 +1096,16 @@ Model EntityRef::owningModel() const
   return Model(
     mgr,
     mgr->modelOwningEntity(this->m_entity));
+}
+
+/**\brief Return the Groups which contains this entity.
+  *
+  */
+Groups EntityRef::containingGroups() const
+{
+  Groups result;
+  EntityRefArrangementOps::appendAllRelations(*this, SUBSET_OF, result);
+  return result;
 }
 
 /// A comparator provided so that entityrefs may be included in ordered sets.

--- a/smtk/model/EntityRef.h
+++ b/smtk/model/EntityRef.h
@@ -178,7 +178,9 @@ public:
   bool associateAttribute(smtk::attribute::System* sys, const smtk::common::UUID &attribId);
   bool disassociateAttribute(smtk::attribute::System* sys,
                              const smtk::common::UUID &attribId, bool reverse = true);
-  AttributeAssignments& attributes();
+  bool disassociateAllAttributes(smtk::attribute::System* sys,
+   const smtk::common::UUID& fromEntity, bool reverse = true);
+
   AttributeSet attributes() const;
 
 #ifndef SHIBOKEN_SKIP

--- a/smtk/model/EntityRef.h
+++ b/smtk/model/EntityRef.h
@@ -65,6 +65,7 @@ class Tessellation;
 // Use full names including namespace to make Shiboken less unhappy:
 typedef std::set<smtk::model::EntityRef> EntityRefs;
 typedef std::vector<smtk::model::EntityRef> EntityRefArray;
+typedef std::vector<Group> Groups;
 
 /**\brief A lightweight entityref pointing to a model entity's manager.
   *
@@ -174,8 +175,9 @@ public:
 
   bool hasAttributes() const;
   bool hasAttribute(const smtk::common::UUID &attribId) const;
-  bool associateAttribute(const smtk::common::UUID &attribId);
-  bool disassociateAttribute(const smtk::common::UUID &attribId, bool reverse = true);
+  bool associateAttribute(smtk::attribute::System* sys, const smtk::common::UUID &attribId);
+  bool disassociateAttribute(smtk::attribute::System* sys,
+                             const smtk::common::UUID &attribId, bool reverse = true);
   AttributeAssignments& attributes();
   AttributeSet attributes() const;
 
@@ -238,6 +240,7 @@ public:
   template<typename T> T instances() const;
 
   Model owningModel() const;
+  Groups containingGroups() const;
 
   bool operator == (const EntityRef& other) const;
   bool operator < (const EntityRef& other) const;

--- a/smtk/model/Manager.cxx
+++ b/smtk/model/Manager.cxx
@@ -63,7 +63,6 @@ Manager::Manager() :
   m_analysisMesh(new UUIDsToTessellations),
   m_attributeAssignments(new UUIDsToAttributeAssignments),
   m_sessions(new UUIDsToSessions),
-  m_attributeSystem(NULL),
   m_globalCounters(2,1) // first entry is session counter, second is model counter
 {
   // TODO: throw() when topology == NULL?
@@ -86,7 +85,6 @@ Manager::Manager(
     m_analysisMesh(mesh),
     m_attributeAssignments(attribs),
     m_sessions(new UUIDsToSessions),
-    m_attributeSystem(NULL),
     m_globalCounters(2,1) // first entry is session counter, second is model counter
 {
 }
@@ -102,7 +100,7 @@ Manager::~Manager()
     // listeners that deletions are occurring.
     this->unregisterSession(this->m_defaultSession, false);
     }
-  this->setAttributeSystem(NULL, false);
+  this->m_attributeAssignments->clear();
 }
 //@}
 
@@ -334,58 +332,6 @@ SessionInfoBits Manager::eraseModel(const Model& model, SessionInfoBits flags)
   this->erase(model.entity(), flags);
 
   return true;
-}
-
-/**\brief Set the attribute manager.
-  *
-  * This is an error if the manager already has a non-null
-  * reference to a different model manager instance.
-  *
-  * If this manager is associated with a different attribute system,
-  * that attribute system is detached (its model manager reference
-  * set to null) and all attribute associations in the model manager
-  * are erased.
-  * This is not an error, but a warning message will be generated.
-  *
-  * On error, false is returned, an error message is generated,
-  * and no change is made to the attribute system.
-  */
-bool Manager::setAttributeSystem(smtk::attribute::System* attSys, bool reverse)
-{
-  if (attSys)
-    {
-    smtk::model::Manager* attSysModelMgr = attSys->refModelManager().get();
-    if (attSysModelMgr && attSysModelMgr != this)
-      {
-      return false;
-      }
-    }
-  if (this->m_attributeSystem && this->m_attributeSystem != attSys)
-    {
-    // Only warn when (a) the new manager is non-NULL and (b) we
-    // have at least 1 attribute association.
-    if (!this->m_attributeAssignments->empty() && attSys)
-      {
-      smtkInfoMacro(this->m_log,
-        "WARNING: Changing attribute managers.\n"
-        "         Current attribute associations cleared.\n");
-      this->m_attributeAssignments->clear();
-      }
-    if (reverse)
-      this->m_attributeSystem->setRefModelManager(ManagerPtr());
-    }
-  this->m_attributeSystem = attSys;
-  if (this->m_attributeSystem && reverse)
-    this->m_attributeSystem->setRefModelManager(shared_from_this());
-  return true;
-}
-
-/**\brief Return the attribute manager associated with this model manager.
-  *
-  */
-smtk::attribute::System* Manager::attributeSystem() const
-{
-  return this->m_attributeSystem;
 }
 
 /// Entity construction
@@ -2906,12 +2852,15 @@ bool Manager::hasAttribute(const UUID&  attribId, const UUID& toEntity)
   * valid (whether it was previously associated or not)
   * and false otherwise.
   */
-bool Manager::associateAttribute(const UUID&  attribId, const UUID& toEntity)
+bool Manager::associateAttribute(
+  smtk::attribute::System* sys,
+  const UUID&  attribId,
+  const UUID& toEntity)
 {
   bool allowed = true;
-  if (this->m_attributeSystem)
+  if (sys)
     {
-    attribute::AttributePtr att = this->m_attributeSystem->findAttribute(attribId);
+    attribute::AttributePtr att = sys->findAttribute(attribId);
     if (!att || !att->associateEntity(toEntity))
       allowed = false;
     }
@@ -2923,7 +2872,11 @@ bool Manager::associateAttribute(const UUID&  attribId, const UUID& toEntity)
 /**\brief Unassign an attribute from an entity.
   *
   */
-bool Manager::disassociateAttribute(const UUID&  attribId, const UUID& fromEntity, bool reverse)
+bool Manager::disassociateAttribute(
+  smtk::attribute::System* sys,
+  const UUID&  attribId,
+  const UUID& fromEntity,
+  bool reverse)
 {
   bool didRemove = false;
   UUIDWithAttributeAssignments ref = this->m_attributeAssignments->find(fromEntity);
@@ -2943,18 +2896,15 @@ bool Manager::disassociateAttribute(const UUID&  attribId, const UUID& fromEntit
       }
 #endif
     // Notify the Attribute of the removal
-    if (reverse)
+    if (reverse && sys)
       {
-      if (this->m_attributeSystem)
+      smtk::attribute::AttributePtr attrib =
+        sys->findAttribute(attribId);
+      // FIXME: Should we check that the manager's refManager
+      //        is this Manager instance?
+      if (attrib)
         {
-        smtk::attribute::AttributePtr attrib =
-          this->m_attributeSystem->findAttribute(attribId);
-        // FIXME: Should we check that the manager's refManager
-        //        is this Manager instance?
-        if (attrib)
-          {
-          attrib->disassociateEntity(fromEntity, false);
-          }
+        attrib->disassociateEntity(fromEntity, false);
         }
       }
     }

--- a/smtk/model/Manager.cxx
+++ b/smtk/model/Manager.cxx
@@ -149,11 +149,6 @@ const UUIDsToTessellations& Manager::analysisMesh() const
   return *this->m_analysisMesh.get();
 }
 
-UUIDsToAttributeAssignments& Manager::attributeAssignments()
-{
-  return *this->m_attributeAssignments;
-}
-
 const UUIDsToAttributeAssignments& Manager::attributeAssignments() const
 {
   return *this->m_attributeAssignments;
@@ -231,7 +226,7 @@ SessionInfoBits Manager::erase(const UUID& uid, SessionInfoBits flags)
     this->tessellations().erase(uid);
 
   if (actual & SESSION_ATTRIBUTE_ASSOCIATIONS)
-    this->attributeAssignments().erase(uid);
+    this->m_attributeAssignments->erase(uid);
 
   // TODO: If this entity is a model and has parents, we should make
   //       the parent own the child models? Erase the children? Leave
@@ -2865,7 +2860,7 @@ bool Manager::associateAttribute(
       allowed = false;
     }
   if (allowed)
-    this->attributeAssignments()[toEntity].associateAttribute(attribId);
+    (*this->m_attributeAssignments)[toEntity].associateAttribute(attribId);
   return allowed;
 }
 

--- a/smtk/model/Manager.h
+++ b/smtk/model/Manager.h
@@ -120,7 +120,6 @@ public:
   UUIDsToTessellations& analysisMesh();
   const UUIDsToTessellations& analysisMesh() const;
 
-  UUIDsToAttributeAssignments& attributeAssignments();
   const UUIDsToAttributeAssignments& attributeAssignments() const;
 
   BitFlags type(const smtk::common::UUID& ofEntity) const;

--- a/smtk/model/Manager.h
+++ b/smtk/model/Manager.h
@@ -123,8 +123,6 @@ public:
   UUIDsToAttributeAssignments& attributeAssignments();
   const UUIDsToAttributeAssignments& attributeAssignments() const;
 
-  smtk::attribute::System* attributeSystem() const;
-
   BitFlags type(const smtk::common::UUID& ofEntity) const;
   int dimension(const smtk::common::UUID& ofEntity) const;
   std::string name(const smtk::common::UUID& ofEntity) const;
@@ -300,8 +298,10 @@ public:
   bool findOrAddEntityToGroup(const smtk::common::UUID& grp, const smtk::common::UUID& ent);
 
   bool hasAttribute(const smtk::common::UUID&  attribId, const smtk::common::UUID& toEntity);
-  bool associateAttribute(const smtk::common::UUID&  attribId, const smtk::common::UUID& toEntity);
-  bool disassociateAttribute(const smtk::common::UUID&  attribId, const smtk::common::UUID& fromEntity, bool reverse = true);
+  bool associateAttribute(smtk::attribute::System* sys,
+                          const smtk::common::UUID&  attribId, const smtk::common::UUID& toEntity);
+  bool disassociateAttribute(smtk::attribute::System* sys,
+                             const smtk::common::UUID&  attribId, const smtk::common::UUID& fromEntity, bool reverse = true);
 
   Vertex insertVertex(const smtk::common::UUID& uid);
   Edge insertEdge(const smtk::common::UUID& uid);
@@ -395,7 +395,6 @@ protected:
   std::string assignDefaultName(const smtk::common::UUID& uid, BitFlags entityFlags);
   IntegerList& entityCounts(const smtk::common::UUID& modelId, BitFlags entityFlags);
   void prepareForEntity(std::pair<smtk::common::UUID,Entity>& entry);
-  bool setAttributeSystem(smtk::attribute::System* sys, bool reverse = true);
 
   // Below are all the different things that can be mapped to a UUID:
   smtk::shared_ptr<UUIDsToEntities> m_topology;
@@ -407,8 +406,6 @@ protected:
   smtk::shared_ptr<UUIDsToTessellations> m_analysisMesh;
   smtk::shared_ptr<UUIDsToAttributeAssignments> m_attributeAssignments;
   smtk::shared_ptr<UUIDsToSessions> m_sessions;
-
-  smtk::attribute::System* m_attributeSystem; // Attribute systems may own a model
 
   smtk::shared_ptr<Session> m_defaultSession;
   smtk::common::UUIDGenerator m_uuidGenerator;

--- a/smtk/model/Model.h
+++ b/smtk/model/Model.h
@@ -19,7 +19,6 @@ class CellEntity;
 class Group;
 class Model;
 typedef std::vector<CellEntity> CellEntities;
-typedef std::vector<Group> Groups;
 typedef std::vector<Model> Models;
 
 /**\brief A entityref subclass that provides methods specific to models.

--- a/smtk/model/testing/cxx/unitEntityRef.cxx
+++ b/smtk/model/testing/cxx/unitEntityRef.cxx
@@ -401,10 +401,10 @@ int main(int argc, char* argv[])
     aid1 = smtk::common::UUID::random();
     aid2 = smtk::common::UUID::random();
     test(!entity.hasAttributes(), "Detecting an un-associated attribute");
-    test( entity.associateAttribute(aid1), "Associating an attribute");
-    test( entity.associateAttribute(aid1), "Re-associating a repeated attribute");
-    test( entity.disassociateAttribute(aid1), "Disassociating an associated attribute");
-    test(!entity.disassociateAttribute(aid2), "Disassociating an un-associated attribute");
+    test( entity.associateAttribute(NULL, aid1), "Associating an attribute");
+    test( entity.associateAttribute(NULL, aid1), "Re-associating a repeated attribute");
+    test( entity.disassociateAttribute(NULL, aid1), "Disassociating an associated attribute");
+    test(!entity.disassociateAttribute(NULL, aid2), "Disassociating an un-associated attribute");
 
     // Test that face entity was created with invalid (but present) face uses.
     Face f(sm, uids[20]);

--- a/smtk/model/testing/cxx/unitManager.cxx
+++ b/smtk/model/testing/cxx/unitManager.cxx
@@ -190,11 +190,11 @@ int main(int argc, char* argv[])
   smtk::common::UUID aid1, aid2;
   aid1 = smtk::common::UUID::random();
   aid2 = smtk::common::UUID::random();
-  test( sm->associateAttribute(/*attribId*/aid1, uids[0]), "Inserting a new attribute should succeed");
-  test( sm->associateAttribute(/*attribId*/aid2, uids[0]), "Inserting a new attribute should succeed");
-  test( sm->associateAttribute(/*attribId*/aid1, uids[0]), "Inserting an attribute twice should succeed");
-  test( sm->disassociateAttribute(/*attribId*/aid1, uids[0]), "Removing a non-existent attribute should fail");
-  test(!sm->disassociateAttribute(/*attribId*/aid1, uids[1]), "Removing a non-existent attribute should fail");
+  test( sm->associateAttribute(NULL, /*attribId*/aid1, uids[0]), "Inserting a new attribute should succeed");
+  test( sm->associateAttribute(NULL, /*attribId*/aid2, uids[0]), "Inserting a new attribute should succeed");
+  test( sm->associateAttribute(NULL, /*attribId*/aid1, uids[0]), "Inserting an attribute twice should succeed");
+  test( sm->disassociateAttribute(NULL, /*attribId*/aid1, uids[0]), "Removing a non-existent attribute should fail");
+  test(!sm->disassociateAttribute(NULL, /*attribId*/aid1, uids[1]), "Removing a non-existent attribute should fail");
 
   // Test removal of arrangement information and entities.
   // Remove a volume from its volume use and the model containing it.

--- a/smtk/model/testing/python/entityRefTutorial.py
+++ b/smtk/model/testing/python/entityRefTutorial.py
@@ -33,7 +33,7 @@ for coord in ['x', 'y', 'z']:
    vdef.addItemDefinition(vi);
 
 velocity = system.createAttribute('velocity', vdef)
-inlet.associateAttribute(velocity.id())
+inlet.associateAttribute(system, velocity.id())
 
 print sm.entitiesOfDimension(2)
 print sm.entitiesOfDimension(3)


### PR DESCRIPTION
Model manager had one and only one reference to an attribute system, so when we do entity association with attribute from different attribute system, such as model operators or simulation templates, we have to switch back and forth the attribute system of the model manager.
This added extra burden for application to manage the logic for switching the system, also could cause hard-to-find bugs if the application logic is not properly handled. So we removed the reference to attribute system from model manager, and changed the association api to include the attribute system as an argument. The manager stills contains the map of entity and its associations for easy access from smtk, but now the association api eliminates the ambiguity of which attribute system to use.

Also, in Manager and EntityRef classes, there were non-const accessor to the entity-attributes assignment map, which could potentially cause inconsistency of the map records in the manager and attribute if developers get hold of the map and modify it directly without going through Manager. By removing these non-const accessors, the developers have to go through the public api in manager to update the map so that we can ensure the map is consistent in the system.