### PR TITLE
Remove usage of removed vtksys:: stringstream's.

### DIFF
--- a/smtk/bridge/discrete/extension/reader/vtkCUBITReader.cxx
+++ b/smtk/bridge/discrete/extension/reader/vtkCUBITReader.cxx
@@ -19,7 +19,7 @@
 #include "vtkPolyData.h"
 #include "vtkPolyDataNormals.h"
 
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 namespace smtk {
   namespace bridge {

--- a/smtk/bridge/discrete/kernel/Serialize/vtkModelXMLParser.cxx
+++ b/smtk/bridge/discrete/kernel/Serialize/vtkModelXMLParser.cxx
@@ -10,7 +10,7 @@
 #include "vtkModelXMLParser.h"
 #include "vtkObjectFactory.h"
 #include "vtkXMLElement.h"
-#include "vtksys/ios/sstream"
+#include <sstream>
 
 vtkStandardNewMacro(vtkModelXMLParser);
 
@@ -63,7 +63,7 @@ void vtkModelXMLParser::StartElement(const char* name, const char** atts)
     }
   else
     {
-    vtksys_ios::ostringstream idstr;
+    std::ostringstream idstr;
     idstr << this->ElementIdIndex++ << ends;
     element->SetId(idstr.str().c_str());
     }

--- a/smtk/bridge/discrete/kernel/Serialize/vtkXMLArchiveReader.cxx
+++ b/smtk/bridge/discrete/kernel/Serialize/vtkXMLArchiveReader.cxx
@@ -32,7 +32,7 @@
 #include <list>
 #include <map>
 #include <vtksys/SystemTools.hxx>
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 vtkStandardNewMacro(vtkXMLArchiveReader);
 
@@ -402,7 +402,7 @@ void SerializeKeyVectorKey(vtkInformation* info,
     return;
     }
 
-  vtksys_ios::istringstream valueStr(values);
+  std::istringstream valueStr(values);
   for (int i = 0; i < length; ++i)
     {
     std::string keyName;

--- a/smtk/bridge/discrete/kernel/Serialize/vtkXMLArchiveWriter.cxx
+++ b/smtk/bridge/discrete/kernel/Serialize/vtkXMLArchiveWriter.cxx
@@ -31,7 +31,7 @@
 #include <list>
 #include <map>
 #include <algorithm>
-#include "vtksys/ios/sstream"
+#include <sstream>
 
 vtkStandardNewMacro(vtkXMLArchiveWriter);
 
@@ -229,7 +229,7 @@ void SerializeStringVectorKey(vtkInformation* info,
   keyElem->SetName(keyName);
   parent->AddNestedElement(keyElem);
 
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   unsigned int length = static_cast<unsigned int>(info->Length(key));
   int* lengths = new int[length];
   for (unsigned int i = 0; i < length; ++i)
@@ -258,7 +258,7 @@ void SerializeKeyVectorKey(vtkInformation* info,
   keyElem->SetName(keyName);
   parent->AddNestedElement(keyElem);
 
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   unsigned int length = static_cast<unsigned int>(info->Length(key));
   for (unsigned int i = 0; i < length; ++i)
     {
@@ -422,7 +422,7 @@ void vtkXMLArchiveWriter::Serialize(const char* name,
   for(; iter != map.end(); iter++)
     {
     std::vector<vtkSmartPointer<vtkObject> >& objs = iter->second;
-    vtksys_ios::ostringstream str;
+    std::ostringstream str;
     str << "Key_" << iter->first;
     this->Serialize(str.str().c_str(), objs);
     }

--- a/smtk/bridge/discrete/kernel/Serialize/vtkXMLArchiveWriter.h
+++ b/smtk/bridge/discrete/kernel/Serialize/vtkXMLArchiveWriter.h
@@ -92,7 +92,7 @@ public:
   //
   // vtkSmartPointer<vtkXMLArchiveWriter> writer =
   //   vtkSmartPointer<vtkXMLArchiveWriter>::New();
-  // vtksys_ios::ostringstream ostr;
+  // std::ostringstream ostr;
   // writer->SetArchiveVersion(1);
   // std::vector<vtkSmartPointer<vtkObject> > objs;
   // objs.push_back(root);

--- a/smtk/bridge/discrete/kernel/Serialize/vtkXMLElement.cxx
+++ b/smtk/bridge/discrete/kernel/Serialize/vtkXMLElement.cxx
@@ -17,7 +17,7 @@ vtkStandardNewMacro(vtkXMLElement);
 
 #include <string>
 #include <vector>
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 # define SNPRINTF _snprintf
@@ -73,7 +73,7 @@ void vtkXMLElement::PrintSelf(ostream& os, vtkIndent indent)
 void vtkXMLElement::AddAttribute(const char* attrName,
                                    unsigned int attrValue)
 {
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   valueStr << attrValue << ends;
   this->AddAttribute(attrName, valueStr.str().c_str());
 }
@@ -81,7 +81,7 @@ void vtkXMLElement::AddAttribute(const char* attrName,
 //----------------------------------------------------------------------------
 void vtkXMLElement::AddAttribute(const char* attrName, int attrValue)
 {
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   valueStr << attrValue << ends;
   this->AddAttribute(attrName, valueStr.str().c_str());
 }
@@ -89,7 +89,7 @@ void vtkXMLElement::AddAttribute(const char* attrName, int attrValue)
 //----------------------------------------------------------------------------
 void vtkXMLElement::AddAttribute(const char* attrName, unsigned long attrValue)
 {
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   valueStr << attrValue << ends;
   this->AddAttribute(attrName, valueStr.str().c_str());
 }
@@ -98,7 +98,7 @@ void vtkXMLElement::AddAttribute(const char* attrName, unsigned long attrValue)
 //----------------------------------------------------------------------------
 void vtkXMLElement::AddAttribute(const char* attrName, vtkIdType attrValue)
 {
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   valueStr << attrValue << ends;
   this->AddAttribute(attrName, valueStr.str().c_str());
 }
@@ -107,7 +107,7 @@ void vtkXMLElement::AddAttribute(const char* attrName, vtkIdType attrValue)
 //----------------------------------------------------------------------------
 void vtkXMLElement::AddAttribute(const char* attrName, double attrValue)
 {
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   valueStr << attrValue << ends;
   this->AddAttribute(attrName, valueStr.str().c_str());
 }
@@ -135,7 +135,7 @@ void vtkXMLElement::AddAttribute(const char* attrName,
     return;
     }
 
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   for(unsigned int i=0; i<length; i++)
     {
     valueStr << vals[i];
@@ -156,7 +156,7 @@ void vtkXMLElement::AddAttribute(const char *attrName,
     return;
     }
 
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   for(unsigned int i=0; i<length; i++)
     {
     valueStr << vals[i] << " ";
@@ -175,7 +175,7 @@ void vtkXMLElement::AddAttribute(const char* attrName,
     return;
     }
 
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   for(unsigned int i=0; i<length; i++)
     {
     valueStr << vals[i] << " ";
@@ -195,7 +195,7 @@ void vtkXMLElement::AddAttribute(const char* attrName,
     return;
     }
 
-  vtksys_ios::ostringstream valueStr;
+  std::ostringstream valueStr;
   for(unsigned int i=0; i<length; i++)
     {
     valueStr << vals[i] << " ";
@@ -523,7 +523,7 @@ unsigned int vtkXMLVectorAttributeParse(const char* str,
                                            T* data)
 {
   if(!str || !length) { return 0; }
-  vtksys_ios::stringstream vstr;
+  std::stringstream vstr;
   vstr << str << ends;
   for(unsigned int i=0; i < length; ++i)
     {

--- a/smtk/bridge/discrete/kernel/vtkDiscreteModelWrapper.cxx
+++ b/smtk/bridge/discrete/kernel/vtkDiscreteModelWrapper.cxx
@@ -39,7 +39,7 @@
 #include "vtkStringArray.h"
 #include "vtkCompositeDataIterator.h"
 #include "vtkModelItemIterator.h"
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 vtkStandardNewMacro(vtkDiscreteModelWrapper);
 //vtkCxxSetObjectMacro(vtkDiscreteModelWrapper, Model, vtkDiscreteModel);
@@ -252,7 +252,7 @@ vtkStringArray* vtkDiscreteModelWrapper::SerializeModel()
     }
   vtkSmartPointer<vtkXMLModelWriter> serializer =
     vtkSmartPointer<vtkXMLModelWriter>::New();
-  vtksys_ios::ostringstream ostr;
+  std::ostringstream ostr;
   // Set to version to 1 (default is 0)
   serializer->SetArchiveVersion(1);
   // The archiver expects a vector of objects
@@ -306,7 +306,7 @@ int vtkDiscreteModelWrapper::RebuildModel(const char* data,
   this->Model->Reset();
 
   // Create an input stream to read the XML back
-  vtksys_ios::istringstream istr(data);
+  std::istringstream istr(data);
   vtkSmartPointer<vtkXMLModelReader> reader =
     vtkSmartPointer<vtkXMLModelReader>::New();
 

--- a/smtk/bridge/discrete/kernel/vtkXMLModelReader.cxx
+++ b/smtk/bridge/discrete/kernel/vtkXMLModelReader.cxx
@@ -42,7 +42,7 @@
 #include "vtkType.h"
 #
 #include <map>
-#include "vtksys/ios/sstream"
+#include <sstream>
 #include <vtksys/SystemTools.hxx>
 
 
@@ -375,7 +375,7 @@ vtkModelLoopUse* vtkXMLModelReader::ConstructModelLoopUse(int /*id*/)
   for(size_t i=0;i<associatedModelEdgeUses.size();i++)
     {
     // get edge use adjacencies
-    vtksys_ios::ostringstream idstr;
+    std::ostringstream idstr;
     idstr << associatedModelEdgeUses[i] << ends;
     vtkXMLElement* edgeUseElement =
       this->RootElement->FindNestedElement(idstr.str().c_str());
@@ -479,7 +479,7 @@ vtkModelRegion* vtkXMLModelReader::ConstructModelRegion(int id)
     this->Model->GetModelEntity(vtkModelMaterialType, associations[vtkModelMaterialType][0]));
 
   // get shell use adjacencies
-  vtksys_ios::ostringstream idstr;
+  std::ostringstream idstr;
   idstr << associations[vtkModelShellUseType][0] << ends;
   vtkXMLElement* shellElement = this->RootElement->FindNestedElement(idstr.str().c_str());
   std::vector<vtkIdType> shellFaceUses;
@@ -619,7 +619,7 @@ vtkModelEdgeUse* vtkXMLModelReader::ConstructModelEdgeUse(int id)
   for(size_t i=0;i<associations[vtkModelVertexUseType].size();i++)
     {
     // get vertex use adjacencies
-    vtksys_ios::ostringstream idstr;
+    std::ostringstream idstr;
     idstr << associations[vtkModelVertexUseType][i] << ends;
     vtkXMLElement* vertexUseElement =
       this->RootElement->FindNestedElement(idstr.str().c_str());

--- a/smtk/bridge/discrete/kernel/vtkXMLModelWriter.cxx
+++ b/smtk/bridge/discrete/kernel/vtkXMLModelWriter.cxx
@@ -27,7 +27,7 @@
 
 #include <list>
 #include <map>
-#include "vtksys/ios/sstream"
+#include <sstream>
 
 vtkStandardNewMacro(vtkXMLModelWriter);
 
@@ -303,7 +303,7 @@ void vtkXMLModelWriter::Serialize(const char* name,
   for(; iter != map.end(); iter++)
     {
     std::vector<vtkSmartPointer<vtkObject> >& objs = iter->second;
-    vtksys_ios::ostringstream str;
+    std::ostringstream str;
     str << "Key_" << iter->first;
     this->Serialize(str.str().c_str(), objs);
     }
@@ -340,7 +340,7 @@ vtkXMLElement* vtkXMLModelWriter::CreateDOM(const char* rootName,
   return this->RootElement;
 }
 
-void vtkXMLModelWriter::Serialize(vtksys_ios::ostringstream& ostr, const char* rootName,
+void vtkXMLModelWriter::Serialize(std::ostringstream& ostr, const char* rootName,
   std::vector<vtkSmartPointer<vtkObject> >& objs)
 {
   if(this->Internal)

--- a/smtk/bridge/discrete/kernel/vtkXMLModelWriter.h
+++ b/smtk/bridge/discrete/kernel/vtkXMLModelWriter.h
@@ -50,7 +50,7 @@
 
 
 #include <vector> // Vector of smart pointers
-#include <vtksys/ios/sstream>
+#include <sstream>
 #include "vtkSmartPointer.h" // Vector of smart pointers
 
 //BTX
@@ -90,13 +90,13 @@ public:
   //
   // vtkSmartPointer<vtkXMLModelWriter> writer =
   //   vtkSmartPointer<vtkXMLModelWriter>::New();
-  // vtksys_ios::ostringstream ostr;
+  // std::ostringstream ostr;
   // writer->SetArchiveVersion(1);
   // std::vector<vtkSmartPointer<vtkSerializableObject> > objs;
   // objs.push_back(shell);
   // writer->Serialize(ostr, "ConceptualModel", objs);
   // \endcode
-  virtual void Serialize(vtksys_ios::ostringstream& ostr, const char* rootName,
+  virtual void Serialize(std::ostringstream& ostr, const char* rootName,
     std::vector<vtkSmartPointer<vtkObject> >& objs);
 //ETX
 

--- a/smtk/bridge/discrete/legacycmb/CMBModel/Plugin/vtkCMBImportBCFileOperatorClient.cxx
+++ b/smtk/bridge/discrete/legacycmb/CMBModel/Plugin/vtkCMBImportBCFileOperatorClient.cxx
@@ -20,7 +20,7 @@
 #include "vtkSMProxyManager.h"
 #include "vtkSMStringVectorProperty.h"
 
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 vtkStandardNewMacro(vtkCMBImportBCFileOperatorClient);
 

--- a/smtk/bridge/discrete/legacycmb/CMBModel/Plugin/vtkCMBModelBuilder2DClient.cxx
+++ b/smtk/bridge/discrete/legacycmb/CMBModel/Plugin/vtkCMBModelBuilder2DClient.cxx
@@ -22,7 +22,7 @@
 #include "vtkSMSession.h"
 #include "vtkSMStringVectorProperty.h"
 
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 vtkStandardNewMacro(vtkCMBModelBuilder2DClient);
 
@@ -116,7 +116,7 @@ bool vtkCMBModelBuilder2DClient::UpdateClientModel(vtkDiscreteModel* ClientModel
   const char* data = SerializedModel->GetElement(0);
 
   // Create an input stream to read the XML back
-  vtksys_ios::istringstream istr(data);
+  std::istringstream istr(data);
   vtkSmartPointer<vtkXMLModelReader> reader =
     vtkSmartPointer<vtkXMLModelReader>::New();
   ClientModel->Reset();

--- a/smtk/bridge/discrete/legacycmb/CMBModel/Plugin/vtkCMBModelBuilderClient.cxx
+++ b/smtk/bridge/discrete/legacycmb/CMBModel/Plugin/vtkCMBModelBuilderClient.cxx
@@ -20,7 +20,7 @@
 #include "vtkSMProxyManager.h"
 #include "vtkSMStringVectorProperty.h"
 
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 vtkStandardNewMacro(vtkCMBModelBuilderClient);
 
@@ -105,7 +105,7 @@ bool vtkCMBModelBuilderClient::UpdateClientModel(vtkDiscreteModel* ClientModel,
   const char* data = SerializedModel->GetElement(0);
 
   // Create an input stream to read the XML back
-  vtksys_ios::istringstream istr(data);
+  std::istringstream istr(data);
   vtkSmartPointer<vtkXMLModelReader> reader =
     vtkSmartPointer<vtkXMLModelReader>::New();
   ClientModel->Reset();

--- a/smtk/bridge/discrete/legacycmb/CMBModel/Plugin/vtkGeoTransformOperatorClient.cxx
+++ b/smtk/bridge/discrete/legacycmb/CMBModel/Plugin/vtkGeoTransformOperatorClient.cxx
@@ -20,7 +20,7 @@
 #include "vtkSMProxyManager.h"
 #include "vtkSMStringVectorProperty.h"
 
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 vtkStandardNewMacro(vtkGeoTransformOperatorClient);
 

--- a/smtk/bridge/discrete/legacycmb/SimBuilderMesh/vtkCMBMeshGridRepresentationClient.cxx
+++ b/smtk/bridge/discrete/legacycmb/SimBuilderMesh/vtkCMBMeshGridRepresentationClient.cxx
@@ -22,7 +22,7 @@
 #include "vtkSMStringVectorProperty.h"
 #include "vtkSMPropertyHelper.h"
 
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 vtkStandardNewMacro(vtkCMBMeshGridRepresentationClient);
 vtkCxxSetObjectMacro(vtkCMBMeshGridRepresentationClient, MeshRepresentationSource, vtkSMProxy);

--- a/smtk/bridge/discrete/legacycmb/SimBuilderMesh/vtkCMBMeshWrapper.cxx
+++ b/smtk/bridge/discrete/legacycmb/SimBuilderMesh/vtkCMBMeshWrapper.cxx
@@ -15,7 +15,7 @@
 #include <vtkDiscreteModel.h>
 #include <vtkDiscreteModelWrapper.h>
 
-#include <vtksys/ios/sstream>
+#include <sstream>
 
 vtkStandardNewMacro(vtkCMBMeshWrapper);
 

--- a/smtk/bridge/discrete/operation/testing/cxx/DiscreteSerializationTest.cxx
+++ b/smtk/bridge/discrete/operation/testing/cxx/DiscreteSerializationTest.cxx
@@ -22,7 +22,7 @@
 #include "vtkModelShellUse.h"
 
 #include <vector>
-#include <vtksys/ios/sstream>
+#include <sstream>
 #include <fstream>
 
 // This tests the serialization of the CMB model but doesn't
@@ -37,7 +37,7 @@ int TestSerialization(vtkDiscreteModel* model)
   // Write it to an archive (a string stream)
   vtkSmartPointer<vtkXMLModelWriter> writer =
     vtkSmartPointer<vtkXMLModelWriter>::New();
-  vtksys_ios::ostringstream ostr;
+  std::ostringstream ostr;
   // Set to version to 1 (default is 0)
   writer->SetArchiveVersion(1);
   // The archiver expects a vector of objects
@@ -48,7 +48,7 @@ int TestSerialization(vtkDiscreteModel* model)
   writer->Serialize(ostr, "ConceptualModel", objs);
 
   // Create an input stream to read the XML back
-  vtksys_ios::istringstream istr(ostr.str());
+  std::istringstream istr(ostr.str());
 
   // Read using a vtkXMLModelReader
   vtkSmartPointer<vtkXMLModelReader> reader =
@@ -62,7 +62,7 @@ int TestSerialization(vtkDiscreteModel* model)
   // we got it right.
   objs.clear();
   objs.push_back(reader->GetModel());
-  vtksys_ios::ostringstream ostr2;
+  std::ostringstream ostr2;
   writer->Serialize(ostr2, "ConceptualModel", objs);
 
   if(strcmp(ostr2.str().c_str(), ostr.str().c_str()))


### PR DESCRIPTION
vtksys/kwsys has removed all stringstream classes, as all support versions
of the C++ standard library now include them.