### PR TITLE
Update mesh reader logic

### DIFF
--- a/CMake/SMTKTestingMacros.cmake
+++ b/CMake/SMTKTestingMacros.cmake
@@ -17,9 +17,15 @@ function(smtk_unit_tests)
     )
 
   set(have_testing_data OFF)
+  set(using_hdf OFF)
+  if(MOAB_USE_HDF)
+    set(using_hdf ON)
+  elseif(ENABLE_HDF5)
+    set(using_hdf ON)
+  endif()
   if (SMTK_DATA_DIR
       AND EXISTS ${SMTK_DATA_DIR}/ReadMe.mkd
-      AND MOAB_USE_HDF)
+      AND using_hdf)
     #we check moab for hdf support since that is the file format
     #for all our test data
     set(have_testing_data ON)

--- a/smtk/mesh/testing/python/extractTessellation.py
+++ b/smtk/mesh/testing/python/extractTessellation.py
@@ -24,6 +24,8 @@ def test_file_load():
     print 'data_dir', smtk.testing.DATA_DIR
     mesh_path = os.path.join(smtk.testing.DATA_DIR, 'mesh', 'sixth_hexflatcore.h5m')
     c = smtk.io.ImportMesh.entireFile(mesh_path,m)
+    if not c.isValid():
+        raise RuntimeError("Failed to read valid mesh")
     print c
     print c.numberOfMeshes()
 

--- a/smtk/mesh/testing/python/iterateMesh.py
+++ b/smtk/mesh/testing/python/iterateMesh.py
@@ -64,6 +64,8 @@ def test_file_load():
     print 'data_dir', smtk.testing.DATA_DIR
     mesh_path = os.path.join(smtk.testing.DATA_DIR, 'mesh', 'sixth_hexflatcore.h5m')
     c = smtk.io.ImportMesh.entireFile(mesh_path,m)
+    if not c.isValid():
+        raise RuntimeError("Failed to read valid mesh")
 
     #1. iterate meshes
     meshVisitor = MeshVisitor()

--- a/smtk/mesh/testing/python/simple.py
+++ b/smtk/mesh/testing/python/simple.py
@@ -24,6 +24,8 @@ def test_file_load():
     print 'data_dir', smtk.testing.DATA_DIR
     mesh_path = os.path.join(smtk.testing.DATA_DIR, 'mesh', 'sixth_hexflatcore.h5m')
     c = smtk.io.ImportMesh.entireFile(mesh_path,m)
+    if not c.isValid():
+        raise RuntimeError("Failed to read valid mesh")
     print c
     print c.numberOfMeshes()
 


### PR DESCRIPTION
Minor change to include mesh tests that load from file when ENABLE_HDF5 is set. Also updates python mesh tests to confirm that mesh was read in and is valid.

@robertmaynard please review