### PR TITLE
Added signal in qtAssociationWidget to broadcast selected entities.

### DIFF
--- a/smtk/extension/qt/qtAssociationWidget.cxx
+++ b/smtk/extension/qt/qtAssociationWidget.cxx
@@ -113,10 +113,10 @@ void qtAssociationWidget::initWidget( )
   // signals/slots
   QObject::connect(this->Internals->CurrentList,
     SIGNAL(currentItemChanged (QListWidgetItem * , QListWidgetItem * )),
-    this, SLOT(onCurrentListSelectionChanged(QListWidgetItem * , QListWidgetItem * )));
+    this, SLOT(onEntitySelected(QListWidgetItem * , QListWidgetItem * )));
   QObject::connect(this->Internals->AvailableList,
     SIGNAL(currentItemChanged (QListWidgetItem * , QListWidgetItem * )),
-    this, SLOT(onAvailableListSelectionChanged(QListWidgetItem * , QListWidgetItem * )));
+    this, SLOT(onEntitySelected(QListWidgetItem * , QListWidgetItem * )));
 
   QObject::connect(this->Internals->MoveToRight,
     SIGNAL(clicked()), this, SLOT(onRemoveAssigned()));
@@ -233,18 +233,20 @@ void qtAssociationWidget::showAttributeAssociation(
       if( theEntiy.hasAttribute( (*itAtt)->id() ) )
         {
         this->addAttributeAssociationItem(
-          this->Internals->CurrentList, *itAtt);
+          this->Internals->CurrentList, *itAtt, false);
         }
       else if(!uniqueDefs.contains(*itAttDef))
         {
         // we need to make sure this att is not associated with other
         // same type model entities.
         this->addAttributeAssociationItem(
-          this->Internals->AvailableList, *itAtt);
+          this->Internals->AvailableList, *itAtt, false);
         }
       }
     }
 
+  this->Internals->CurrentList->sortItems();
+  this->Internals->AvailableList->sortItems();
   this->Internals->CurrentList->blockSignals(false);
   this->Internals->AvailableList->blockSignals(false);
 }
@@ -304,8 +306,9 @@ void qtAssociationWidget::showEntityAssociation(
   typedef smtk::model::EntityRefs::const_iterator cit;
   for (cit i =modelEnts.begin(); i != modelEnts.end(); ++i)
     {
-    this->addModelAssociationListItem(this->Internals->CurrentList, *i);
+    this->addModelAssociationListItem(this->Internals->CurrentList, *i, false);
     }
+  this->Internals->CurrentList->sortItems();
   std::set<smtk::model::EntityRef> usedModelEnts = this->processAttUniqueness(attDef, modelEnts);
 
   // Now that we have add all the used model entities, we need to move on to all model
@@ -331,9 +334,9 @@ void qtAssociationWidget::showEntityAssociation(
   for(EntityRefs::iterator i = avail.begin(); i != avail.end(); ++i)
     {
     if (tmpGrp.meetsMembershipConstraints(*i))
-      this->addModelAssociationListItem(this->Internals->AvailableList, *i);
+      this->addModelAssociationListItem(this->Internals->AvailableList, *i, false);
     }
-
+  this->Internals->AvailableList->sortItems();
   this->Internals->CurrentList->blockSignals(false);
   this->Internals->AvailableList->blockSignals(false);
 }
@@ -422,17 +425,20 @@ qtAssociationWidget::processDefUniqueness(const smtk::model::EntityRef& theEntit
   return uniqueDefs;
 }
 
-
 //----------------------------------------------------------------------------
-void qtAssociationWidget::onCurrentListSelectionChanged(
-  QListWidgetItem * /*current*/, QListWidgetItem * /*previous*/)
+void qtAssociationWidget::onEntitySelected(
+  QListWidgetItem * currentItem, QListWidgetItem * /*previous*/)
 {
-}
-
-//----------------------------------------------------------------------------
-void qtAssociationWidget::onAvailableListSelectionChanged(
-  QListWidgetItem * /*current*/, QListWidgetItem * /*previous*/)
-{
+  if(currentItem)
+    {
+    smtk::model::EntityRef entref = this->getModelEntityItem(currentItem);
+    if(entref.isValid())
+      {
+      smtk::common::UUIDs selents;
+      selents.insert(entref.entity());
+      this->Internals->View->uiManager()->invokeEntitiesSelected(selents);
+      }
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -498,7 +504,7 @@ void qtAssociationWidget::removeSelectedItem(QListWidget* theList)
 
 //----------------------------------------------------------------------------
 QListWidgetItem* qtAssociationWidget::addModelAssociationListItem(
-  QListWidget* theList, smtk::model::EntityRef modelItem)
+  QListWidget* theList, smtk::model::EntityRef modelItem, bool sort)
 {
   QListWidgetItem* item = new QListWidgetItem(
                             QString::fromStdString(modelItem.name()),
@@ -508,12 +514,16 @@ QListWidgetItem* qtAssociationWidget::addModelAssociationListItem(
   QVariant vdata( QString::fromStdString(modelItem.entity().toString()) );
   item->setData(Qt::UserRole, vdata);
   theList->addItem(item);
+  if(sort)
+    {
+    theList->sortItems();
+    }
   return item;
 }
 
 //----------------------------------------------------------------------------
 QListWidgetItem* qtAssociationWidget::addAttributeAssociationItem(
-  QListWidget* theList, smtk::attribute::AttributePtr att)
+  QListWidget* theList, smtk::attribute::AttributePtr att, bool sort)
 {
   QString txtLabel(att->name().c_str());
 
@@ -523,6 +533,10 @@ QListWidgetItem* qtAssociationWidget::addAttributeAssociationItem(
   vdata.setValue(static_cast<void*>(att.get()));
   item->setData(Qt::UserRole, vdata);
   theList->addItem(item);
+  if(sort)
+    {
+    theList->sortItems();
+    }
   return item;
 }
 
@@ -578,6 +592,7 @@ void qtAssociationWidget::onRemoveAssigned()
 {
   this->Internals->CurrentList->blockSignals(true);
   this->Internals->AvailableList->blockSignals(true);
+  QListWidgetItem* selItem = NULL;
   if(this->Internals->CurrentAtt.lock())
     {
     smtk::model::EntityRef currentItem = this->getSelectedModelEntityItem(
@@ -586,7 +601,7 @@ void qtAssociationWidget::onRemoveAssigned()
       {
       this->Internals->CurrentAtt.lock()->disassociateEntity(currentItem);
       this->removeSelectedItem(this->Internals->CurrentList);
-      this->addModelAssociationListItem(
+      selItem = this->addModelAssociationListItem(
         this->Internals->AvailableList, currentItem);
       emit this->attAssociationChanged();
       }
@@ -599,7 +614,7 @@ void qtAssociationWidget::onRemoveAssigned()
       {
       currentAtt->disassociateEntity(this->Internals->CurrentModelGroup);
       this->removeSelectedItem(this->Internals->CurrentList);
-      this->addAttributeAssociationItem(
+      selItem = this->addAttributeAssociationItem(
         this->Internals->AvailableList, currentAtt);
       emit this->attAssociationChanged();
       }
@@ -607,6 +622,12 @@ void qtAssociationWidget::onRemoveAssigned()
 
   this->Internals->CurrentList->blockSignals(false);
   this->Internals->AvailableList->blockSignals(false);
+  if(selItem)
+    {
+    this->Internals->AvailableList->setCurrentItem(selItem);
+    this->Internals->CurrentList->setCurrentItem(NULL);
+    this->Internals->CurrentList->clearSelection();
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -614,6 +635,7 @@ void qtAssociationWidget::onAddAvailable()
 {
   this->Internals->CurrentList->blockSignals(true);
   this->Internals->AvailableList->blockSignals(true);
+  QListWidgetItem* selItem = NULL;
   if(this->Internals->CurrentAtt.lock())
     {
     smtk::model::EntityRef currentItem = this->getSelectedModelEntityItem(
@@ -622,7 +644,7 @@ void qtAssociationWidget::onAddAvailable()
       {
       this->Internals->CurrentAtt.lock()->associateEntity(currentItem);
       this->removeSelectedItem(this->Internals->AvailableList);
-      this->addModelAssociationListItem(
+      selItem = this->addModelAssociationListItem(
         this->Internals->CurrentList, currentItem);
       emit this->attAssociationChanged();
       }
@@ -641,7 +663,7 @@ void qtAssociationWidget::onAddAvailable()
         }
       currentAtt->associateEntity(this->Internals->CurrentModelGroup);
       this->removeSelectedItem(this->Internals->AvailableList);
-      this->addAttributeAssociationItem(
+      selItem = this->addAttributeAssociationItem(
         this->Internals->CurrentList, currentAtt);
       emit this->attAssociationChanged();
       }
@@ -649,6 +671,12 @@ void qtAssociationWidget::onAddAvailable()
 
   this->Internals->CurrentList->blockSignals(false);
   this->Internals->AvailableList->blockSignals(false);
+  if(selItem)
+    {
+    this->Internals->CurrentList->setCurrentItem(selItem);
+    this->Internals->AvailableList->setCurrentItem(NULL);
+    this->Internals->AvailableList->clearSelection();
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -656,6 +684,8 @@ void qtAssociationWidget::onExchange()
 {
   this->Internals->CurrentList->blockSignals(true);
   this->Internals->AvailableList->blockSignals(true);
+  QListWidgetItem* selCurrentItem = NULL;
+  QListWidgetItem* selAvailItem = NULL;
   if(this->Internals->CurrentAtt.lock())
     {
     smtk::model::EntityRef currentItem = this->getSelectedModelEntityItem(
@@ -667,11 +697,11 @@ void qtAssociationWidget::onExchange()
       this->Internals->CurrentAtt.lock()->disassociateEntity(currentItem);
       this->Internals->CurrentAtt.lock()->associateEntity(availableItem);
       this->removeSelectedItem(this->Internals->CurrentList);
-      this->addModelAssociationListItem(
+      selCurrentItem = this->addModelAssociationListItem(
         this->Internals->CurrentList, availableItem);
 
       this->removeSelectedItem(this->Internals->AvailableList);
-      this->addModelAssociationListItem(
+      selAvailItem = this->addModelAssociationListItem(
         this->Internals->AvailableList, currentItem);
       emit this->attAssociationChanged();
       }
@@ -685,13 +715,13 @@ void qtAssociationWidget::onExchange()
     if(availAtt &&currentAtt)
       {
       currentAtt->disassociateEntity(this->Internals->CurrentModelGroup);
-      this->addAttributeAssociationItem(
+      selCurrentItem = this->addAttributeAssociationItem(
         this->Internals->AvailableList, currentAtt);
       this->removeSelectedItem(this->Internals->CurrentList);
 
       availAtt->associateEntity(this->Internals->CurrentModelGroup);
       this->removeSelectedItem(this->Internals->AvailableList);
-      this->addAttributeAssociationItem(
+      selAvailItem = this->addAttributeAssociationItem(
         this->Internals->CurrentList, availAtt);
 
       emit this->attAssociationChanged();
@@ -700,6 +730,15 @@ void qtAssociationWidget::onExchange()
 
   this->Internals->CurrentList->blockSignals(false);
   this->Internals->AvailableList->blockSignals(false);
+  if(selCurrentItem)
+    {
+    this->Internals->CurrentList->setCurrentItem(selCurrentItem);
+    }
+  if(selAvailItem)
+    {
+    this->Internals->AvailableList->setCurrentItem(selAvailItem);
+    }
+
 }
 
 //----------------------------------------------------------------------------

--- a/smtk/extension/qt/qtAssociationWidget.h
+++ b/smtk/extension/qt/qtAssociationWidget.h
@@ -48,8 +48,6 @@ namespace smtk
       virtual void showDomainsAssociation(
         std::vector<smtk::model::Group>& theDomains,
         std::vector<smtk::attribute::DefinitionPtr>& attDefs);
-      void onCurrentListSelectionChanged(QListWidgetItem * , QListWidgetItem * );
-      void onAvailableListSelectionChanged(QListWidgetItem * , QListWidgetItem * );
 
     signals:
       void attAssociationChanged();
@@ -60,6 +58,7 @@ namespace smtk
       virtual void onExchange();
       virtual void onNodalOptionChanged(int);
       virtual void onDomainAssociationChanged();
+      virtual void onEntitySelected(QListWidgetItem * , QListWidgetItem * );
 
     protected:
       virtual void initWidget( );
@@ -74,12 +73,12 @@ namespace smtk
       //returns the Item it has added to the widget
       //ownership of the item is handled by the widget so no need to delete
       virtual QListWidgetItem* addModelAssociationListItem(
-           QListWidget* theList, smtk::model::EntityRef modelItem);
+           QListWidget* theList, smtk::model::EntityRef modelItem, bool sort=true);
 
       //returns the Item it has added to the widget
       //ownership of the item is handled by the widget so no need to delete
       virtual QListWidgetItem* addAttributeAssociationItem(
-        QListWidget* theList, smtk::attribute::AttributePtr att);
+        QListWidget* theList, smtk::attribute::AttributePtr att, bool sort=true);
 
 
       virtual void addDomainListItem( const smtk::model::Group& domainItem,

--- a/smtk/extension/qt/qtModelOperationWidget.cxx
+++ b/smtk/extension/qt/qtModelOperationWidget.cxx
@@ -205,13 +205,14 @@ bool qtModelOperationWidget::setCurrentOperation(
   smtk::attribute::qtUIManager* uiManager =
     new smtk::attribute::qtUIManager(*(att->system()), "Operators");
 
-
   QObject::connect(uiManager, SIGNAL(fileItemCreated(smtk::attribute::qtFileItem*)),
     this, SIGNAL(fileItemCreated(smtk::attribute::qtFileItem*)));
   QObject::connect(uiManager, SIGNAL(modelEntityItemCreated(smtk::attribute::qtModelEntityItem*)),
     this, SIGNAL(modelEntityItemCreated(smtk::attribute::qtModelEntityItem*)));
   QObject::connect(uiManager, SIGNAL(meshSelectionItemCreated(smtk::attribute::qtMeshSelectionItem*)),
     this, SLOT(onMeshSelectionItemCreated(smtk::attribute::qtMeshSelectionItem*)));
+  QObject::connect(uiManager, SIGNAL(entitiesSelected(const smtk::common::UUIDs&)),
+    this, SLOT(selectEntityItems(const smtk::common::UUIDs&, bool)));
 
   qtInstancedView* theView = qobject_cast<qtInstancedView*>(
     uiManager->initializeView(opParent, instanced, false));

--- a/smtk/extension/qt/qtModelOperationWidget.h
+++ b/smtk/extension/qt/qtModelOperationWidget.h
@@ -59,6 +59,7 @@ namespace smtk
       void meshSelectionItemCreated(
           smtk::attribute::qtMeshSelectionItem* meshItem,
           const std::string& opName, const smtk::common::UUID& uuid);
+      void entitiesSelected(const smtk::common::UUIDs&);
 
     protected slots:
       virtual void onOperationSelected();

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -801,6 +801,8 @@ QDockWidget* qtModelView::operatorsDock()
     this, SIGNAL(meshSelectionItemCreated(
                  smtk::attribute::qtMeshSelectionItem*,
                  const std::string&, const smtk::common::UUID&)));
+  QObject::connect(opWidget, SIGNAL(entitiesSelected(const smtk::common::UUIDs&)),
+    this, SIGNAL(modelEntityItemCreated(smtk::attribute::qtModelEntityItem*)));
 
   QWidget* dockP = NULL;
   foreach(QWidget *widget, QApplication::topLevelWidgets())

--- a/smtk/extension/qt/qtUIManager.h
+++ b/smtk/extension/qt/qtUIManager.h
@@ -47,8 +47,6 @@ namespace smtk
 
     Q_OBJECT
 
-    friend class qtRootView;
-
     public:
     qtUIManager(smtk::attribute::System &system,
                 const std::string &toplevelViewName);
@@ -181,9 +179,16 @@ namespace smtk
       void modelEntityItemCreated(smtk::attribute::qtModelEntityItem* entItem);
       void meshSelectionItemCreated(smtk::attribute::qtMeshSelectionItem*);
       void uiChanged(smtk::attribute::qtBaseView*, smtk::attribute::ItemPtr);
+      void entitiesSelected(const smtk::common::UUIDs&);
+
+    friend class qtRootView;
+    friend class qtAssociationWidget;
+
+    protected slots:
+      void invokeEntitiesSelected(const smtk::common::UUIDs& uuids)
+        { emit this->entitiesSelected(uuids); }
 
     protected:
-
       virtual void internalInitialize();
 
    private:


### PR DESCRIPTION
The qtAssociationWidget allows users to select and associate model
entities to attributes. When entities are highlighted in the list
view, it will be nice to show what those entities are in the 3d
render view, hence a signal is added when the entities are selected,
which will allow the application connect and select entity geometry.