### PR TITLE
Added ResourceSet and ResourceSetReader to python wrapper

### DIFF
--- a/smtk/common/ResourceSet.cxx
+++ b/smtk/common/ResourceSet.cxx
@@ -124,7 +124,7 @@ addResourceInfo(const std::string id,
 }
 
 //----------------------------------------------------------------------------
-unsigned
+unsigned int
 ResourceSet::
 numberOfResources() const
 {

--- a/smtk/common/ResourceSet.h
+++ b/smtk/common/ResourceSet.h
@@ -66,7 +66,7 @@ class SMTKCORE_EXPORT ResourceSet
                        ResourceState state,
                        std::string link="");
 
-  unsigned numberOfResources() const;
+  unsigned int numberOfResources() const;
 
   const std::vector<std::string> resourceIds() const;
 

--- a/smtk/io/testing/python/CMakeLists.txt
+++ b/smtk/io/testing/python/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(smtkIOPythonTests
   unitOperatorLog
+  ResourceSetTest
 )
 
 # Additional tests that require SMTK_DATA_DIR
@@ -25,4 +26,17 @@ if (SMTK_DATA_DIR AND EXISTS ${SMTK_DATA_DIR}/ReadMe.mkd)
         ENVIRONMENT "PYTHONPATH=${VTKPY_DIR}${VTKPY_DIR}${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
     )
   endforeach()
+
+  set(reader_test ResourceSetReaderTest)
+  add_test(${reader_test}Py
+    ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/${reader_test}.py
+    ${SMTK_DATA_DIR}/smtk/attribute/resourceTest/resources.xml
+    2
+  )
+  set_tests_properties(${reader_test}Py
+    PROPERTIES
+      ENVIRONMENT "PYTHONPATH=${VTKPY_DIR}${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
+  )
+
 endif()

--- a/smtk/io/testing/python/ResourceSetReaderTest.py
+++ b/smtk/io/testing/python/ResourceSetReaderTest.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python
+import sys
+#=============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+#=============================================================================
+import smtk
+from smtk.simple import *
+
+class TestResourceSetReader():
+    """A test for ResourceSetReader
+    It is a direct port of the Cxx version"""
+
+    def setUp(self):
+        if len(sys.argv) < 2:
+            print "Reads resource with 1 or more attribute managers"
+            print "Usage: ResourceSetReaderTest resource_file"
+            print "  [expect_number_of_resources]"
+            return 1
+
+        self.status = 0  # return value
+
+        self.resources = smtk.common.ResourceSet()
+        self.reader = smtk.io.ResourceSetReader()
+        self.logger = smtk.io.Logger()
+
+        input_path = sys.argv[1]
+
+        hasErrors = self.reader.readFile(input_path, self.resources, self.logger)
+        if hasErrors:
+            print "Reader has errors"
+            print self.logger.convertToString()
+            self.status = self.status + 1
+
+
+    def testSimpleRead(self):
+        if len(sys.argv) <= 2:
+            return 1
+
+        expectedNumber = 0
+        convert = sys.argv[2]
+
+        try:
+            expectedNumber = int(convert)
+        except:
+            self.status = self.status + 1
+        finally:
+            if expectedNumber < 0:
+                print "ERROR: argv[2] not an unsigned integer"
+                self.status = self.status + 1
+            else:
+                numResources = self.resources.numberOfResources()
+                if numResources != expectedNumber:
+                    print "ERROR: Expecting ", expectedNumber, \
+                    " resources, loaded ", numResources
+                    self.status = self.status + 1
+                else:
+                    print "Number of resources loaded:", numResources
+
+                # dump out resource ids for info only
+                resourceIds = self.resources.resourceIds()
+                for id in resourceIds:
+                    print id
+
+        return self.status
+
+
+if __name__ == '__main__':
+    t = TestResourceSetReader()
+    t.setUp()
+    sys.exit(t.testSimpleRead())

--- a/smtk/io/testing/python/ResourceSetTest.py
+++ b/smtk/io/testing/python/ResourceSetTest.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python
+import sys
+#=============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+#=============================================================================
+import os
+from pprint import pprint
+import smtk
+from smtk.simple import *
+
+def RSTest():
+    """Tests for ResourceSet
+    Currently does not test for ResourceInfo
+    as it is not implemented in the wrapper yet
+    Otherwise this is a direct manual port of the cxx test"""
+
+    status = 0
+    result = False
+    n = 0
+    resourceSet = smtk.common.ResourceSet()
+
+    system1 = smtk.attribute.System.New()
+    result = resourceSet.addResource(system1, "system1", "", smtk.common.ResourceSet.TEMPLATE);
+
+    n = resourceSet.numberOfResources()
+    if result == False:
+        print("addResource() call failed")
+        status = status + 1
+    elif n != 1:
+        print("Wrong number of resources: %i, should be 1" % n)
+        status = status + 1
+
+
+    
+    system2 = smtk.attribute.System.New()
+    result = resourceSet.addResource(system2, "system2", "path2", smtk.common.ResourceSet.INSTANCE);
+
+    n = resourceSet.numberOfResources()
+    if result == False:
+        print("addResource() call failed")
+        status = status + 1
+    elif n != 2:
+        print("Wrong number of resources: %i, should be 2" % n)
+        status = status + 1
+
+
+    result = resourceSet.addResource(system1, "system1-different-id", "", smtk.common.ResourceSet.SCENARIO);
+    n = resourceSet.numberOfResources()
+    if result == False:
+        print("addResource() call failed")
+        status = status + 1
+    elif n != 3:
+        print("Wrong number of resources: %i, should be 3" % n)
+        status = status + 1
+
+
+    result = resourceSet.addResource(system2, "system2")
+    n = resourceSet.numberOfResources()
+    if result == True:
+        print("addResource() call didn't fail failed")
+        status = status + 1
+    elif n != 3:
+        print("Wrong number of resources: %i, should be 3" % n)
+        status = status + 1
+
+
+    ids = resourceSet.resourceIds()
+    if len(ids) != 3:
+        print("Wrong number of ids: %i, should be 3")
+        status = status + 1
+    else:
+        expectedNames = ["system1", "system2", "system1-different-id"]
+        for i in range(len(ids)):
+            if ids[i] != expectedNames[i]:
+                print("Wrong resource name %s, should be %s" % (ids[i], expectedNames[i]) )
+                status = status + 1
+
+
+    # Missing: ResourceInfo tests (function not implemented)
+
+    # Note: ResourcePtr is not implemented (and cannot be due Resource being abstract -- shiboken issues)
+    # Note: ResourceSet.get is modified by shiboken to return a ResourcePtr/shared_ptr<Resource>
+
+    resource = resourceSet.get("system2")
+    if resource == None:
+        print("get() failed")
+        status = status + 1
+    rtype = resource.resourceType()
+    if rtype != smtk.common.Resource.ATTRIBUTE:
+        print("Incorrect resource type %s, should be smtk.common.Resource.ATTRIBUTE" % rtype)
+        status = status + 1
+
+    print("Number of errors: %i" % status)
+    return status
+
+def test():
+    return RSTest()
+
+if __name__ == '__main__':
+    sys.exit(test())
+

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -139,6 +139,7 @@
   <suppress-warning text="skipping field 'Manager::m_arrangements' with unmatched type 'smtk::shared_ptr&lt;UUIDsToArrangements&gt;'"/>
   <suppress-warning text="skipping field 'UUIDGenerator::P' with unmatched type 'Internal'"/>
   <suppress-warning text="skipping function 'smtk::model::Manager::assignDefaultNamesWithOwner', unmatched parameter type 'smtk::model::UUIDWithEntity const&amp;'"/>
+  <suppress-warning text="skipping field 'ResourceSet::m_resourceMap' with unmatched type 'std::map&lt;std::string,ResourceWrapper*&gt;'"/>
   <suppress-warning text="skipping field 'OperatorLog::m_watching' with unmatched type 'std::vector&lt;smtk::model::WeakOperatorPtr&gt;'"/>
   <suppress-warning text="skipping field 'OperatorLog::m_manager' with unmatched type 'smtk::weak_ptr&lt;smtk::model::Manager&gt;'"/>
   <suppress-warning text="skipping function 'smtk::io::OperatorLog::hintSystem', unmatched return type 'smtk::attribute::SystemPtr'"/>
@@ -346,9 +347,12 @@
   <suppress-warning text="skipping function 'smtk::model::Manager::unobserve', unmatched parameter type 'smtk::model::OneToOneCallback'"/>
   <suppress-warning text="skipping field 'DescriptivePhrase::m_parent' with unmatched type 'smtk::weak_ptr&lt;smtk::model::DescriptivePhrase&gt;'"/>
   <suppress-warning text="skipping function 'smtk::io::AttributeReader::readContents', unmatched parameter type 'pugi::xml_node&amp;'" />
+  <suppress-warning text="skipping function 'smtk::io::ResourceSetReader::readIncludedManager', unmatched parameter type 'pugi::xml_node const&amp;'"/>
+  <suppress-warning text="skipping function 'smtk::io::ResourceSetReader::readEmbeddedAttSystem', unmatched parameter type 'pugi::xml_node&amp;'"/>
   <suppress-warning text="skipping function 'smtk::model::Session::createIODelegate', unmatched return type 'smtk::model::SessionIOPtr'"/>
   <suppress-warning text="skipping function 'smtk::model::Manager::findEntitiesByPropertyAs', unmatched return type 'Collection'"/>
   <suppress-warning text="skipping function 'smtk::attribute::Attribute::associations', unmatched return type 'smtk::attribute::ConstModelEntityItemPtr'"/>
+  <suppress-warning text="skipping function 'smtk::common::ResourceSet::getWrapper', unmatched return type 'smtk::common::ResourceWrapper*'"/>
 
   <!-- Ignore until we have time to support Operators -->
   <suppress-warning text="skipping field 'Manager::m_defaultSession' with unmatched type 'smtk::shared_ptr&lt;Session&gt;'"/>
@@ -979,6 +983,34 @@
   <value-type template="smtk::shared_ptr" args="smtk::attribute::ModelEntityItemDefinition" />
   <value-type template="smtk::shared_ptr" args="smtk::attribute::MeshSelectionItem" />
   <value-type template="smtk::shared_ptr" args="smtk::attribute::MeshSelectionItemDefinition" />
+  <value-type template="smtk::shared_ptr" args="smtk::attribute::System">
+    <modify-function signature="findAttributes(const std::string &amp;, std::vector&lt;smtk::shared_ptr&lt;smtk::attribute::Attribute&gt; &gt; &amp;)">
+      <modify-argument index="2">
+        <remove-argument />
+      </modify-argument>
+      <modify-argument index="return">
+        <replace-type modified-type="std::vector&lt;smtk::shared_ptr&lt;smtk::attribute::Attribute&gt; &gt;" />
+      </modify-argument>
+      <inject-code class="target" position="beginning">
+        std::vector&lt;smtk::shared_ptr&lt;smtk::attribute::Attribute&gt; &gt; _out;
+        %CPPSELF->get()->findAttributes(%1, _out);
+        %PYARG_0 = %CONVERTTOPYTHON[std::vector&lt;smtk::shared_ptr&lt;smtk::attribute::Attribute&gt; &gt;](_out);
+      </inject-code>
+    </modify-function>
+    <modify-function signature="definitions(std::vector&lt;smtk::shared_ptr&lt;smtk::attribute::Definition&gt;&gt; &amp;)">
+      <modify-argument index="1">
+        <remove-argument />
+      </modify-argument>
+      <modify-argument index="return">
+        <replace-type modified-type="std::vector&lt;smtk::shared_ptr&lt;smtk::attribute::Definition &gt; &gt;" />
+      </modify-argument>
+      <inject-code class="target" position="beginning">
+        std::vector&lt;smtk::shared_ptr&lt;smtk::attribute::Definition &gt; &gt; _out;
+        %CPPSELF->get()->definitions(_out);
+        %PYARG_0 = %CONVERTTOPYTHON[std::vector&lt;smtk::shared_ptr&lt;smtk::attribute::Definition &gt; &gt;](_out);
+      </inject-code>
+    </modify-function>
+  </value-type>
   <value-type template="smtk::shared_ptr" args="smtk::attribute::VoidItem" />
   <value-type template="smtk::shared_ptr" args="smtk::attribute::VoidItemDefinition" />
 
@@ -1002,14 +1034,33 @@
         <enum-type name="Type" />
       </object-type>
 
-      <!-- TODO Get ResourceSet wrappers to compile (Shiboken bug?) -->
-      <!--
       <object-type name="ResourceSet">
         <include file-name="smtk/common/ResourceSet.h" location="local" />
         <enum-type name="ResourceState" />
         <enum-type name="ResourceRole" />
+        <modify-function signature="resourceInfo(std::string,smtk::common::Resource::Type&amp;,smtk::common::ResourceSet::ResourceRole&amp;,smtk::common::ResourceSet::ResourceState&amp;,std::string&amp;) const" remove="all" >
+        </modify-function>       
+        <modify-function signature="get(std::string,smtk::shared_ptr&lt;smtk::common::Resource&gt;&amp;) const">
+          <modify-argument index="2">
+            <remove-argument />
+          </modify-argument>
+          <modify-argument index="return">
+            <replace-type modified-type="smtk::common::Resource&amp;" />
+          </modify-argument>
+          <inject-code class="target" position="beginning">
+            smtk::shared_ptr&lt; smtk::common::Resource &gt; _out;
+            bool result = %CPPSELF->get(%1, _out);
+            if (result)
+              %PYARG_0 = %CONVERTTOPYTHON[smtk::shared_ptr&lt; smtk::common::Resource &gt;](_out);
+            else
+            {
+              smtk::shared_ptr&lt; smtk::common::Resource &gt; _ret;
+              %PYARG_0 = %CONVERTTOPYTHON[smtk::shared_ptr&lt; smtk::common::Resource &gt;](_ret);
+            }
+          </inject-code>
+        </modify-function>
       </object-type>
-      -->
+      
 
       <object-type name="UUIDGenerator">
         <include file-name="smtk/common/UUIDGenerator.h" location="local"/>
@@ -1765,6 +1816,24 @@
           </inject-code>
         </modify-function>
 
+        <add-function signature="CastTo(smtk::shared_ptr&lt;smtk::common::Resource &gt; &amp;)"
+          static="yes"
+          return-type="smtk::shared_ptr&lt;smtk::attribute::System &gt;">
+          <inject-code>
+            %RETURN_TYPE %0 = smtk::dynamic_pointer_cast&lt;smtk::attribute::System &gt;(%1);
+            %PYARG_0 = %CONVERTTOPYTHON[%RETURN_TYPE](%0);
+          </inject-code>
+        </add-function>
+
+        <add-function signature="New()"
+          static="yes"
+          return-type="smtk::shared_ptr&lt;smtk::attribute::System &gt;">
+          <inject-code>
+            %RETURN_TYPE %0(new smtk::attribute::System());
+            %PYARG_0 = %CONVERTTOPYTHON[%RETURN_TYPE](%0);
+          </inject-code>
+        </add-function>
+
      </object-type>
 
       <object-type name="StringItem">
@@ -1972,6 +2041,11 @@
       <object-type name="OperatorLog">
         <include file-name="smtk/io/OperatorLog.h" location="local"/>
       </object-type>
+
+      <object-type name="ResourceSetReader">
+        <include file-name="smtk/io/ResourceSetReader.h" location="local"/>
+      </object-type>
+
     </namespace-type>
 
     <namespace-type name="simulation">


### PR DESCRIPTION
Added a python test as well (direct port of the C++ test).
I added the test in CMakeLists as a seperate entry because that is how the Cxx test was done.

Not all functions in ResourceSet and ResourceSetReader are wrapped.

ResourceSet.h/cxx::numberOfResources() was changed to use unsigned int (from 'unsigned') since shiboken doesn't understand the "unsigned" type.