### PR TITLE
Extend the content stored in JSON when we serialized a smtk mesh coll…

### DIFF
--- a/doc/userguide/mesh/IO.rst
+++ b/doc/userguide/mesh/IO.rst
@@ -34,12 +34,75 @@ Serialization
 
 .. highlight:: json
 .. code-block:: json
-    b0e336a9-5fbf-4dae-b419-3664c17ef402": {
-      "formatVersion":  1,
-      "name": "",
-      "fileType": "moab",
-      "location": "/Users/robert/Work/smtk/data/mesh/tmp/output.0.h5m"
-    }
+    "70ec982c-9562-44bd-a7e7-bd12b84a3271": {
+     "formatVersion":  1,
+     "name": "",
+     "fileType": "moab",
+     "location": "/tmp/output.0.h5m",
+     "nc": 40,
+     "np": 28,
+     "cell_types": "000000100",
+     "domains":  [],
+     "boundary_conditions":  {
+       "0": {
+         "value":  2,
+         "type": "dirichlet"
+       },
+       "1":  {
+         "value":  2,
+         "type": "neumann"
+       },
+     },
+     "modelEntityIds": ["0442f22c-26dc-4e6b-bdd8-1e77b75e5d36", "7d42284b-c7e0-4777-8836-3b77d6aed0e3", "8cdcf988-36bd-43ed-bb60-c76443907f16", "c7a90a24-f058-4d79-8b75-bb58470547bf"],
+     "meshes": {
+       "0":  {
+         "nc": 10,
+         "np": 7,
+         "cell_types": "000000100",
+         "domains":  [],
+         "boundary_conditions":  {
+           "0":  {
+             "value":  2,
+             "type": "neumann"
+           }
+         },
+         "modelEntityIds": ["0442f22c-26dc-4e6b-bdd8-1e77b75e5d36"]
+       },
+       "1":  {
+         "nc": 10,
+         "np": 7,
+         "cell_types": "000000100",
+         "domains":  [],
+         "boundary_conditions":  { },
+         "modelEntityIds": ["7d42284b-c7e0-4777-8836-3b77d6aed0e3"]
+       },
+       "2":  {
+         "nc": 10,
+         "np": 7,
+         "cell_types": "000000100",
+         "domains":  [],
+         "boundary_conditions":  {
+           "0":  {
+             "value":  2,
+             "type": "dirichlet"
+           }
+           "1":  {
+             "value":  2,
+             "type": "neumann"
+           }
+         },
+         "modelEntityIds": ["8cdcf988-36bd-43ed-bb60-c76443907f16"]
+       },
+       "3":  {
+         "nc": 10,
+         "np": 7,
+         "cell_types": "000000100",
+         "domains":  [],
+         "boundary_conditions":  { },
+         "modelEntityIds": ["c7a90a24-f058-4d79-8b75-bb58470547bf"]
+       }
+     }
+   }
 
 
 :smtk:io:`ImportJSON <smtk::io::ImportJSON>`

--- a/smtk/io/ExportJSON.h
+++ b/smtk/io/ExportJSON.h
@@ -103,6 +103,11 @@ public:
                               smtk::mesh::ManagerPtr meshMgr,
                               const std::string& fileWriteLocation);
 
+  //write out a
+  static int forSingleCollection(cJSON* mdesc,
+                                 smtk::mesh::CollectionPtr collection,
+                                 const std::string &fileWriteLocation);
+
   static int forLog(
     cJSON* logrecordarray,
     const smtk::io::Logger& log,


### PR DESCRIPTION
…ections.

We now store a significant increase of information in the smtk mesh collection
JSON stream, so that it is easier for consumers to build a proxy/flywieght
representation of the mesh/collection without loading it from disk.