### PR TITLE
Added int property to related models after mesh op

### DIFF
--- a/smtk/extension/remus/MeshOperator.cxx
+++ b/smtk/extension/remus/MeshOperator.cxx
@@ -154,6 +154,19 @@ OperatorResult MeshOperator::operateInternal()
     //parse the job result as a json string
     smtk::io::ImportJSON::intoModelManager(updatedModel.data(), this->manager());
 
+    // Now set or increment the SMTK_MESH_GEN_PROP property for the models
+    // The client can use this property to check if there is an analysis mesh created
+    // for the model
+    smtk::model::Models::iterator it;
+    for (it = models.begin(); it != models.end(); ++it)
+      {
+      IntegerList& gen(this->manager()->integerProperty(it->entity(), SMTK_MESH_GEN_PROP));
+      if (gen.empty())
+        gen.push_back(0);
+      else
+        ++gen[0];
+      }
+
     //current question is how do we know how to mark the tessellations
     //of the model as modified?
     this->addEntitiesToResult(result, models, MODIFIED);

--- a/smtk/extension/vtk/vtkModelMultiBlockSource.cxx
+++ b/smtk/extension/vtk/vtkModelMultiBlockSource.cxx
@@ -164,8 +164,12 @@ bool vtkModelMultiBlockSource::GetHasAnalysisMesh() const
   if(this->ModelEntityID && this->ModelEntityID[0])
     {
     smtk::common::UUID uid(this->ModelEntityID);
-    smtk::model::EntityRef modelRef(this->ModelMgr, uid);
-    return modelRef.hasAnalysisMesh() != NULL;
+    if(this->ModelMgr->hasIntegerProperty(uid, SMTK_MESH_GEN_PROP))
+      {
+      const smtk::model::IntegerList& gen(
+        this->ModelMgr->integerProperty(uid, SMTK_MESH_GEN_PROP));
+      return !gen.empty();
+      }
     }
   return false;
 }


### PR DESCRIPTION
Added an int property, SMTK_MESH_GEN_PROP, after an mesh op, to show if the model has
an analysis mesh created and associated with the model. The value of this property
tells the generation of analysis mesh created for the model. The client
can query this property for the existence of analysis mesh on a model.