### PR TITLE
Add python bindings for attribute system methods to return all atts, defs

### DIFF
--- a/smtk/io/testing/python/CMakeLists.txt
+++ b/smtk/io/testing/python/CMakeLists.txt
@@ -27,6 +27,19 @@ if (SMTK_DATA_DIR AND EXISTS ${SMTK_DATA_DIR}/ReadMe.mkd)
     )
   endforeach()
 
+  set(reader_test attributeReaderTest)
+  add_test(${reader_test}Py
+    ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/${reader_test}.py
+    ${SMTK_DATA_DIR}/smtk/attribute/resourceTest/ShallowWater2D.sbi
+    29
+    19
+  )
+  set_tests_properties(${reader_test}Py
+    PROPERTIES
+      ENVIRONMENT "PYTHONPATH=${VTKPY_DIR}${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
+  )
+
   set(reader_test ResourceSetReaderTest)
   add_test(${reader_test}Py
     ${PYTHON_EXECUTABLE}

--- a/smtk/io/testing/python/attributeReaderTest.py
+++ b/smtk/io/testing/python/attributeReaderTest.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python
+import sys
+#=============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+#=============================================================================
+import smtk
+from smtk.simple import *
+
+class TestAttributeReader():
+    """A test for AttributeReader"""
+
+    def setUp(self):
+        if len(sys.argv) < 2:
+            print "Reads attribute system file"
+            print "Usage: AttributeReaderTest attribute_file"
+            print "  [expect_number_of_definitions]"
+            print "  [expect_number_of_attributes]"
+            return 1
+
+        self.status = 0  # return value
+
+        self.attsys = smtk.attribute.System()
+        self.reader = smtk.io.AttributeReader()
+        self.logger = smtk.io.Logger()
+
+        input_path = sys.argv[1]
+
+        hasErrors = self.reader.read(self.attsys, input_path, self.logger)
+        if hasErrors:
+            print "Reader has errors"
+            print self.logger.convertToString()
+            self.status = self.status + 1
+
+
+    def testSimpleRead(self):
+        # Test definition count
+        if len(sys.argv) <= 2:
+            return 1
+
+        expectedDefinitionCount = 0
+        convert = sys.argv[2]
+
+        try:
+            expectedDefinitionCount = int(convert)
+        except:
+            self.status = self.status + 1
+        finally:
+            if expectedDefinitionCount < 0:
+                print "ERROR: argv[2] not an unsigned integer"
+                self.status = self.status + 1
+            else:
+                definitionList = self.attsys.definitions()
+                if len(definitionList) != expectedDefinitionCount:
+                    print "ERROR: Expecting ", expectedDefinitionCount, \
+                    " definitions, loaded ", len(definitionList)
+                    self.status = self.status + 1
+                else:
+                    print "Number of definitions loaded:", len(definitionList)
+                    #for i,defn in enumerate(definitionList):
+                    #    print i, defn.type(), defn.isAbstract()
+
+        # Test attribute count
+        if len(sys.argv) <= 3:
+            return self.status
+
+        expectedAttributeCount = 0
+        convert = sys.argv[3]
+
+        try:
+            expectedAttributeCount = int(convert)
+        except:
+            self.status = self.status + 1
+        finally:
+            if expectedAttributeCount < 0:
+                print "ERROR: argv[2] not an unsigned integer"
+                self.status = self.status + 1
+            else:
+                attributeList = self.attsys.attributes()
+                if len(attributeList) != expectedAttributeCount:
+                    print "ERROR: Expecting ", expectedAttributeCount, \
+                    " attributes, loaded ", len(attributeList)
+                    self.status = self.status + 1
+                else:
+                    print "Number of attributes loaded:", len(attributeList)
+                    #for i,att in enumerate(attributeList):
+                    #    print i, att.name()
+
+        return self.status
+
+
+if __name__ == '__main__':
+    t = TestAttributeReader()
+    t.setUp()
+    sys.exit(t.testSimpleRead())

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -1857,6 +1857,34 @@
           </inject-code>
         </modify-function>
 
+        <modify-function signature="definitions(std::vector&lt; smtk::shared_ptr&lt; smtk::attribute::Definition &gt; &gt;&amp;) const">
+          <modify-argument index="1">
+            <remove-argument />
+          </modify-argument>
+          <modify-argument index="return">
+            <replace-type modified-type="std::vector&lt; smtk::shared_ptr&lt; smtk::attribute::Definition &gt; &gt;" />
+          </modify-argument>
+          <inject-code class="target" position="beginning">
+            std::vector&lt; smtk::shared_ptr&lt; smtk::attribute::Definition &gt; &gt; _out;
+            %CPPSELF->definitions(_out);
+            %PYARG_0 = %CONVERTTOPYTHON[std::vector&lt; smtk::shared_ptr&lt; smtk::attribute::Definition &gt; &gt;](_out);
+          </inject-code>
+        </modify-function>
+
+        <modify-function signature="attributes(std::vector&lt; smtk::shared_ptr&lt; smtk::attribute::Attribute &gt; &gt;&amp;) const">
+          <modify-argument index="1">
+            <remove-argument />
+          </modify-argument>
+          <modify-argument index="return">
+            <replace-type modified-type="std::vector&lt; smtk::shared_ptr&lt; smtk::attribute::Attribute &gt; &gt;" />
+          </modify-argument>
+          <inject-code class="target" position="beginning">
+            std::vector&lt; smtk::shared_ptr&lt; smtk::attribute::Attribute &gt; &gt; _out;
+            %CPPSELF->attributes(_out);
+            %PYARG_0 = %CONVERTTOPYTHON[std::vector&lt; smtk::shared_ptr&lt; smtk::attribute::Attribute &gt; &gt;](_out);
+          </inject-code>
+        </modify-function>
+
         <add-function signature="CastTo(smtk::shared_ptr&lt;smtk::common::Resource &gt; &amp;)"
           static="yes"
           return-type="smtk::shared_ptr&lt;smtk::attribute::System &gt;">


### PR DESCRIPTION
This PR adds python bindings for the smtk::attribute::System::attributes() and smtk::attribute::System::definitions() methods. Although these 2 methods are not generally required for most applications, they provide a convenient way to traverse an attribute manager for demo/example purposes.
