### PR TITLE
Made vtk parsers and writers in discrete bridge to handle full 3D topology.

### DIFF
--- a/smtk/bridge/discrete/operation/vtkCMBModelWriterV2.cxx
+++ b/smtk/bridge/discrete/operation/vtkCMBModelWriterV2.cxx
@@ -125,7 +125,9 @@ void vtkCMBModelWriterV2::SetAnalysisGridData(vtkDiscreteModel* model, vtkPolyDa
     vtkIdTypeArray* pointMap = analysisGridInfo->GetModelPointToAnalysisPoint();
     vtkIdTypeArray* cellMap = analysisGridInfo->GetModelCellToAnalysisCells();
     vtkCharArray* cellSides = analysisGridInfo->GetModelCellToAnalysisCellSides();
-    if(pointMap != NULL && cellMap != NULL && cellSides != NULL)
+    if((pointMap != NULL && pointMap->GetNumberOfTuples() == poly->GetNumberOfPoints()) &&
+       (cellMap != NULL && cellMap->GetNumberOfTuples() == poly->GetNumberOfCells()) &&
+       (cellSides != NULL && cellSides->GetNumberOfTuples() == poly->GetNumberOfCells()))
       {
       pointMap->SetName(vtkDiscreteModel::GetPointMapArrayName());
       poly->GetPointData()->AddArray(pointMap);

--- a/smtk/bridge/discrete/operation/vtkCMBModelWriterV5.cxx
+++ b/smtk/bridge/discrete/operation/vtkCMBModelWriterV5.cxx
@@ -59,7 +59,7 @@ void vtkCMBModelWriterV5::SetModelEdgeData(vtkDiscreteModel* model, vtkPolyData*
   for(edges->Begin();!edges->IsAtEnd();edges->Next())
     {
     vtkDiscreteModelEdge* edge = vtkDiscreteModelEdge::SafeDownCast(edges->GetCurrentItem());
-    if(edge->GetModelRegion() != NULL || model->GetModelDimension() == 2)
+//    if(edge->GetModelRegion() != NULL || model->GetModelDimension() == 2)
       {
       entities.push_back(edge);
       }
@@ -116,7 +116,7 @@ void vtkCMBModelWriterV5::SetModelEdgeData(vtkDiscreteModel* model, vtkPolyData*
 void vtkCMBModelWriterV5::SetModelFaceData(vtkDiscreteModel* Model, vtkPolyData* Poly)
 {
   std::vector<vtkModelEntity*> Entities;
-  if(Model->GetModelDimension() == 2)
+//  if(Model->GetModelDimension() == 2)
     {
     // the adjacent edge ids for each model face is separated by a -1
     vtkIdTypeArray* ModelFaceAdjacentEdgesId = vtkIdTypeArray::New();
@@ -130,7 +130,10 @@ void vtkCMBModelWriterV5::SetModelFaceData(vtkDiscreteModel* Model, vtkPolyData*
       vtkDiscreteModelFace* Face = vtkDiscreteModelFace::SafeDownCast(Faces->GetCurrentItem());
       Entities.push_back(Face);
       vtkModelMaterial* Material = Face->GetMaterial();
-      ModelFaceMaterialIds->InsertNextValue(Material->GetUniquePersistentId());
+      if(Material)
+        {
+        ModelFaceMaterialIds->InsertNextValue(Material->GetUniquePersistentId());
+        }
       // Loop Information is encoded as follows: nL l0e0 l0e1 ... -1 l1e0 ...
       // Where nL is the number of loops in the face followed by the edges in
       // loop (for example l0e0 is edge 0 of loop 0) - with each loop separated by -1
@@ -173,12 +176,14 @@ void vtkCMBModelWriterV5::SetModelFaceData(vtkDiscreteModel* Model, vtkPolyData*
     ModelEdgeDirections->SetName(ModelParserHelper::GetModelEdgeDirectionsString());
     Poly->GetFieldData()->AddArray(ModelEdgeDirections);
     ModelEdgeDirections->Delete();
-
-    ModelFaceMaterialIds->SetName(ModelParserHelper::GetFaceMaterialIdString());
-    Poly->GetFieldData()->AddArray(ModelFaceMaterialIds);
+    if(ModelFaceMaterialIds->GetNumberOfTuples())
+      {
+      ModelFaceMaterialIds->SetName(ModelParserHelper::GetFaceMaterialIdString());
+      Poly->GetFieldData()->AddArray(ModelFaceMaterialIds);
+      }
     ModelFaceMaterialIds->Delete();
     }
-  else if(Model->GetModelDimension() == 3)
+  if(Model->GetModelDimension() == 3)
     {
     vtkIdTypeArray* ModelFaceAdjacentRegionsId = vtkIdTypeArray::New();
     ModelFaceAdjacentRegionsId->SetNumberOfComponents(2);
@@ -187,7 +192,7 @@ void vtkCMBModelWriterV5::SetModelFaceData(vtkDiscreteModel* Model, vtkPolyData*
     for(Faces->Begin();!Faces->IsAtEnd();Faces->Next())
       {
       vtkDiscreteModelFace* Face = vtkDiscreteModelFace::SafeDownCast(Faces->GetCurrentItem());
-      Entities.push_back(Face);
+ //     Entities.push_back(Face);
       vtkIdType ids[2] = {-1, -1};
       for(int j=0;j<2;j++)
         {

--- a/smtk/bridge/discrete/testing/python/CMakeLists.txt
+++ b/smtk/bridge/discrete/testing/python/CMakeLists.txt
@@ -6,6 +6,7 @@ set(smtkDiscreteSessionPythonTests
 set(smtkDiscreteSessionPythonDataTests
   discreteBathymetry
   discreteCreateEdges
+  discreteCreateAndSaveEdges
   discreteReadFile
   discreteSplitEdge
 )

--- a/smtk/bridge/discrete/testing/python/discreteCreateAndSaveEdges.py
+++ b/smtk/bridge/discrete/testing/python/discreteCreateAndSaveEdges.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python
+#=============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+#=============================================================================
+import os
+import sys
+import smtk
+import smtk.testing
+from smtk.simple import *
+
+class TestDiscreteCreateAndSaveEdges(smtk.testing.TestCase):
+
+  def resetTestFiles(self):
+    self.filesToTest = []
+
+  def addExternalFile(self, pathStr, validator = None):
+    self.filesToTest += [{'filename':pathStr, 'validator':validator}]
+
+  def addTestFile(self, pathList, validator = None):
+    self.addExternalFile(
+      os.path.join(*([smtk.testing.DATA_DIR,] + pathList)),
+      validator)
+
+  def validateCreateAndSaveEdges(self, model):
+
+    if self.haveVTK() and self.haveVTKExtension():
+
+      self.startRenderTest()
+
+      mbs = self.addModelToScene(model)
+
+      self.renderer.SetBackground(0.5,0.5,1)
+      ac = self.renderer.GetActors()
+      ac.InitTraversal()
+      act = ac.GetNextActor()
+      act.GetProperty().SetLineWidth(2)
+      act.GetProperty().SetPointSize(8)
+      act.GetMapper().SetResolveCoincidentTopologyToPolygonOffset()
+      cam = self.renderer.GetActiveCamera()
+      cam.SetFocalPoint(0., 0., 0.)
+      cam.SetPosition(15,-10,-20)
+      cam.SetViewUp(0,1,0)
+      self.renderer.ResetCamera()
+      self.renderWindow.Render()
+      self.assertImageMatch(['baselines', 'discrete', 'createedges-hybridModelOneCube.png'])
+      self.interact()
+
+  def setUp(self):
+    import os, sys
+    self.resetTestFiles()
+    self.addTestFile(['cmb', 'hybridModelOneCube.cmb'], self.validateCreateAndSaveEdges)
+
+    self.mgr = smtk.model.Manager.create()
+    sess = self.mgr.createSession('discrete')
+    sess.assignDefaultName()
+    SetActiveSession(sess)
+    self.shouldSave = False
+
+  def verifyCreateAndSaveEdges(self, filename, validator):
+    """Read a single file and validate that the operator worked.
+    This is done by checking number of cells greater than zero
+    reported by the output model as well as running an optional
+    function on the model to do further model-specific testing."""
+
+    print '\n\nFile: {fname}'.format(fname=filename)
+
+    mod = smtk.model.Model(Read(filename)[0])
+    self.assertEqual(len(mod.cells()), 2, 'Expected {nc} free cells'.format(nc=2))
+
+    btm = GetActiveSession().op('create edges')
+    self.assertIsNotNone(btm, 'Missing create edges operator.')
+    SetVectorValue(btm.findAsModelEntity('model'), [mod,])
+
+    res = btm.operate()   
+    sys.stdout.flush()
+    self.assertEqual(res.findInt('outcome').value(0), smtk.model.OPERATION_SUCCEEDED,
+        'create edges failed.')
+
+    writeop = GetActiveSession().op('write')
+    self.assertIsNotNone(writeop, 'Missing discrete write operator.')
+    SetVectorValue(writeop.findAsModelEntity('model'), [mod,])
+    tmpfile = ['testCreateAndSaveEdges.cmb',]
+    outfilename = os.path.join(*([smtk.testing.TEMP_DIR,] + tmpfile))
+    writeop.findAsFile('filename').setValue(0, outfilename)
+    res = writeop.operate()   
+    sys.stdout.flush()
+    self.assertEqual(res.findInt('outcome').value(0), smtk.model.OPERATION_SUCCEEDED,
+        'write SimpleBox model with edges failed.')
+
+    mod = smtk.model.Model(Read(outfilename)[0])
+    self.assertEqual(len(mod.cells()), 2, 'Expected {nc} free cells'.format(nc=2))
+
+    if validator:
+      validator(mod)
+
+    print '  Success'
+
+  def testCreateAndSaveEdges(self):
+    "Read each file named in setUp and validate the reader worked."
+    for test in self.filesToTest:
+      self.verifyCreateAndSaveEdges(test['filename'], test['validator'])
+
+    if self.shouldSave:
+      out = file('testcreateandsaveedges.json', 'w')
+      print >>out, smtk.io.ExportJSON.fromModelManager(self.mgr)
+      out.close()
+
+if __name__ == '__main__':
+  smtk.testing.process_arguments()
+  smtk.testing.main()

--- a/smtk/bridge/discrete/testing/python/discreteSplitEdge.py
+++ b/smtk/bridge/discrete/testing/python/discreteSplitEdge.py
@@ -100,11 +100,14 @@ class TestDiscreteSplitEdge(smtk.testing.TestCase):
       ac = self.renderer.GetActors()
       ac.InitTraversal()
       act = ac.GetNextActor()
-      act.GetProperty().SetLineWidth(5)
+      act.GetProperty().SetLineWidth(2)
+      act.GetProperty().SetPointSize(8)
+      act.GetMapper().SetResolveCoincidentTopologyToPolygonOffset()
+
       cam = self.renderer.GetActiveCamera()
       self.renderer.ResetCamera()
       self.renderWindow.Render()
-      self.assertImageMatchIfFileExists(['baselines', 'discrete', 'edge-split-test2D.png'])
+      self.assertImageMatch(['baselines', 'discrete', 'edge-split-test2D.png'])
       self.interact()
 
   def setUp(self):


### PR DESCRIPTION
vtk parsers and writers in discrete bridge could not handle full 3D models, meaning they can't write and read a 3D model with faces, edges and vertices. This constraint prevented the 3D discrete model being processed by meshers that require full 3D topology. With this commit, full 3D discrete models with edges can now be written and loaded with the writers and parsers.