### PR TITLE
Submit to a valid CDash URL.

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -9,5 +9,5 @@ set(CTEST_NIGHTLY_START_TIME "21:00:00 EDT")
 
 set(CTEST_DROP_METHOD "http")
 set(CTEST_DROP_SITE "open.cdash.org")
-set(CTEST_DROP_LOCATION "/CDash/submit.php?project=SMTK")
+set(CTEST_DROP_LOCATION "/submit.php?project=SMTK")
 set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
Apparently `open.cdash.org` does not use the same URL scheme ans the old drop site.