### PR TITLE
Allow mesh::HandleRanges to be efficiently saved to json.

### DIFF
--- a/smtk/mesh/CMakeLists.txt
+++ b/smtk/mesh/CMakeLists.txt
@@ -4,6 +4,7 @@ set(meshSrcs
   CellTypes.cxx
   Collection.cxx
   ExtractTessellation.cxx
+  Handle.cxx
   Manager.cxx
   MeshSet.cxx
   PointConnectivity.cxx

--- a/smtk/mesh/CellSet.h
+++ b/smtk/mesh/CellSet.h
@@ -76,6 +76,8 @@ public:
   //get the connectivity for a single cell
   smtk::mesh::PointConnectivity pointConnectivity( std::size_t ) const;
 
+  //get the underlying HandleRange that this CellSet represents
+  const smtk::mesh::HandleRange& range() const { return this->m_range; }
 private:
   smtk::mesh::CollectionPtr m_parent;
   smtk::mesh::HandleRange m_range; //range of moab cell ids

--- a/smtk/mesh/Handle.cxx
+++ b/smtk/mesh/Handle.cxx
@@ -1,0 +1,153 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+
+#include "smtk/mesh/Handle.h"
+#include "cJSON.h"
+
+#include <boost/cstdint.hpp>
+#include <iostream>
+#include <sstream>
+
+
+namespace smtk {
+namespace mesh {
+
+namespace detail
+{
+
+#define MOAB_TYPE_WIDTH 4
+#define MOAB_ID_WIDTH (8*sizeof(smtk::mesh::Handle)-MOAB_TYPE_WIDTH)
+#define MOAB_TYPE_MASK ((smtk::mesh::Handle)0xF << MOAB_ID_WIDTH)
+#define MOAB_ID_MASK (~MOAB_TYPE_MASK)
+
+  inline ::moab::EntityID to_id(smtk::mesh::Handle handle)
+  {
+  return (handle & MOAB_ID_MASK);
+  }
+
+  inline smtk::mesh::Handle to_handle(::moab::EntityType type,
+                                      ::moab::EntityID id)
+  {
+  if (type > ::moab::MBMAXTYPE)
+    {
+    return smtk::mesh::Handle();  //<You've got to return something.  What do you return?
+    }
+  return (((smtk::mesh::Handle)type) << MOAB_ID_WIDTH)|id;
+  }
+
+#undef MOAB_TYPE_WIDTH
+#undef MOAB_ID_WIDTH
+#undef MOAB_TYPE_MASK
+#undef MOAB_ID_MASK
+
+  //presumes that all values in the range are withing the same entity type
+  cJSON* subset_to_json_array(const smtk::mesh::HandleRange& range)
+  {
+  cJSON* array = cJSON_CreateArray();
+  //iterate the range finding
+  typedef smtk::mesh::HandleRange::const_pair_iterator const_pair_iterator;
+
+  for(const_pair_iterator i=range.begin();
+      i != range.end();
+      ++i)
+    {
+    ::moab::EntityID start = to_id(i->first);
+    ::moab::EntityID end = to_id(i->second);
+
+    cJSON_AddItemToArray(array, cJSON_CreateNumber(start));
+    cJSON_AddItemToArray(array, cJSON_CreateNumber(end));
+    }
+
+  return array;
+  }
+
+  //presumes that all values in the range are withing the same entity type
+  smtk::mesh::HandleRange subset_from_json_array(int type,
+                                                 cJSON* array)
+  {
+  smtk::mesh::HandleRange result;
+  ::moab::EntityType et = static_cast< ::moab::EntityType >(type);
+  cJSON* n = array->child;
+  while(n)
+    {
+    ::moab::EntityID start = to_handle(et, n->valuedouble);
+    ::moab::EntityID end = to_handle(et, n->next->valuedouble);
+    result.insert(start,end);
+
+    //since we are reading two nodes at a time
+    if(n->next)
+      { n = n->next->next; }
+    else
+      { n = NULL; }
+    }
+
+  return result;
+  }
+}
+
+//----------------------------------------------------------------------------
+//convert a handle range to a json formatted node
+cJSON* to_json(const smtk::mesh::HandleRange& range)
+{
+  cJSON* json_dict = cJSON_CreateObject();
+
+  //first we subset by type
+  std::stringstream buffer;
+  std::string typeAsString;
+  for(::moab::EntityType i= ::moab::MBVERTEX;
+      i != ::moab::MBMAXTYPE;
+      ++i)
+  {
+    smtk::mesh::HandleRange subset = range.subset_by_type(i);
+    if(subset.empty())
+      {
+      continue;
+      }
+
+    //build the name
+    buffer << i;
+    buffer >> typeAsString;
+    buffer.clear();
+
+    cJSON* jarray = detail::subset_to_json_array(subset);
+    cJSON_AddItemToObject(json_dict, typeAsString.c_str(), jarray);
+  }
+
+  return json_dict;
+}
+
+//----------------------------------------------------------------------------
+//convert json formatted string to a handle range
+smtk::mesh::HandleRange from_json(cJSON* json)
+{
+  smtk::mesh::HandleRange result;
+
+  std::stringstream buffer;
+  //iterate the children
+  for (cJSON* arr = json->child; arr; arr = arr->next)
+    {
+    if (arr->type == cJSON_Array)
+      {
+      //extract the name
+      int type;
+      buffer << std::string(arr->string);
+      buffer >> type;
+      buffer.clear();
+
+      smtk::mesh::HandleRange subset = detail::subset_from_json_array(type,
+                                                                      arr);
+      result.merge(subset);
+      }
+    }
+  return result;
+}
+
+}
+}

--- a/smtk/mesh/Handle.h
+++ b/smtk/mesh/Handle.h
@@ -11,14 +11,23 @@
 #ifndef __smtk_mesh_Handle_h
 #define __smtk_mesh_Handle_h
 
+#include "smtk/CoreExports.h"
 #include "smtk/mesh/moab/HandleRange.h"
+
+#ifndef SHIBOKEN_SKIP
+#  include "cJSON.h"
+#endif // SHIBOKEN_SKIP
 
 namespace smtk {
 namespace mesh {
   typedef smtk::mesh::moab::Handle Handle;
   typedef smtk::mesh::moab::HandleRange HandleRange;
-}
-}
 
+  SMTKCORE_EXPORT cJSON* to_json(const smtk::mesh::HandleRange& range);
+
+  SMTKCORE_EXPORT smtk::mesh::HandleRange from_json(cJSON* json);
+
+}
+}
 
 #endif

--- a/smtk/mesh/MeshSet.h
+++ b/smtk/mesh/MeshSet.h
@@ -113,6 +113,9 @@ public:
   //invalid, and using them will cause any undefined behavior
   bool mergeCoincidentContactPoints(double tolerance=1.0e-6) const;
 
+  //get the underlying HandleRange that this MeshSet represents
+  const smtk::mesh::HandleRange& range() const { return this->m_range; }
+
 private:
   smtk::mesh::CollectionPtr m_parent;
   smtk::mesh::Handle m_handle;

--- a/smtk/mesh/PointSet.h
+++ b/smtk/mesh/PointSet.h
@@ -62,6 +62,9 @@ public:
   //so generally this is only used if you fully understand the input domain
   bool get(float* xyz) const;
 
+  //get the underlying HandleRange that this PointSet represents
+  const smtk::mesh::HandleRange& range() const { return this->m_points; }
+
 private:
 
   smtk::mesh::CollectionPtr m_parent;

--- a/smtk/mesh/testing/cxx/CMakeLists.txt
+++ b/smtk/mesh/testing/cxx/CMakeLists.txt
@@ -16,6 +16,7 @@ set(unit_tests
   UnitTestManager.cxx
   UnitTestModelToMesh.cxx
   UnitTestQueryTypes.cxx
+  UnitTestReadWriteHandles.cxx
   UnitTestTypeSet.cxx
 )
 

--- a/smtk/mesh/testing/cxx/UnitTestReadWriteHandles.cxx
+++ b/smtk/mesh/testing/cxx/UnitTestReadWriteHandles.cxx
@@ -1,0 +1,172 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+
+#include "smtk/mesh/Collection.h"
+#include "smtk/mesh/Handle.h"
+#include "smtk/mesh/Manager.h"
+
+#include "smtk/mesh/testing/cxx/helpers.h"
+
+//force to use filesystem version 3
+#define BOOST_FILESYSTEM_VERSION 3
+#include <boost/filesystem.hpp>
+using namespace boost::filesystem;
+
+
+namespace
+{
+
+inline smtk::mesh::Handle to_handle(::moab::EntityType type,
+                                    ::moab::EntityID id)
+{
+  const std::size_t id_width = (8*sizeof(smtk::mesh::Handle)-4);
+  if (type > ::moab::MBMAXTYPE)
+    {
+    return smtk::mesh::Handle();
+    }
+  return (((smtk::mesh::Handle)type) << id_width)|id;
+}
+
+//----------------------------------------------------------------------------
+void verify_empty_handle()
+{
+  smtk::mesh::HandleRange range;
+
+  //convert empty handle to json
+  cJSON* json = smtk::mesh::to_json(range);
+
+  //verify that the json has no children, since the range is empty
+  test( (json->child == NULL), "empty handle range json form should be empty" );
+
+  //convert back to a handle
+  smtk::mesh::HandleRange result = smtk::mesh::from_json(json);
+
+  test( result == range, "empty handle didn't serialize properly");
+}
+
+//----------------------------------------------------------------------------
+void verify_meshset_handle()
+{
+  smtk::mesh::Handle first = to_handle(::moab::MBENTITYSET, 1);
+  smtk::mesh::Handle second = to_handle(::moab::MBENTITYSET, 1024);
+
+  //make range have 1024 meshes
+  smtk::mesh::HandleRange range;
+  range.insert(first,second);
+
+  test( range.size() == 1024, "verify range has proper length");
+  test( range.all_of_type( ::moab::MBENTITYSET) == true, "verify range is all mesh sets");
+
+  //now verify that it converts to json properly
+  cJSON* json = smtk::mesh::to_json(range);
+
+  //verify that the json has no children, since the range is empty
+  test( (json->child != NULL), "meshset handle json form should have a child node" );
+
+  //convert back to a handle
+  smtk::mesh::HandleRange result = smtk::mesh::from_json(json);
+  test( result == range, "meshset handle didn't serialize properly");
+}
+
+//----------------------------------------------------------------------------
+void verify_single_cell_type_handle()
+{
+  smtk::mesh::Handle first = to_handle(::moab::MBHEX, 1);
+  smtk::mesh::Handle second = to_handle(::moab::MBHEX, 450);
+
+  //make range have 1024 meshes
+  smtk::mesh::HandleRange range;
+  range.insert(first,second);
+
+  //now verify that it converts to json properly
+  cJSON* json = smtk::mesh::to_json(range);
+
+  //verify that the json has no children, since the range is empty
+  test( (json->child != NULL), "meshset handle json form should have a child node" );
+
+  //convert back to a handle
+  smtk::mesh::HandleRange result = smtk::mesh::from_json(json);
+  test( result == range, "single cell set handle didn't serialize properly");
+}
+
+//----------------------------------------------------------------------------
+void verify_mixed_handle()
+{
+  smtk::mesh::Handle first = to_handle(::moab::MBENTITYSET, 1);
+  smtk::mesh::Handle second = to_handle(::moab::MBENTITYSET, 45);
+
+  smtk::mesh::Handle third = to_handle(::moab::MBENTITYSET, 100);
+  smtk::mesh::Handle fourth = to_handle(::moab::MBENTITYSET, 450);
+
+  smtk::mesh::Handle fifth = to_handle(::moab::MBHEX, 1);
+  smtk::mesh::Handle sixth = to_handle(::moab::MBHEX, 450);
+
+  //make range have 1024 meshes
+  smtk::mesh::HandleRange range;
+  range.insert(first,second);
+  range.insert(third,fourth);
+  range.insert(fifth,sixth);
+
+  //now verify that it converts to json properly
+  cJSON* json = smtk::mesh::to_json(range);
+
+  //verify that the json has no children, since the range is empty
+  test( (json->child != NULL), "meshset handle json form should have a child node" );
+
+  //convert back to a handle
+  smtk::mesh::HandleRange result = smtk::mesh::from_json(json);
+  test( result == range, "mixed cell set handle didn't serialize properly");
+}
+
+
+//----------------------------------------------------------------------------
+void verify_large_number_of_values_handle()
+{
+  smtk::mesh::Handle first = to_handle(::moab::MBENTITYSET, 1);
+  smtk::mesh::Handle second = to_handle(::moab::MBENTITYSET, 2048);
+
+  smtk::mesh::Handle third = to_handle(::moab::MBHEX, 0);
+  smtk::mesh::Handle fourth = to_handle(::moab::MBHEX, 4194303);
+
+  smtk::mesh::Handle fifth = to_handle(::moab::MBHEX, 0);
+  smtk::mesh::Handle sixth = to_handle(::moab::MBHEX, 8388607);
+
+  //make range have 1024 meshes
+  smtk::mesh::HandleRange range;
+  range.insert(first,second);
+  range.insert(third,fourth);
+  range.insert(fifth,sixth);
+
+  //now verify that it converts to json properly
+  cJSON* json = smtk::mesh::to_json(range);
+
+  //verify that the json has no children, since the range is empty
+  test( (json->child != NULL), "meshset handle json form should have a child node" );
+
+  //convert back to a handle
+  smtk::mesh::HandleRange result = smtk::mesh::from_json(json);
+  test( result == range, "mixed cell set handle didn't serialize properly");
+}
+
+
+}
+
+//----------------------------------------------------------------------------
+int UnitTestReadWriteHandles(int, char**)
+{
+  verify_empty_handle();
+
+  verify_meshset_handle();
+  verify_single_cell_type_handle();
+  verify_mixed_handle();
+
+  verify_large_number_of_values_handle();
+  return 0;
+}


### PR DESCRIPTION
This is required to properly serialize a lightweight representation of the
moab database, to clients such as ModelBuilder.