### PR TITLE
Added operator switched signal-slots in operator related widgets.

### DIFF
--- a/smtk/extension/qt/CMakeLists.txt
+++ b/smtk/extension/qt/CMakeLists.txt
@@ -35,6 +35,7 @@ set(QAttrLibSrcs
   qtMeshSelectionItem.cxx
   qtModelEntityItem.cxx
   qtModelOperationWidget.cxx
+  qtOperatorDockWidget.cxx
   )
 
 set(QAttrLibUIs
@@ -78,6 +79,7 @@ set(QAttrLibHeaders
   qtMeshSelectionItem.h
   qtModelEntityItem.h
   qtModelOperationWidget.h
+  qtOperatorDockWidget.h
 )
 
 #install the headers

--- a/smtk/extension/qt/qtMeshSelectionItem.cxx
+++ b/smtk/extension/qt/qtMeshSelectionItem.cxx
@@ -358,11 +358,25 @@ void qtMeshSelectionItem::clearSelection()
   meshSelectionItem->reset();
 }
 //----------------------------------------------------------------------------
-void qtMeshSelectionItem::resetSelectionState()
+void qtMeshSelectionItem::resetSelectionState(bool emitSignal)
 {
   this->Internals->uncheckOpButtons();
   this->Internals->m_outSelection.clear();
   this->clearSelection();
+
+  smtk::attribute::MeshSelectionItemPtr meshSelectionItem =
+    dynamic_pointer_cast<MeshSelectionItem>(this->getObject());
+  if(meshSelectionItem)
+    {
+    meshSelectionItem->setModifyMode(NONE);
+    }
+
+  if(emitSignal)
+    {
+    smtk::attribute::ModelEntityItem::Ptr modelEntities =
+      this->refModelEntityItem();
+    emit this->requestMeshSelection(modelEntities);
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/smtk/extension/qt/qtMeshSelectionItem.h
+++ b/smtk/extension/qt/qtMeshSelectionItem.h
@@ -53,7 +53,7 @@ namespace smtk
     public slots:
       void setOutputOptional(int);
       void clearSelection();
-      void resetSelectionState();
+      void resetSelectionState(bool emitSignal = false);
 
     signals:
       void requestMeshSelection(smtk::attribute::ModelEntityItemPtr pEntItem);

--- a/smtk/extension/qt/qtModelOperationWidget.cxx
+++ b/smtk/extension/qt/qtModelOperationWidget.cxx
@@ -57,6 +57,7 @@ public:
   };
 
   smtk::model::Session::WeakPtr CurrentSession;
+  std::string CurrrentOpName;
   QVBoxLayout* WidgetLayout;
   QPointer<QComboBox> OperationCombo;
   QStackedLayout* OperationsLayout;
@@ -158,13 +159,64 @@ void qtModelOperationWidget::setSession(smtk::model::SessionPtr session)
 }
 
 //----------------------------------------------------------------------------
-bool qtModelOperationWidget::setCurrentOperation(
+void qtModelOperationWidget::cancelOperator(const std::string& opName)
+{
+  if(this->Internals->OperatorMap.contains(opName))
+    {
+    OperatorPtr brOp = this->Internals->OperatorMap[opName].opPtr;
+    emit this->operationCancelled(brOp);
+    }
+}
+
+//----------------------------------------------------------------------------
+bool qtModelOperationWidget::checkExistingOperator(const std::string& opName)
+{
+  // if the operator is already created, just set its UI to be current widget
+  if(this->Internals->OperatorMap.contains(opName))
+    {
+    this->Internals->OperatorMap[opName].opUiView->requestModelEntityAssociation();
+    this->Internals->OperationsLayout->setCurrentWidget(
+      this->Internals->OperatorMap[opName].opUiParent);
+    return true;
+    }
+  return false;
+}
+
+//----------------------------------------------------------------------------
+bool qtModelOperationWidget::initOperatorUI(
   const smtk::model::OperatorPtr& brOp)
 {
+  std::string opName = brOp->name();
+  std::string prevOpName = this->Internals->CurrrentOpName;
+  if(!prevOpName.empty() && opName != prevOpName)
+    {
+    // we need to reset previous operator's UI
+    this->cancelOperator(prevOpName);
+    }
+
+  // set the operator combobox to the corrent index
+  if(opName != this->Internals->OperationCombo->currentText().toStdString())
+    {
+    StringList opNames = brOp->session()->operatorNames(false);
+    std::sort(opNames.begin(), opNames.end());
+    int idx = std::find(opNames.begin(), opNames.end(), opName) - opNames.begin();
+    this->Internals->OperationCombo->blockSignals(true);
+    this->Internals->OperationCombo->setCurrentIndex(idx);
+    this->Internals->OperationCombo->blockSignals(false);
+    }
+
+  // if the operator is already created, just set its UI to be current widget
+  if(this->checkExistingOperator(opName))
+    {
+    this->Internals->CurrrentOpName = opName;
+    return true;
+    }
+
   if(!brOp->specification()->isValid())
     {
     return false;
     }
+
   SessionRef bs(brOp->manager(), brOp->session()->sessionId());
   this->setSession(bs.session());
   QFrame* opParent = new QFrame(this);
@@ -204,24 +256,15 @@ bool qtModelOperationWidget::setCurrentOperation(
   opInfo.opUiManager = uiManager;
   opInfo.opUiView = theView;
 
-  this->Internals->OperatorMap[brOp->name()] = opInfo;
+  this->Internals->OperatorMap[opName] = opInfo;
   this->Internals->OperationsLayout->addWidget(opParent);
   this->Internals->OperationsLayout->setCurrentWidget(opParent);
-
-  if(brOp->name() != this->Internals->OperationCombo->currentText().toStdString())
-    {
-    StringList opNames = brOp->session()->operatorNames(false);
-    std::sort(opNames.begin(), opNames.end());
-    int idx = std::find(opNames.begin(), opNames.end(), brOp->name()) - opNames.begin();
-    this->Internals->OperationCombo->blockSignals(true);
-    this->Internals->OperationCombo->setCurrentIndex(idx);
-    this->Internals->OperationCombo->blockSignals(false);
-    }
+  this->Internals->CurrrentOpName = opName;
   return true;
 }
 
 //----------------------------------------------------------------------------
-bool qtModelOperationWidget::setCurrentOperation(
+bool qtModelOperationWidget::setCurrentOperator(
   const std::string& opName, smtk::model::SessionPtr session)
 {
   this->setSession(session);
@@ -237,16 +280,10 @@ bool qtModelOperationWidget::setCurrentOperation(
     return true;
     }
 
-  if(this->Internals->OperatorMap.contains(opName))
-    {
-    this->Internals->OperatorMap[opName].opUiView->requestModelEntityAssociation();
-    this->Internals->OperationsLayout->setCurrentWidget(
-      this->Internals->OperatorMap[opName].opUiParent);
-    return true;
-    }
+  OperatorPtr brOp = this->Internals->OperatorMap.contains(opName) ?
+    this->Internals->OperatorMap[opName].opPtr :
+    session->op(opName); // create the operator
 
-  // create the operator
-  OperatorPtr brOp = session->op(opName);
   if (!brOp)
     {
     std::cerr
@@ -255,7 +292,7 @@ bool qtModelOperationWidget::setCurrentOperation(
       << " (" << session->sessionId() << ")\n";
     return false;
     }
-  return this->setCurrentOperation(brOp);
+  return this->initOperatorUI(brOp);
 }
 
 //----------------------------------------------------------------------------
@@ -283,7 +320,7 @@ void qtModelOperationWidget::expungeEntities(
 //----------------------------------------------------------------------------
 void qtModelOperationWidget::onOperationSelected()
 {
-  this->setCurrentOperation(
+  this->setCurrentOperator(
     this->Internals->OperationCombo->currentText().toStdString(),
     this->Internals->CurrentSession.lock());
 }
@@ -302,9 +339,9 @@ void qtModelOperationWidget::onOperate()
 void qtModelOperationWidget::onMeshSelectionItemCreated(
   smtk::attribute::qtMeshSelectionItem* meshItem)
 {
-  std::string opName = this->Internals->OperationCombo->currentText().toStdString();
   if(this->Internals->CurrentSession.lock())
     {
+    std::string opName = this->Internals->OperationCombo->currentText().toStdString();
     smtk::common::UUID sessId =
       this->Internals->CurrentSession.lock()->sessionId();
     emit this->meshSelectionItemCreated(meshItem, opName, sessId);

--- a/smtk/extension/qt/qtModelOperationWidget.cxx
+++ b/smtk/extension/qt/qtModelOperationWidget.cxx
@@ -159,6 +159,12 @@ void qtModelOperationWidget::setSession(smtk::model::SessionPtr session)
 }
 
 //----------------------------------------------------------------------------
+void qtModelOperationWidget::cancelCurrentOperator()
+{
+  this->cancelOperator(this->Internals->CurrrentOpName);
+}
+
+//----------------------------------------------------------------------------
 void qtModelOperationWidget::cancelOperator(const std::string& opName)
 {
   if(this->Internals->OperatorMap.contains(opName))

--- a/smtk/extension/qt/qtModelOperationWidget.cxx
+++ b/smtk/extension/qt/qtModelOperationWidget.cxx
@@ -97,10 +97,11 @@ void qtModelOperationWidget::initWidget( )
   this->Internals->OperateButton->setDefault(true);
 
   QHBoxLayout* operatorLayout = new QHBoxLayout();
-//  QLabel* opLabel = new QLabel("Operator:");
-//  opLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  operatorLayout->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+  this->Internals->OperationCombo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  this->Internals->OperateButton->setMinimumHeight(32);
   this->Internals->OperateButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-//  operatorLayout->addWidget(opLabel);
+
   operatorLayout->addWidget(this->Internals->OperateButton);
   operatorLayout->addWidget(this->Internals->OperationCombo);
   this->Internals->WidgetLayout->addLayout(operatorLayout);

--- a/smtk/extension/qt/qtModelOperationWidget.h
+++ b/smtk/extension/qt/qtModelOperationWidget.h
@@ -62,8 +62,11 @@ namespace smtk
           const std::string& opName, const smtk::common::UUID& uuid);
       void entitiesSelected(const smtk::common::UUIDs&);
 
+    friend class qtModelView;
+
     protected slots:
       virtual void onOperationSelected();
+      virtual void cancelCurrentOperator();
       virtual void cancelOperator(const std::string& opName);
       virtual void onMeshSelectionItemCreated(smtk::attribute::qtMeshSelectionItem*);
       virtual bool checkExistingOperator(const std::string& opName);

--- a/smtk/extension/qt/qtModelOperationWidget.h
+++ b/smtk/extension/qt/qtModelOperationWidget.h
@@ -45,15 +45,16 @@ namespace smtk
       virtual QSize sizeHint() const;
 
     public slots:
-      virtual bool setCurrentOperation(
+      virtual bool setCurrentOperator(
         const std::string& opName, smtk::model::SessionPtr session);
-      virtual bool setCurrentOperation(const smtk::model::OperatorPtr& brOp);
+      virtual bool initOperatorUI(const smtk::model::OperatorPtr& brOp);
       virtual void expungeEntities(
         const smtk::model::EntityRefs& expungedEnts);
       virtual void onOperate();
 
     signals:
       void operationRequested(const smtk::model::OperatorPtr& brOp);
+      void operationCancelled(const smtk::model::OperatorPtr& brOp);
       void fileItemCreated(smtk::attribute::qtFileItem* fileItem);
       void modelEntityItemCreated(smtk::attribute::qtModelEntityItem* entItem);
       void meshSelectionItemCreated(
@@ -63,7 +64,9 @@ namespace smtk
 
     protected slots:
       virtual void onOperationSelected();
+      virtual void cancelOperator(const std::string& opName);
       virtual void onMeshSelectionItemCreated(smtk::attribute::qtMeshSelectionItem*);
+      virtual bool checkExistingOperator(const std::string& opName);
 
     protected:
       virtual void initWidget( );

--- a/smtk/extension/qt/qtModelPanel.cxx
+++ b/smtk/extension/qt/qtModelPanel.cxx
@@ -59,6 +59,8 @@ qtModelPanel::qtModelPanel(QWidget* p)
 //-----------------------------------------------------------------------------
 qtModelPanel::~qtModelPanel()
 {
+  delete this->Internal->ModelView;
+  delete this->Internal;
 }
 
 //-----------------------------------------------------------------------------

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -797,6 +797,8 @@ QDockWidget* qtModelView::operatorsDock()
   qtModelOperationWidget* opWidget = new qtModelOperationWidget();
   QObject::connect(opWidget, SIGNAL(operationRequested(const smtk::model::OperatorPtr&)),
     this, SIGNAL(operationRequested(const smtk::model::OperatorPtr&)));
+  QObject::connect(opWidget, SIGNAL(operationCancelled(const smtk::model::OperatorPtr&)),
+    this, SIGNAL(operationCancelled(const smtk::model::OperatorPtr&)));
   QObject::connect(opWidget, SIGNAL(fileItemCreated(smtk::attribute::qtFileItem*)),
     this, SIGNAL(fileItemCreated(smtk::attribute::qtFileItem*)));
   QObject::connect(opWidget, SIGNAL(modelEntityItemCreated(smtk::attribute::qtModelEntityItem*)),
@@ -847,7 +849,7 @@ void qtModelView::initOperatorsDock(
   this->operatorsDock()->show();
   SessionRef bs(session->manager(), session->sessionId());
 
-  this->m_OperatorsWidget->setCurrentOperation(opName, session);
+  this->m_OperatorsWidget->setCurrentOperator(opName, session);
   this->m_OperatorsDock->setWindowTitle(bs.flagSummary().c_str());
 }
 
@@ -869,7 +871,7 @@ bool qtModelView::requestOperation(
     this->operatorsDock()->show();
     SessionRef bs(brOp->manager(), brOp->session()->sessionId());
 
-    this->m_OperatorsWidget->setCurrentOperation(brOp);
+    this->m_OperatorsWidget->initOperatorUI(brOp);
     this->m_OperatorsDock->setWindowTitle(bs.flagSummary().c_str());
     }
   return true;

--- a/smtk/extension/qt/qtModelView.cxx
+++ b/smtk/extension/qt/qtModelView.cxx
@@ -36,10 +36,10 @@
 #include "smtk/extension/qt/qtAttribute.h"
 #include "smtk/extension/qt/qtModelEntityItem.h"
 #include "smtk/extension/qt/qtModelOperationWidget.h"
+#include "smtk/extension/qt/qtOperatorDockWidget.h"
 #include "smtk/extension/qt/qtUIManager.h"
 
 #include <QPointer>
-#include <QDockWidget>
 #include <QDropEvent>
 #include <QDragEnterEvent>
 #include <QDragMoveEvent>
@@ -787,7 +787,7 @@ void qtModelView::operatorInvoked()
 }
 
 //----------------------------------------------------------------------------
-QDockWidget* qtModelView::operatorsDock()
+qtOperatorDockWidget* qtModelView::operatorsDock()
 {
   if(this->m_OperatorsDock && this->m_OperatorsWidget)
     {
@@ -822,7 +822,7 @@ QDockWidget* qtModelView::operatorsDock()
       }
     }
 
-  QDockWidget* dw = new QDockWidget(dockP);
+  qtOperatorDockWidget* dw = new qtOperatorDockWidget(dockP);
   QScrollArea* s = new QScrollArea(dw);
   s->setWidgetResizable(true);
   s->setFrameShape(QFrame::NoFrame);
@@ -831,9 +831,10 @@ QDockWidget* qtModelView::operatorsDock()
   opWidget->setSizePolicy(QSizePolicy::Preferred,
     QSizePolicy::Expanding);
   s->setWidget(opWidget);
-  dw->setObjectName("operatorsDockWidget");
   dw->setWidget(s);
-  dw->setFloating(true);
+
+  QObject::connect(dw, SIGNAL(closing()),
+    this, SLOT(onOperationPanelClosing()));
 
   this->m_OperatorsWidget = opWidget;
   this->m_OperatorsDock = dw;
@@ -1275,6 +1276,16 @@ std::string qtModelView::determineAction (const QPoint& evtpos) const
     return thedelegate->determineAction(evtpos, idx, opt);
     }
   return "";
+}
+
+//-----------------------------------------------------------------------------
+void qtModelView::onOperationPanelClosing()
+{
+  // If the operation panel is closing, cancel current operation
+  if(this->m_OperatorsWidget)
+    {
+    this->m_OperatorsWidget->cancelCurrentOperator();
+    }
 }
 
   } // namespace model

--- a/smtk/extension/qt/qtModelView.h
+++ b/smtk/extension/qt/qtModelView.h
@@ -87,6 +87,7 @@ public slots:
 signals:
   void entitiesSelected(const smtk::model::EntityRefs& selEntityRefs);
   void operationRequested(const smtk::model::OperatorPtr& brOp);
+  void operationCancelled(const smtk::model::OperatorPtr& brOp);
   void operationFinished(const smtk::model::OperatorResult&);
   void fileItemCreated(smtk::attribute::qtFileItem* fileItem);
   void modelEntityItemCreated(smtk::attribute::qtModelEntityItem* entItem);

--- a/smtk/extension/qt/qtModelView.h
+++ b/smtk/extension/qt/qtModelView.h
@@ -26,7 +26,6 @@
 
 class QDropEvent;
 class QMenu;
-class QDockWidget;
 
 namespace smtk {
  namespace attribute {
@@ -41,6 +40,7 @@ namespace smtk {
 
 class DescriptivePhrase;
 class qtModelOperationWidget;
+class qtOperatorDockWidget;
 
 class SMTKQTEXT_EXPORT qtModelView : public QTreeView
 {
@@ -106,6 +106,7 @@ protected slots:
                                const smtk::model::Group& grp,
                                const smtk::model::EntityRefs& entities);
   virtual void newIndexAdded(const QModelIndex & newidx);
+  virtual void onOperationPanelClosing();
 
 protected:
   // If 'Delete' button is pressed, invoke proper operation if possible.
@@ -157,7 +158,7 @@ protected:
   bool initOperator(smtk::model::OperatorPtr op);
   void initOperatorsDock(
     const std::string& opName, smtk::model::SessionPtr session);
-  QDockWidget* operatorsDock();
+  qtOperatorDockWidget* operatorsDock();
 
 /*
   void findIndexes(
@@ -174,7 +175,7 @@ protected:
   const QColor& newcolor, OperatorPtr brOp);
 
   QMenu* m_ContextMenu;
-  QDockWidget* m_OperatorsDock;
+  qtOperatorDockWidget* m_OperatorsDock;
   qtModelOperationWidget* m_OperatorsWidget;
 };
 

--- a/smtk/extension/qt/qtOperatorDockWidget.cxx
+++ b/smtk/extension/qt/qtOperatorDockWidget.cxx
@@ -1,0 +1,38 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/extension/qt/qtOperatorDockWidget.h"
+#include <QCloseEvent>
+
+// -----------------------------------------------------------------------------
+namespace smtk {
+  namespace model {
+
+//-----------------------------------------------------------------------------
+qtOperatorDockWidget::qtOperatorDockWidget(QWidget* p)
+  : QDockWidget(p)
+{
+  this->setObjectName("operatorsDockWidget");
+  this->setFloating(true);
+}
+
+//-----------------------------------------------------------------------------
+qtOperatorDockWidget::~qtOperatorDockWidget()
+{
+}
+
+//-----------------------------------------------------------------------------
+void qtOperatorDockWidget::closeEvent(QCloseEvent* clevent)
+{
+  emit this->closing();
+  this->QDockWidget::closeEvent(clevent);
+}
+
+  } // namespace model
+} // namespace smtk

--- a/smtk/extension/qt/qtOperatorDockWidget.h
+++ b/smtk/extension/qt/qtOperatorDockWidget.h
@@ -1,0 +1,48 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+// .NAME qtOperatorDockWidget - the dockwidget for smtk model operators.
+// .SECTION Description
+// The main purpose of this class is to overwrite the closeEvent(), so that
+// it can signal others that the operator panel is closing. The
+// NOTE, QDockWidget::visibilityChanged(bool) This signal is emitted when
+// the dock widget becomes visible (or invisible). This happens when the
+// widget is hidden or shown, as well as when it is docked in a tabbed dock
+// area and its tab becomes selected or unselected, which is not what we want.
+// .SECTION Caveats
+
+#ifndef _qtOperatorDockWidget_h
+#define _qtOperatorDockWidget_h
+
+#include "smtk/extension/qt/Exports.h"
+#include <QDockWidget>
+
+namespace smtk {
+  namespace model {
+
+class SMTKQTEXT_EXPORT qtOperatorDockWidget : public QDockWidget
+{
+  Q_OBJECT
+
+public:
+  qtOperatorDockWidget(QWidget* p = NULL);
+  ~qtOperatorDockWidget();
+
+signals:
+   void closing();
+
+protected:
+   virtual void closeEvent(QCloseEvent * event);
+
+};
+
+  } // namespace model
+} // namespace smtk
+
+#endif // !_qtOperatorDockWidget_h


### PR DESCRIPTION
When the qtModelOperationWidget switches operators, it will now emit
an operationCancelled signal to let application know the current operator
is being cancelled, and give the application a chance to reset its state
if the canceling operator modified the behavior of the application, such
as cursor shape, selection mode, etc.