### PR TITLE
Add methods to fetch attribute items given a "path."

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -6,9 +6,10 @@ set( CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000 )
 set (CTEST_CUSTOM_WARNING_EXCEPTION
   ${CTEST_CUSTOM_WARNING_EXCEPTION}
   "smtk/SMTKCorePython"
-  ".*ClientServer.cxx:[0-9]*:[0-9]*: warning: use of old-style cast"
-  ".*Python/.* warning: declaration of .* shadows a member of 'this' [-Wshadow]"
-  ".*VTK/Wrapping/PythonCore/vtkPythonArgs.h.* warning: use of old-style cast [-Wold-style-cast]"
+  "ClientServer.cxx:[0-9]*:[0-9]*: warning: use of old-style cast"
+  "Python/.* warning: declaration of .* shadows a member of 'this' \\[-Wshadow\\]"
+  "vtkPythonArgs.h.* warning: use of old-style cast \\[-Wold-style-cast\\]"
+  "Done, 0 warnings"
 )
 
 ##------------------------------------------------------------------------------

--- a/smtk/attribute/Attribute.h
+++ b/smtk/attribute/Attribute.h
@@ -92,6 +92,18 @@ namespace smtk
            smtk::attribute::ItemPtr() : this->m_items[static_cast<std::size_t>(ith)]);
       }
 
+      smtk::attribute::ConstItemPtr itemAtPath(
+        const std::string& path, const std::string& seps = "/") const;
+      smtk::attribute::ItemPtr itemAtPath(
+        const std::string& path, const std::string& seps = "/");
+
+      template<typename T>
+      typename T::ConstPtr itemAtPathAs(
+        const std::string& path, const std::string& seps = "/") const;
+      template<typename T>
+      typename T::Ptr itemAtPathAs(
+        const std::string& path, const std::string& seps = "/");
+
       smtk::attribute::ItemPtr find(
         const std::string& name,
         SearchStyle style = ACTIVE_CHILDREN);
@@ -267,6 +279,19 @@ namespace smtk
         }
       }
       return result;
+    }
+//----------------------------------------------------------------------------
+    /**\brief Return an item given its path, converted to a given pointer type.
+      */
+    template<typename T>
+    typename T::ConstPtr Attribute::itemAtPathAs(
+      const std::string& path, const std::string& seps) const
+    {
+    typename T::ConstPtr result;
+    smtk::attribute::ConstItemPtr itm = this->itemAtPath(path, seps);
+    if (!!itm)
+      result = smtk::dynamic_pointer_cast<const T>(itm);
+    return result;
     }
 //----------------------------------------------------------------------------
     template<typename T>

--- a/smtk/attribute/testing/python/CMakeLists.txt
+++ b/smtk/attribute/testing/python/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Additional tests that require SMTK_DATA_DIR
-set(smtkModelPythonDataTests
+set(smtkAttributePythonDataTests
   copyDefinitionTest
   copyAttributeTest
+)
+set(smtkAttributePythonNewDataTests
+  attributeItemByPath
 )
 
 add_test(associationTestPy ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/associationTest.py)
@@ -27,12 +30,23 @@ set_tests_properties(
 )
 
 if (SMTK_DATA_DIR AND EXISTS ${SMTK_DATA_DIR}/ReadMe.mkd)
-  foreach (test ${smtkModelPythonDataTests})
+  foreach (test ${smtkAttributePythonDataTests})
     add_test(
       ${test}Py
       ${PYTHON_EXECUTABLE}
       ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py
       ${SMTK_DATA_DIR})
+    set_tests_properties(${test}Py
+      PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${VTKPY_DIR}${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
+    )
+  endforeach()
+  # New-style tests that use smtk.testing.TestCase
+  foreach (test ${smtkAttributePythonNewDataTests})
+    add_test(${test}Py
+             ${PYTHON_EXECUTABLE}
+             ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py
+             -D ${SMTK_DATA_DIR})
     set_tests_properties(${test}Py
       PROPERTIES
         ENVIRONMENT "PYTHONPATH=${VTKPY_DIR}${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"

--- a/smtk/attribute/testing/python/attributeItemByPath.py
+++ b/smtk/attribute/testing/python/attributeItemByPath.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+import sys
+#=============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+#=============================================================================
+import smtk
+from smtk.simple import *
+import smtk.testing
+import os
+
+class TestAttributeItemByPath(smtk.testing.TestCase):
+
+    def setUp(self):
+        if smtk.testing.DATA_DIR == '':
+          self.skipTest('SMTK test-data directory not provided')
+
+        self.system = smtk.attribute.System()
+        logger = smtk.io.Logger()
+        reader = smtk.io.AttributeReader()
+        filenm = os.path.join(smtk.testing.DATA_DIR, 'smtk', 'attribute', 'HydraTemplateV1.sbt')
+        status = reader.read(self.system, filenm, logger)
+        print '\n'.join([logger.record(i).message for i in range(logger.numberOfRecords())])
+        self.assertFalse(status, 'Could not read {fn}'.format(fn=filenm))
+
+    def testItemInSimplePath(self):
+        att = self.system.createAttribute('hydrostat')
+        itemInSimplePath = att.itemAtPath('Hydrostat', '/')
+        self.assertIsNotNone(itemInSimplePath, 'Could not find expected item.')
+        self.assertEqual(itemInSimplePath.name(), 'Hydrostat', 'Got wrong attribute "{nm}".'.format(nm=itemInSimplePath.name()))
+
+    def testItemInChildPath(self):
+        att = self.system.createAttribute('BasicTurbulenceModel')
+        itemInChildren = att.itemAtPath('Method/prandtl', '/')
+        self.assertIsNotNone(itemInChildren, 'Could not find expected item.')
+        self.assertEqual(itemInChildren.name(), 'prandtl', 'Got wrong attribute "{nm}".'.format(nm=itemInChildren.name()))
+
+    def testItemInGroupPath(self):
+        att = self.system.createAttribute('InitialConditions')
+        itemInGroup = att.itemAtPath('InitialConditions/Velocity', '/')
+        self.assertIsNotNone(itemInGroup, 'Could not find expected item.')
+        self.assertEqual(itemInGroup.name(), 'Velocity', 'Got wrong attribute "{nm}".'.format(nm=itemInGroup.name()))
+
+    def testItemInDeepPath(self):
+        att = self.system.createAttribute('ppesolver')
+        deepItem = att.itemAtPath('PressurePoissonSolver/ppetype/preconditioner', '/')
+        self.assertIsNotNone(deepItem, 'Could not find expected item.')
+        self.assertEqual(deepItem.name(), 'preconditioner', 'Got wrong attribute "{nm}".'.format(nm=deepItem.name()))
+
+        # Do the same thing with a different separator
+        deepItem = att.itemAtPath('PressurePoissonSolver-ppetype-preconditioner', '-')
+        self.assertIsNotNone(deepItem, 'Could not find expected item with alternate path separator.')
+        self.assertEqual(deepItem.name(), 'preconditioner',
+            'Got wrong attribute "{nm}" with alt. path separator.'.format(nm=deepItem.name()))
+
+if __name__ == '__main__':
+  smtk.testing.process_arguments()
+  smtk.testing.main()

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -139,7 +139,8 @@
   <suppress-warning text="skipping function 'smtk::model::Manager::assignDefaultNamesWithOwner', unmatched parameter type 'smtk::model::UUIDWithEntity const&amp;'"/>
   <suppress-warning text="skipping field 'OperatorLog::m_watching' with unmatched type 'std::vector&lt;smtk::model::WeakOperatorPtr&gt;'"/>
   <suppress-warning text="skipping field 'OperatorLog::m_manager' with unmatched type 'smtk::weak_ptr&lt;smtk::model::Manager&gt;'"/>
-
+  <suppress-warning text="skipping function 'smtk::io::OperatorLog::hintSystem', unmatched return type 'smtk::attribute::SystemPtr'"/>
+  <suppress-warning text="skipping field 'OperatorLog::m_hintSys' with unmatched type 'smtk::shared_ptr&lt;smtk::attribute::System&gt;'"/>
 
   <!-- do not support input or output streams-->
   <suppress-warning text="skipping function 'smtk::common::operator&lt;&lt;', unmatched return type 'std::ostream&amp;'"/>

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -76,6 +76,8 @@
 	<suppress-warning text="skipping function 'smtk::model::Manager::setEntityOfTypeAndDimension', unmatched return type 'Manager::iter_type'"/>
   <suppress-warning text="skipping function 'smtk::attribute::ModelEntityItem::begin', unmatched return type 'smtk::model::EntityRefArray::const_iterator'"/>
   <suppress-warning text="skipping function 'smtk::attribute::ModelEntityItem::end', unmatched return type 'smtk::model::EntityRefArray::const_iterator'"/>
+  <suppress-warning text="skipping function 'smtk::attribute::Attribute::itemAtPathAs', unmatched return type 'T::Ptr'"/>
+  <suppress-warning text="skipping function 'smtk::attribute::Attribute::itemAtPathAs', unmatched return type 'T::ConstPtr'"/>
 
   <!-- Use cJSON objects. For now we will ignore these-->
   <suppress-warning text="skipping function 'smtk::io::ImportJSON::ofDanglingEntities', unmatched parameter type 'cJSON*'"/>


### PR DESCRIPTION
This commit adds `Attribute::itemAtPath` to fetch an item from an attribute that may be a nested child or group member by specifying a string naming the tree to descend to find the item. A string of separator characters may also be specified; it defaults to "/".

As an example, consider an attribute A that has items aa, bb, and cc. Item bb is an IntItem with children pp, qq, rr. Item rr is a GroupItem with a member item named jj. Normally, if we wanted to access jj, we would have to `ItemPtr jj = A->findInt("bb")->findGroup("rr")->find("jj");`. This is concise but not suitable for occasions when a user might wish to specify a path at runtime. With this patch, we can instead call `ItemPtr jj = A->itemAtPath("bb/rr/jj");`.

This branch also adds a templated version that downcasts the return value to the requested item subclass: `IntItemPtr jj = A->itemAtPathAs<IntItem>("bb/rr/jj");`.