### PR TITLE
Polygon modeling session.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ option(SMTK_ENABLE_PARAVIEW_SUPPORT "Build paraview plugins for model sessions" 
 
 option(SMTK_ENABLE_CGM_SESSION "Build CGM component" OFF)
 option(SMTK_ENABLE_DISCRETE_SESSION "Build discrete model session components" OFF)
+option(SMTK_ENABLE_POLYGON_SESSION "Build Boost.polygon model session." ON)
 if (SMTK_ENABLE_VTK_SUPPORT)
   option(SMTK_ENABLE_EXODUS_SESSION "Build a session to Exodus-II side sets" ON)
 endif()

--- a/doc/userguide/model/index.rst
+++ b/doc/userguide/model/index.rst
@@ -15,3 +15,7 @@ that may each interact with different solid modeling kernels.
    sessions.rst
    property-names.rst
    user-interface.rst
+   session-cgm.rst
+   session-discrete.rst
+   session-exodus.rst
+   session-polygon.rst

--- a/doc/userguide/model/session-cgm.rst
+++ b/doc/userguide/model/session-cgm.rst
@@ -1,0 +1,15 @@
+Session: CGM
+------------
+
+SMTK has a *CGM* session type that bridges the `Common Geometry Model (CGM) <CGM>`_ meta-modeling kernel.
+Depending on how your CGM library is compiled, it provides access to the ACIS and/or OpenCascade CAD kernels,
+which are parametric modeling kernels that provide a full boundary-representation topology.
+
+CGM also includes a discrete modeling kernel of its own focused on 3-dimensional polyhedral solid models.
+While multiple CAD kernels may be used in the same CGM session, this is not the usual case.
+
+.. todo:: The CGM session provides 2 "static" settings controlling the accuracy of model entity tessellations.
+.. todo:: Starting CGM with a different Engine
+.. todo:: CGM engines and file types
+
+.. _CGM: http://sigma.mcs.anl.gov/cgm-library/

--- a/doc/userguide/model/session-discrete.rst
+++ b/doc/userguide/model/session-discrete.rst
@@ -1,0 +1,11 @@
+Session: Discrete
+-----------------
+
+SMTK has a session type named *discrete* that bridges a VTK-based discrete modeling kernel.
+This kernel provides access to 2-D and 3-D polygonal and polyhedral models,
+with operators that allow model edges and faces to be split or merged.
+
+Models need not include a full topology (e.g., only volumes and faces may be represented,
+with edges implied; or geometric entities may be modeled but not all of their oriented use-records).
+However, several operations such as "*create edges"* exist to generate a full topology from
+a self-consistent but incomplete model.

--- a/doc/userguide/model/session-exodus.rst
+++ b/doc/userguide/model/session-exodus.rst
@@ -1,0 +1,14 @@
+Session: Exodus
+---------------
+
+SMTK has a session type named *exodus* that is not technically a modeling kernel
+but does allow you to mark up meshes saved in the Exodus-II_ file format for use
+in an existing simulation — assuming that element blocks and side sets that
+segregate the model into one or more regions per material and one or more
+groups per boundary-condition are already present in the exodus mesh.
+
+.. todo:: Describe what blocks and sets are
+.. todo:: Describe how blocks and sets are mapped to models and groups
+.. todo:: Show simple example?
+
+.. _Exodus-II: http://exodusii.sf.net/

--- a/doc/userguide/model/session-polygon.rst
+++ b/doc/userguide/model/session-polygon.rst
@@ -1,0 +1,63 @@
+Session: Polygon
+----------------
+
+SMTK has a session type named *polygon* that bridges Boost.polygon_'s modeling kernel.
+This kernel provides access to 2-D polygonal models,
+with operators that allow model edges and faces to be split or merged
+as well as boolean operations and Voronoi diagram computation.
+
+Boost's polygonal modeler uses integer arithmetic to achieve high performance
+with robust geometric predicates.
+SMTK converts 3-D floating-point coordinates into 2-D integer coordinates for you,
+but you must provide several pieces of information for each model instance:
+
+* A base point for the plane holding the polygon
+* Either x- and y-axis vectors (in 3-D world coordinates) describing the planar
+  coordinate system you wish to use, or an x-axis and the plane's normal vector.
+* Either a minimum feature size (in world coordinates) that your model should
+  represent or an integer model scaling factor that each world coordinate is
+  multiplied by before rounding to an integer.
+
+This session does not allow model edges to have more than 2 model vertices.
+A model edge may have zero or one vertices when the edge is a periodic loop denoted
+with identical first and last points; in this case, the first and last
+point must also be the model vertex.
+A model edge must have two model vertices when it is not periodic, one at each
+end of the edge.
+Model edges may have any number of interior points that are not model vertices.
+These restrictions are imposed so that it is possible to quickly determine what
+model face lies adjacent to each model vertex.
+If model edges could have interior vertices,
+the assumption that each edge may border at most 2 faces
+would be much more difficult to enforce and validate.
+
+This decision regarding model vertices and edges has further implications.
+Edges may not have any self-intersections other than at points where segments meet.
+When edges are joined into loops to form a face,
+they are intersected with one another first;
+if any intersections are found, then the model edges are split when
+the face is created.
+
+Note that SMTK is slightly more restrictive (in that it splits edges and
+creates model vertices) than Boost requires because Boost does not model
+edges at all; instead it models polygons as sequences of points –
+optionally with a list of holes which are themselves polygons.
+In Boost's modeler, points are not shared between faces;
+each face is a model in its own right.
+Because of this, it is simple for Boost to use *keyholed edges* to
+represent holes in faces.
+Keyholed edges are edges coincident along a portion of their length
+and effectively split a face with holes into a face with no holes but
+with infinitesimal slivers connecting the region outside the face to
+each hole.
+SMTK can accept keyholed edges but they must be broken into multiple
+model edges at intersections so that SMTK's assumption that planar edges
+border at most 2 different surface regions.
+
+Meshing Boost.polygon models
+============================
+
+Boost polygonal models are conforming piecewise-linear cell complexes (PLCs), and
+may thus be meshed by any SMTK mesh worker that accepts models in this form.
+
+.. _Boost.polygon: http://www.boost.org/doc/libs/1_59_0/libs/polygon/doc/index.htm

--- a/smtk/PublicPointerDefs.h
+++ b/smtk/PublicPointerDefs.h
@@ -141,6 +141,7 @@ namespace smtk
     typedef std::vector<smtk::model::UseEntity> UseEntities;
     class Vertex;
     typedef std::vector<smtk::model::Vertex> Vertices;
+    typedef std::set<smtk::model::Vertex> VertexSet;
     class VertexUse;
     typedef std::vector<smtk::model::VertexUse> VertexUses;
     class Volume;
@@ -176,6 +177,7 @@ namespace smtk
     class ExportJSON;
     class ImportJSON;
     class OperatorLog;
+    class Logger;
   }
 
   namespace common

--- a/smtk/attribute/ModelEntityItem.cxx
+++ b/smtk/attribute/ModelEntityItem.cxx
@@ -146,8 +146,7 @@ bool ModelEntityItem::appendValue(const smtk::model::EntityRef& val)
     {
     if (!this->isSet(i))
       {
-      this->setValue(i, val);
-      return true;
+      return this->setValue(i, val);
       }
     }
   // Second - are we allowed to change the number of values?

--- a/smtk/bridge/CMakeLists.txt
+++ b/smtk/bridge/CMakeLists.txt
@@ -13,6 +13,17 @@ if(SMTK_ENABLE_DISCRETE_SESSION)
 endif()
 
 ################################################################################
+# Build Boost.Polygon session
+################################################################################
+if (SMTK_ENABLE_POLYGON_SESSION)
+  if (${Boost_MAJOR_VERSION} LESS 2 AND ${Boost_MINOR_VERSION} LESS 52)
+    message(FATAL_ERROR
+      "Polygon session requires Boost 1.52 or newer, found ${Boost_VERSION}")
+  endif()
+  add_subdirectory(polygon)
+endif()
+
+################################################################################
 # Build Exodus-II session
 ################################################################################
 if (SMTK_ENABLE_EXODUS_SESSION)

--- a/smtk/bridge/exodus/testing/python/exoReadFile.py
+++ b/smtk/bridge/exodus/testing/python/exoReadFile.py
@@ -94,7 +94,7 @@ class TestExodusSession(smtk.testing.TestCase):
                 grp.setTessellation(smtk.model.Tessellation())
 
         self.startRenderTest()
-        mbs = self.addModelToScene(self.model)
+        mbs, filt, mapper, actor = self.addModelToScene(self.model)
 
         self.renderer.SetBackground(1,1,1)
         cam = self.renderer.GetActiveCamera()

--- a/smtk/bridge/polygon/CMakeLists.txt
+++ b/smtk/bridge/polygon/CMakeLists.txt
@@ -1,0 +1,85 @@
+set(polygonSrcs
+  Session.cxx
+  Operator.cxx
+  internal/Model.cxx
+  internal/Vertex.cxx
+  operators/CreateModel.cxx
+  operators/CreateVertices.cxx
+  operators/CreateEdge.cxx
+  operators/CreateFaces.cxx
+  operators/SplitEdge.cxx
+)
+
+set(polygonHeaders
+  Session.h
+  Operator.h
+  internal/Model.h
+  operators/CreateModel.h
+  operators/CreateVertices.h
+  operators/CreateEdge.h
+  operators/CreateFaces.h
+  operators/SplitEdge.h
+)
+
+smtk_session_json("${CMAKE_CURRENT_SOURCE_DIR}/Session.json" polygonSessionJSON)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/CreateModel.sbt" polygonOperatorXML)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/CreateVertices.sbt" polygonOperatorXML)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/CreateEdge.sbt" polygonOperatorXML)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/CreateFaces.sbt" polygonOperatorXML)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/operators/SplitEdge.sbt" polygonOperatorXML)
+
+add_library(smtkPolygonSession ${polygonSrcs})
+target_link_libraries(smtkPolygonSession
+  LINK_PUBLIC
+    smtkCore
+  )
+smtk_export_header(smtkPolygonSession Exports.h)
+
+# On Mac OS X, set the directory included as part of the installed library's path:
+if (BUILD_SHARED_LIBS)
+  set_target_properties(smtkPolygonSession PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
+
+# Install the library and exports the library when used from a build tree
+smtk_install_library(smtkPolygonSession)
+# Install the headers
+smtk_public_headers(${polygonHeaders})
+
+
+install(FILES PointerDefs.h DESTINATION include/smtk/${SMTK_VERSION}/smtk/bridge/polygon)
+target_include_directories(smtkPolygonSession
+  PUBLIC
+    $<BUILD_INTERFACE:${SMTK_SOURCE_DIR}/smtk/bridge/discrete/extension/meshing>
+)
+
+if(SMTK_ENABLE_PYTHON_WRAPPING AND Shiboken_FOUND)
+
+  # Extract the headers from polygon library we built to give them to shiboken
+  sbk_wrap_library(smtkPolygonSession
+    GENERATOR_ARGS --avoid-protected-hack
+    WORKING_DIRECTORY ${SMTK_SOURCE_DIR}/smtk
+    LOCAL_INCLUDE_DIRECTORIES
+      ${SMTK_SOURCE_DIR}/smtk/common
+      ${SMTK_SOURCE_DIR}/smtk/attribute
+      ${SMTK_SOURCE_DIR}/smtk/model
+      ${SMTK_SOURCE_DIR}/smtk/session
+      ${SMTK_SOURCE_DIR}/smtk/bridge/polygon
+      ${SMTK_SOURCE_DIR}/smtk/simulation
+      ${SMTK_SOURCE_DIR}/smtk/io
+      ${SMTK_SOURCE_DIR}/smtk/view
+      ${SMTK_SOURCE_DIR}/smtk
+      ${SMTK_BINARY_DIR}/smtk
+      ${CMAKE_CURRENT_BINARY_DIR}
+    TYPESYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/typesystem.xml
+    HEADERS ${polygonHeaders}
+    DEPENDS smtkCore
+  )
+endif()
+
+if(SMTK_ENABLE_PARAVIEW_SUPPORT)
+  add_subdirectory(plugin)
+endif()
+
+if (SMTK_ENABLE_TESTING)
+  add_subdirectory(testing)
+endif()

--- a/smtk/bridge/polygon/Operator.cxx
+++ b/smtk/bridge/polygon/Operator.cxx
@@ -1,0 +1,37 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/bridge/polygon/Operator.h"
+#include "smtk/bridge/polygon/Session.h"
+
+#include "smtk/model/EntityRef.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+/// Return a shared pointer to the session backing a polygon operator.
+Session* Operator::polygonSession()
+{
+  return dynamic_cast<smtk::bridge::polygon::Session*>(this->session());
+}
+
+/*
+/// A helper to return the polygon entity associated with \a smtkEntity.
+internal::Entity* Operator::polygonEntity(const smtk::model::EntityRef& smtkEntity)
+{
+  ToolDataUser* tdu = TDUUID::findEntityById(smtkEntity.entity());
+  RefEntity* ent = dynamic_cast<RefEntity*>(tdu);
+  return ent;
+}
+*/
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk

--- a/smtk/bridge/polygon/Operator.h
+++ b/smtk/bridge/polygon/Operator.h
@@ -1,0 +1,55 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#ifndef __smtk_session_polygon_Operator_h
+#define __smtk_session_polygon_Operator_h
+
+#include "smtk/bridge/polygon/Exports.h"
+
+#include "smtk/model/Operator.h"
+#include "smtk/model/Manager.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+class Session;
+
+/**\brief An operator using the polygon kernel.
+  *
+  * This is a base class for actual polygon operators.
+  * It provides convenience methods for accessing polygon-specific data
+  * for its subclasses to use internally.
+  */
+class SMTKPOLYGONSESSION_EXPORT Operator : public smtk::model::Operator
+{
+protected:
+  Session* polygonSession();
+  /*
+  internal::Entity* polygonEntity(const smtk::model::EntityRef& smtkEntity);
+
+  template<typename T>
+  T polygonEntityAs(const smtk::model::EntityRef& smtkEntity);
+  */
+};
+
+/*
+/// A convenience method for returning the polygon counterpart of an SMTK entity already cast to a subtype.
+template<typename T>
+T Operator::polygonEntityAs(const smtk::model::EntityRef& smtkEntity)
+{
+  return dynamic_cast<T>(this->polygonEntity(smtkEntity));
+}
+*/
+
+    } // namespace polygon
+  } // namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_polygon_Operator_h

--- a/smtk/bridge/polygon/PointerDefs.h
+++ b/smtk/bridge/polygon/PointerDefs.h
@@ -1,0 +1,27 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_session_polygon_PointerDefs_h
+#define __smtk_session_polygon_PointerDefs_h
+
+#include "smtk/SharedPtr.h"
+#include "smtk/SystemConfig.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+class Session;
+typedef smtk::shared_ptr< smtk::bridge::polygon::Session > SessionPtr;
+
+    } // namespace polygon
+  } // namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_polygon_PointerDefs_h

--- a/smtk/bridge/polygon/Session.cxx
+++ b/smtk/bridge/polygon/Session.cxx
@@ -1,0 +1,100 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/bridge/polygon/Session.h"
+
+#include "smtk/AutoInit.h"
+
+#include "smtk/model/EntityRef.h"
+#include "smtk/model/SessionRef.h"
+#include "smtk/model/Model.h"
+#include "smtk/model/Group.h"
+#include "smtk/model/VolumeUse.h"
+#include "smtk/model/FaceUse.h"
+#include "smtk/model/EdgeUse.h"
+#include "smtk/model/VertexUse.h"
+#include "smtk/model/Volume.h"
+#include "smtk/model/Face.h"
+#include "smtk/model/Edge.h"
+#include "smtk/model/Vertex.h"
+#include "smtk/model/Manager.h"
+#include "smtk/model/Shell.h"
+#include "smtk/model/Chain.h"
+#include "smtk/model/Loop.h"
+
+#include "smtk/common/UUID.h"
+
+#include "smtk/Options.h"
+#include "smtk/AutoInit.h"
+
+#include "smtk/bridge/polygon/internal/Model.h"
+
+#include <string.h> // for strcmp
+
+using smtk::model::EntityRef;
+using namespace smtk::common;
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+/// Default constructor.
+Session::Session()
+{
+  this->initializeOperatorSystem(Session::s_operators);
+}
+
+/// Virtual destructor. Here because Session overrides virtual methods from Session.
+Session::~Session()
+{
+}
+
+/// The polygon session supports smtk::model::SESSION_EVERYTHING.
+smtk::model::SessionInfoBits Session::allSupportedInformation() const
+{
+  return smtk::model::SESSION_EVERYTHING;
+}
+
+smtk::model::SessionInfoBits Session::transcribeInternal(
+  const smtk::model::EntityRef& entity,
+  smtk::model::SessionInfoBits requestedInfo,
+  int depth)
+{
+  (void)entity;
+  (void)requestedInfo;
+  (void)depth;
+  return smtk::model::SESSION_EVERYTHING;
+}
+
+void Session::addStorage(
+  const smtk::common::UUID& uid,
+  smtk::bridge::polygon::internal::entity::Ptr s)
+{
+  this->m_storage[uid] = s;
+}
+
+bool Session::removeStorage(const smtk::common::UUID& uid)
+{
+  return this->m_storage.erase(uid) > 0;
+}
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+#include "smtk/bridge/polygon/Session_json.h" // For Session_json
+smtkImplementsModelingKernel(
+  SMTKPOLYGONSESSION_EXPORT,
+  polygon,
+  Session_json,
+  smtk::model::SessionHasNoStaticSetup,
+  smtk::bridge::polygon::Session,
+  true /* inherit "universal" operators */
+);
+smtkComponentInitMacro(smtk_polygon_create_model_operator);

--- a/smtk/bridge/polygon/Session.h
+++ b/smtk/bridge/polygon/Session.h
@@ -1,0 +1,105 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#ifndef __smtk_session_polygon_Session_h
+#define __smtk_session_polygon_Session_h
+
+#include "smtk/bridge/polygon/Exports.h"
+#include "smtk/bridge/polygon/PointerDefs.h"
+#include "smtk/bridge/polygon/internal/Entity.h"
+
+#include "smtk/model/Session.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+      namespace internal {
+        class pmodel;
+        class vertex;
+      }
+
+/**\brief Methods that handle translation between polygon and SMTK instances.
+  *
+  * While the TDUUID class keeps a map from SMTK UUIDs to polygon ToolDataUser
+  * pointers, this is not enough to handle everything SMTK provides:
+  * there is no way to track cell-use or shell entities since they do
+  * not inherit ToolDataUser instances. Also, some engines (e.g., facet)
+  * do not appear to store some entity types (e.g., RefGroup).
+  *
+  * Also, simply loading a polygon file does not translate the entire model
+  * into SMTK; instead, it assigns UUIDs to entities if they do not already
+  * exist. This class (Session) provides a method for requesting the
+  * entity, arrangement, and/or tessellation information for a UUID be
+  * mapped into SMTK from polygon.
+  */
+class SMTKPOLYGONSESSION_EXPORT Session : public smtk::model::Session
+{
+public:
+  smtkTypeMacro(Session);
+  smtkSuperclassMacro(smtk::model::Session);
+  smtkSharedFromThisMacro(smtk::model::Session);
+  smtkCreateMacro(smtk::model::Session);
+  smtkDeclareModelingKernel();
+  typedef smtk::model::SessionInfoBits SessionInfoBits;
+  virtual ~Session();
+
+  virtual SessionInfoBits allSupportedInformation() const;
+
+protected:
+  friend class Operator;
+  friend class CreateModel;
+  friend class CreateVertices;
+  friend class CreateEdge;
+  friend class SplitEdge;
+  friend class internal::pmodel;
+
+  Session();
+
+  virtual smtk::model::SessionInfoBits transcribeInternal(
+    const smtk::model::EntityRef& entity, SessionInfoBits requestedInfo, int depth = -1);
+
+  void addStorage(const smtk::common::UUID& uid, smtk::bridge::polygon::internal::entity::Ptr storage);
+  bool removeStorage(const smtk::common::UUID& uid);
+
+  template<typename T>
+  typename T::Ptr findStorage(const smtk::common::UUID& uid)
+    {
+    internal::EntityIdToPtr::iterator it = this->m_storage.find(uid);
+    if (it != this->m_storage.end())
+      return smtk::dynamic_pointer_cast<T>(it->second);
+    static typename T::Ptr blank;
+    return blank;
+    }
+
+  template<typename T>
+  T findOrAddStorage(const smtk::common::UUID& uid)
+    {
+    internal::EntityIdToPtr::iterator it = this->m_storage.find(uid);
+    if (it != this->m_storage.end())
+      return smtk::dynamic_pointer_cast<T>(it->second);
+
+    T blank = T::create();
+    it = this->m_storage.insert(
+      internal::EntityIdToPtr::value_type(
+        uid,smtk::dynamic_pointer_cast<internal::entity>(blank))).first;
+    return smtk::dynamic_pointer_cast<T>(it->second);
+    }
+
+  internal::EntityIdToPtr m_storage;
+
+private:
+  Session(const Session&); // Not implemented.
+  void operator = (const Session&); // Not implemented.
+};
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_polygon_Session_h

--- a/smtk/bridge/polygon/Session.json
+++ b/smtk/bridge/polygon/Session.json
@@ -1,0 +1,12 @@
+{
+  "kernel": "polygon",
+  "engines": [
+    {
+      "name": "native",
+      "filetypes": [
+        ".poly (Triangle polygon file)",
+        ".smesh (Surface mesh)"
+      ]
+    }
+  ]
+}

--- a/smtk/bridge/polygon/internal/Config.h
+++ b/smtk/bridge/polygon/internal/Config.h
@@ -1,0 +1,55 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_bridge_polygon_internal_bpConfig_h
+#define __smtk_bridge_polygon_internal_bpConfig_h
+#ifndef SHIBOKEN_SKIP
+
+#include "smtk/SharedPtr.h"
+#include "smtk/common/UUID.h"
+
+#include "boost/polygon/polygon.hpp"
+
+#include <list>
+#include <map>
+#include <set>
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+      namespace internal {
+
+        class entity;
+        class vertex;
+        class edge;
+        class face;
+        class pmodel;
+
+        typedef smtk::shared_ptr<entity> EntityPtr;
+        typedef smtk::shared_ptr<vertex> VertexPtr;
+        typedef smtk::shared_ptr<edge> EdgePtr;
+        typedef smtk::shared_ptr<face> FacePtr;
+
+        typedef long long Coord;
+        typedef smtk::common::UUID Id;
+        typedef boost::polygon::point_data<Coord> Point;
+        typedef boost::polygon::segment_data<Coord> Segment;
+        typedef boost::polygon::interval_data<Coord> Interval;
+        typedef std::map<Point,Id> PointToVertexId;
+        typedef std::map<Id,EntityPtr> EntityIdToPtr;
+        typedef std::list<Point> PointSeq;
+        typedef std::map<Point,VertexPtr> VertexById;
+
+      } // namespace internal
+    } // namespace polygon
+  } // namespace bridge
+} // namespace smtk
+
+#endif // SHIBOKEN_SKIP
+#endif // __smtk_bridge_polygon_internal_bpConfig_h

--- a/smtk/bridge/polygon/internal/Edge.h
+++ b/smtk/bridge/polygon/internal/Edge.h
@@ -1,0 +1,58 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_bridge_polygon_internal_edge_h
+#define __smtk_bridge_polygon_internal_edge_h
+
+#include "smtk/bridge/polygon/internal/Entity.h"
+#include "smtk/SharedPtr.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+      namespace internal {
+
+class pmodel;
+
+class edge : public entity
+{
+public:
+  smtkTypeMacro(edge);
+  smtkCreateMacro(edge);
+  smtkSharedFromThisMacro(entity);
+  virtual ~edge() { }
+
+  std::size_t pointsSize() const { return this->m_points.size(); }
+
+  PointSeq::const_iterator pointsBegin() const { return this->m_points.begin(); }
+  PointSeq::iterator pointsBegin() { return this->m_points.begin(); }
+
+  PointSeq::const_iterator pointsEnd() const { return this->m_points.end(); }
+  PointSeq::iterator pointsEnd() { return this->m_points.end(); }
+
+  PointSeq::const_reverse_iterator pointsRBegin() const { return this->m_points.rbegin(); }
+  PointSeq::reverse_iterator pointsRBegin() { return this->m_points.rbegin(); }
+
+  PointSeq::const_reverse_iterator pointsREnd() const { return this->m_points.rend(); }
+  PointSeq::reverse_iterator pointsREnd() { return this->m_points.rend(); }
+
+protected:
+  edge() { }
+
+  friend class pmodel;
+
+  PointSeq m_points;
+};
+
+      } // namespace internal
+    } // namespace polygon
+  }  // namespace bridge
+} // namespace smtk
+
+#endif // __smtk_bridge_polygon_internal_edge_h

--- a/smtk/bridge/polygon/internal/Entity.h
+++ b/smtk/bridge/polygon/internal/Entity.h
@@ -1,0 +1,64 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_bridge_polygon_internal_Entity_h
+#define __smtk_bridge_polygon_internal_Entity_h
+
+#include "smtk/SharedFromThis.h"
+#include "smtk/bridge/polygon/PointerDefs.h"
+#include "smtk/bridge/polygon/internal/Config.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+      namespace internal {
+
+/**\brief A base class for all internal entity storage.
+  *
+  * Every entity stores a pointer to its parent and its UUID.
+  * This class uses smtkEnableSharedPtr so that all entities may be
+  * managed via one pool of shared pointers.
+  */
+class entity : smtkEnableSharedPtr(entity)
+{
+public:
+  smtkTypeMacro(entity);
+
+  Id id() const { return this->m_id; }
+  void setId(const Id& i) { this->m_id = i; }
+
+  entity* parent() const { return this->m_parent; }
+  void setParent(entity* p) { this->m_parent = p; }
+
+  template<typename T>
+  T* parentAs() const { return dynamic_cast<T*>(this->m_parent); }
+
+protected:
+  entity()
+    : m_parent(NULL)
+    { }
+  entity(const Id& uid, entity* p)
+    : m_id(uid), m_parent(p)
+    { }
+  virtual ~entity()
+    {
+    this->m_parent = NULL;
+    }
+
+  entity* m_parent;
+  Id m_id;
+};
+
+      } // namespace internal
+    } // namespace polygon
+  }  // namespace bridge
+} // namespace smtk
+
+#endif // __smtk_bridge_polygon_internal_Entity_h
+

--- a/smtk/bridge/polygon/internal/Model.cxx
+++ b/smtk/bridge/polygon/internal/Model.cxx
@@ -1,0 +1,474 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#include "smtk/bridge/polygon/internal/Model.h"
+#include "smtk/bridge/polygon/internal/Edge.h"
+
+#include "smtk/model/Session.h"
+#include "smtk/model/Manager.h"
+#include "smtk/model/Model.h"
+#include "smtk/model/Vertex.h"
+#include "smtk/model/Tessellation.h"
+#include "smtk/io/Logger.h"
+
+#include "smtk/bridge/polygon/internal/Model.txx"
+
+using namespace smtk::model;
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+      namespace internal {
+
+pmodel::pmodel()
+  : m_session(NULL), m_featureSize(1e-8)
+{
+  for (int i = 0; i < 3; ++i)
+    {
+    this->m_origin[i] = 0.; // Base point of plane for model
+    this->m_xAxis[i] = 0.; // Vector whose length should be equal to one "unit" (e.g., m_scale integers long)
+    this->m_yAxis[i] = 0.; // In-plane vector orthogonal to m_xAxis with the same length.
+    this->m_zAxis[i] = 0.; // Normal vector orthogonal to m_xAxis and m_yAxis with the same length.
+    this->m_iAxis[i] = 0.; // Vector whose length should be equal to one "unit" (e.g., 1 integer delta long)
+    this->m_jAxis[i] = 0.; // In-plane vector orthogonal to m_iAxis with the same length.
+    }
+  this->m_xAxis[0] = this->m_yAxis[1] = this->m_zAxis[2] = 1.;
+  this->m_iAxis[0] = this->m_jAxis[1] = 1.;
+}
+
+pmodel::~pmodel()
+{
+  // Tis better to have dereferenced and crashed than never to have crashed at all:
+  this->m_session = NULL;
+}
+
+bool pmodel::computeModelScaleAndNormal(
+  std::vector<double>& origin,
+  std::vector<double>& x_axis,
+  std::vector<double>& y_axis,
+  double featureSize,
+  smtk::io::Logger& log)
+{
+  if (featureSize <= 0.)
+    {
+    smtkErrorMacro(log,
+      "Feature size must be positive (not " << featureSize << ").");
+    return false;
+    }
+  this->m_featureSize = featureSize;
+
+  if (origin.size() != 3 || x_axis.size() != 3 || y_axis.size() != 3)
+    {
+    smtkErrorMacro(log,
+      "Vector of length 3 expected for"
+      << " origin (" << origin.size() << "),"
+      << " x axis (" << x_axis.size() << "), and"
+      << " y axis (" << y_axis.size() << ").");
+    return false;
+    }
+  double xl2 = 0., yl2 = 0., zl2 = 0.;
+  for (int i = 0; i < 3; ++i)
+    {
+    this->m_origin[i] = origin[i];
+    this->m_xAxis[i] = x_axis[i];
+    this->m_yAxis[i] = y_axis[i];
+    xl2 += x_axis[i] * x_axis[i];
+    yl2 += y_axis[i] * y_axis[i];
+    this->m_zAxis[i] =
+      x_axis[(i+1) % 3] * y_axis[(i+2) % 3] -
+      x_axis[(i+2) % 3] * y_axis[(i+1) % 3];
+    zl2 += this->m_zAxis[i] * this->m_zAxis[i];
+    }
+  if (xl2 < 1e-16 || yl2 < 1e-16 || zl2 < 1e-16)
+    {
+    smtkErrorMacro(log,
+      "Vectors of non-zero L2 norm required for "
+      << " x (" << xl2 << "),"
+      << " y (" << yl2 << "), and"
+      << " z (" << zl2 << ") axes.");
+    return false;
+    }
+  xl2 = sqrt(xl2);
+  yl2 = sqrt(yl2);
+  zl2 = sqrt(zl2);
+  // Scale each feature size to be 231000 integer quanta.
+  this->m_scale = 231000 / featureSize;
+  // Make the world (x,y) axes unit length and the (i,j) axes one quantum in length:
+  for (int i = 0; i < 3; ++i)
+    {
+    this->m_xAxis[i] /= xl2;
+    this->m_yAxis[i] /= yl2;
+    this->m_zAxis[i] /= zl2;
+    this->m_iAxis[i] = this->m_xAxis[i] / this->m_scale;
+    this->m_jAxis[i] = this->m_yAxis[i] / this->m_scale;
+    }
+  return true;
+}
+
+bool pmodel::computeModelScaleAndYAxis(
+  std::vector<double>& origin,
+  std::vector<double>& x_axis,
+  std::vector<double>& z_axis,
+  double featureSize,
+  smtk::io::Logger& log)
+{
+  if (featureSize <= 0.)
+    {
+    smtkErrorMacro(log,
+      "Feature size must be positive (not " << featureSize << ").");
+    return false;
+    }
+  this->m_featureSize = featureSize;
+
+  if (origin.size() != 3 || x_axis.size() != 3 || z_axis.size() != 3)
+    {
+    smtkErrorMacro(log,
+      "Vector of length 3 expected for"
+      << " origin (" << origin.size() << "),"
+      << " x axis (" << x_axis.size() << "), and"
+      << " z axis (" << z_axis.size() << ").");
+    return false;
+    }
+  double xl2 = 0., yl2 = 0., zl2 = 0.;
+  for (int i = 0; i < 3; ++i)
+    {
+    this->m_origin[i] = origin[i];
+    this->m_xAxis[i] = x_axis[i];
+    this->m_zAxis[i] = z_axis[i];
+    xl2 += x_axis[i] * x_axis[i];
+    zl2 += z_axis[i] * z_axis[i];
+    this->m_yAxis[i] =
+      z_axis[(i+1) % 3] * x_axis[(i+2) % 3] -
+      z_axis[(i+2) % 3] * x_axis[(i+1) % 3];
+    yl2 += this->m_yAxis[i] * this->m_yAxis[i];
+    }
+  if (xl2 < 1e-16 || yl2 < 1e-16 || zl2 < 1e-16)
+    {
+    smtkErrorMacro(log,
+      "Vectors of non-zero L2 norm required for "
+      << " x (" << xl2 << "),"
+      << " y (" << yl2 << "), and"
+      << " z (" << zl2 << ") axes.");
+    return false;
+    }
+  xl2 = sqrt(xl2);
+  yl2 = sqrt(yl2);
+  zl2 = sqrt(zl2);
+  // Make the axes one feature-size in length:
+  this->m_scale = 231000 / featureSize;
+  // Make the world (x,y) axes unit length and the (i,j) axes one quantum in length:
+  for (int i = 0; i < 3; ++i)
+    {
+    this->m_xAxis[i] /= xl2;
+    this->m_yAxis[i] /= yl2;
+    this->m_zAxis[i] /= zl2;
+    this->m_iAxis[i] = this->m_xAxis[i] / this->m_scale;
+    this->m_jAxis[i] = this->m_yAxis[i] / this->m_scale;
+    }
+  return true;
+}
+
+bool pmodel::computeFeatureSizeAndNormal(
+  std::vector<double>& origin,
+  std::vector<double>& x_axis,
+  std::vector<double>& y_axis,
+  long long modelScale,
+  smtk::io::Logger& log)
+{
+  if (origin.size() != 3 || x_axis.size() != 3 || y_axis.size() != 3)
+    {
+    smtkErrorMacro(log,
+      "Vector of length 3 expected for"
+      << " origin (" << origin.size() << "),"
+      << " x axis (" << x_axis.size() << "), and"
+      << " y axis (" << y_axis.size() << ").");
+    return false;
+    }
+  double xl2 = 0., yl2 = 0., zl2 = 0.;
+  for (int i = 0; i < 3; ++i)
+    {
+    this->m_origin[i] = origin[i];
+    this->m_xAxis[i] = x_axis[i];
+    this->m_yAxis[i] = y_axis[i];
+    xl2 += x_axis[i] * x_axis[i];
+    yl2 += y_axis[i] * y_axis[i];
+    this->m_zAxis[i] =
+      x_axis[(i+1) % 3] * y_axis[(i+2) % 3] -
+      x_axis[(i+2) % 3] * y_axis[(i+1) % 3];
+    zl2 += this->m_zAxis[i] * this->m_zAxis[i];
+    }
+  if (xl2 < 1e-16 || yl2 < 1e-16 || zl2 < 1e-16)
+    {
+    smtkErrorMacro(log,
+      "Vectors of non-zero L2 norm required for "
+      << " x (" << xl2 << "),"
+      << " y (" << yl2 << "), and"
+      << " z (" << zl2 << ") axes.");
+    return false;
+    }
+  xl2 = sqrt(xl2);
+  yl2 = sqrt(yl2);
+  zl2 = sqrt(zl2);
+  this->m_scale = modelScale;
+  this->m_featureSize = 1.0;
+  for (int i = 0; i < 3; ++i)
+    {
+    this->m_xAxis[i] /= xl2;
+    this->m_yAxis[i] /= yl2;
+    this->m_zAxis[i] /= zl2;
+    this->m_iAxis[i] = this->m_xAxis[i] / this->m_scale;
+    this->m_jAxis[i] = this->m_yAxis[i] / this->m_scale;
+    }
+  return true;
+}
+
+smtk::model::Vertices pmodel::findOrAddModelVertices(
+  smtk::model::ManagerPtr mgr,
+  const std::vector<double>& points,
+  int numCoordsPerPt)
+{
+  smtk::model::Vertices vertices;
+  std::vector<double>::const_iterator it = points.begin();
+  long long i = 0;
+  for (i = 0; it != points.end(); it += numCoordsPerPt, i += numCoordsPerPt)
+    {
+    Point projected = this->projectPoint(it, it + numCoordsPerPt);
+    vertices.push_back(this->findOrAddModelVertex(mgr, projected));
+    }
+  return vertices;
+}
+
+/**\brief Add a vertex to the model manager.
+  *
+  * This creates a vertex record in the model manager and adds its tessellation.
+  * It also adds the integer coordinates of the point to
+  * the internal model's data (this instance).
+  * This does **not** relate the vertex record in the model manager to a parent model
+  * or owning geometric entity (such as an edge, face, or volume).
+  */
+smtk::model::Vertex pmodel::findOrAddModelVertex(
+  smtk::model::ManagerPtr mgr,
+  const Point& pt)
+{
+  PointToVertexId::const_iterator pit = this->m_vertices.find(pt);
+  if (pit != this->m_vertices.end())
+    return smtk::model::Vertex(mgr, pit->second);
+
+  // Add a model vertex to the manager
+  smtk::model::Vertex v = mgr->addVertex();
+  // Add a coordinate-map lookup to local storage:
+  this->m_vertices[pt] = v.entity();
+  vertex::Ptr vi = vertex::create();
+  vi->m_coords = pt;
+  vi->setParent(this);
+  this->m_session->addStorage(v.entity(), vi);
+  // Figure out the floating-point approximation for our discretized coordinate
+  // and add it to the tessellation for the new model vertex:
+  double snappedPt[3];
+  this->liftPoint(pt, snappedPt);
+  smtk::model::Tessellation tess;
+  tess.addPoint(snappedPt);
+  v.setTessellation(&tess);
+
+  // Add vertex to model as a free cell (which it is until it bounds something).
+  smtk::model::Model self(mgr, this->id());
+  self.embedEntity(v);
+
+  v.assignDefaultName();
+  return v;
+}
+
+/**\brief Split the model edge with the given \a edgeId at the given \a coords.
+  *
+  * The point coordinates need not lie precisely on the edge, but are assumed not
+  * to cause the split edge to intersect (or miss) any faces or edges the original
+  * edge did not.
+  *
+  * If the point coordinates already specify a model vertex, this method returns false.
+  *
+  * FIXME: Return new edge Ids and new vertex Id.
+  */
+bool pmodel::splitModelEdgeAtPoint(smtk::model::ManagerPtr mgr, const Id& edgeId, const std::vector<double>& coords)
+{
+  Point pt = this->projectPoint(coords.begin(), coords.end());
+  if (this->pointId(pt))
+    return false; // Point is already a model vertex.
+  // TODO: Find point on edge closest to pt? Need to find where to insert model vertex?
+  smtk::model::Vertex v = this->findOrAddModelVertex(mgr, pt);
+  return this->splitModelEdgeAtModelVertex(mgr, edgeId, v.entity());
+}
+
+/** Split the model edge at one of its points that has been promoted to a model vertex.
+  *
+  * Since model edges are not allowed to have model vertices along their interior,
+  * this method should not be exposed as a public operator but may be used internally
+  * when performing other operations.
+  */
+bool pmodel::splitModelEdgeAtModelVertex(smtk::model::ManagerPtr mgr, const Id& edgeId, const Id& vertexId)
+{
+  // Look up edge
+  edge::Ptr edg = this->session()->findStorage<edge>(edgeId);
+  // Look up vertex
+  vertex::Ptr vrt = this->session()->findStorage<vertex>(vertexId);
+  if (!edg || !vrt)
+    return false;
+  PointSeq::const_iterator split;
+  for (split = edg->pointsBegin(); split != edg->pointsEnd(); ++split)
+    {
+    if (vrt->point() == *split)
+      { // Split the edge at this location by creating 2 new edges and deleting this edge.
+      return this->splitModelEdgeAtModelVertex(mgr, edg, vrt, split);
+      }
+    }
+  // Edge did not contain model vertex in its sequence.
+  return false;
+}
+
+typedef std::vector<std::pair<size_t, Segment> > SegmentSplitsT;
+
+bool pmodel::splitModelEdgeAtModelVertex(
+  smtk::model::ManagerPtr mgr, edge::Ptr edgeToSplit, vertex::Ptr splitPoint, PointSeq::const_iterator location)
+{
+  size_t npts;
+  if (
+    !edgeToSplit ||
+    !splitPoint ||
+    (npts = edgeToSplit->pointsSize()) < 3 ||
+    location == edgeToSplit->pointsBegin() ||
+    *location == *edgeToSplit->pointsRBegin())
+    return false;
+
+  SegmentSplitsT segs;
+  SegmentSplitsT::iterator segSplit;
+  segs.reserve(npts - 1); // Preallocation to prevent vector from reallocating and invalidating segSplit iterator.
+  PointSeq::const_iterator prev = edgeToSplit->pointsBegin();
+  size_t n = 0;
+  PointSeq::const_iterator it = prev;
+  for (++it; it != edgeToSplit->pointsEnd(); ++it, ++n, prev = it)
+    {
+    segs.push_back(std::pair<size_t,Segment>(n, Segment(*prev, *it)));
+    if (prev == location)
+      segSplit = segs.begin() + n;
+    }
+
+  // Remove edgeToSplit from its endpoint vertices so that creation
+  // of new edges can succeed (otherwise it will fail when trying
+  // to insert a coincident edge at the existing edge endpoints). 
+  std::pair<Id,Id> adjacentFaces = this->removeModelEdgeFromEndpoints(mgr, edgeToSplit);
+
+  // Now we can create the new model edges.
+  this->createModelEdgeFromSegments(mgr, segs.begin(), segSplit);
+  this->createModelEdgeFromSegments(mgr, segSplit, segs.end());
+
+  // TODO: Fix face adjacency information (face relations and at all 3 vertices)
+  //       Fix face loops by replacing old edge with new edges.
+  //       Create/fix vertex use at model vertex? No, this should be done wherever the vertex is created.
+  return true;
+}
+
+// TODO: Remove edgeToSplit so that creation can succeed (otherwise
+//       it will fail when trying to insert a coincident edge at the
+//       existing edge endpoints. 
+std::pair<Id,Id> pmodel::removeModelEdgeFromEndpoints(smtk::model::ManagerPtr mgr, EdgePtr edg)
+{
+  std::pair<Id,Id> result;
+  if (!edg || !mgr)
+    return result;
+
+  Id epids[2];
+  epids[0] = this->pointId(*edg->pointsBegin());
+  epids[1] = this->pointId(*edg->pointsRBegin());
+  if (!epids[0])
+    return result; // edge is periodic and has no model vertices
+
+  // Iterate over both endpoints (which may be the same, but in that
+  // case we still need to remove both edge-incidence records).
+  for (int i = 0; i < 2; ++i)
+    {
+    vertex::Ptr endpt = this->session()->findStorage<vertex>(epids[i]);
+    vertex::incident_edges::iterator where;
+    for (where = endpt->edgesBegin(); where != endpt->edgesEnd(); ++where)
+      {
+      if (where->edgeId() == edg->id())
+        { // found the incident edge.
+        if (!result.first)
+          {
+          vertex::incident_edges::iterator tmp = where;
+          result.first =
+            (where == endpt->edgesBegin() ?
+             endpt->edgesRBegin()->clockwiseFaceId() :
+             (--tmp)->clockwiseFaceId());
+          result.second = where->clockwiseFaceId();
+          }
+        endpt->removeEdgeAt(where);
+        }
+      }
+    }
+  return result;
+}
+
+Point pmodel::edgeTestPoint(const Id& edgeId, bool edgeEndPt) const
+{
+  edge::Ptr e = this->m_session->findStorage<edge>(edgeId);
+  if (e)
+    {
+    if (edgeEndPt == true)
+      { // Return test point near *last* vertex of forwards edge.
+      PointSeq::const_reverse_iterator it = e->pointsRBegin();
+      ++it; // Advance from endpoint by 1 so we are not coincident to the endpoint.
+      return *it;
+      }
+    else
+      { // Return test point near *first* vertex of forwards edge.
+      PointSeq::const_iterator it = e->pointsBegin();
+      ++it;
+      return *it;
+      }
+    }
+  return Point(); // FIXME: Do something better? detectable?
+}
+
+void pmodel::addEdgeTessellation(smtk::model::Edge& edgeRec, internal::edge::Ptr edgeData)
+{
+  if (!edgeRec.isValid() || !edgeData)
+    return;
+
+  smtk::model::Manager::Ptr mgr = edgeRec.manager();
+  smtk::model::Tessellation empty;
+  UUIDsToTessellations::iterator tessIt =
+    mgr->setTessellation(edgeRec.entity(), empty);
+
+  // Now populate the tessellation in place.
+  PointSeq::const_iterator ptIt;
+  std::vector<double> coords(3);
+  std::size_t numPts = edgeData->pointsSize();
+  std::vector<int> conn;
+  conn.reserve(numPts + 2);
+  conn.push_back(smtk::model::TESS_POLYLINE);
+  conn.push_back(numPts);
+  for (ptIt = edgeData->pointsBegin(); ptIt != edgeData->pointsEnd(); ++ptIt)
+    {
+    this->liftPoint(*ptIt, coords.begin());
+    conn.push_back(tessIt->second.addCoords(&coords[0]));
+    }
+  tessIt->second.insertCell(0, conn);
+}
+
+Id pmodel::pointId(const Point& p) const
+{
+  PointToVertexId::const_iterator it = this->m_vertices.find(p);
+  if (it == this->m_vertices.end())
+    return Id();
+  return it->second;
+}
+
+      } // namespace internal
+    } // namespace polygon
+  } // namespace bridge
+} // namespace smtk

--- a/smtk/bridge/polygon/internal/Model.h
+++ b/smtk/bridge/polygon/internal/Model.h
@@ -1,0 +1,142 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_bridge_polygon_internal_model_h
+#define __smtk_bridge_polygon_internal_model_h
+
+#include "smtk/bridge/polygon/internal/Entity.h"
+#include "smtk/PublicPointerDefs.h"
+#include "smtk/SharedFromThis.h"
+
+#include "smtk/model/Edge.h"
+#include "smtk/model/Vertex.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+      namespace internal {
+
+class pmodel : public entity
+{
+public:
+  smtkTypeMacro(pmodel);
+  smtkCreateMacro(pmodel);
+  smtkSharedFromThisMacro(entity);
+  pmodel();
+  ~pmodel();
+
+  bool computeModelScaleAndNormal(
+    std::vector<double>& origin,
+    std::vector<double>& x_axis,
+    std::vector<double>& y_axis,
+    double featureSize,
+    smtk::io::Logger& log);
+
+  bool computeModelScaleAndYAxis(
+    std::vector<double>& origin,
+    std::vector<double>& x_axis,
+    std::vector<double>& z_axis,
+    double featureSize,
+    smtk::io::Logger& log);
+
+  bool computeFeatureSizeAndNormal(
+    std::vector<double>& origin,
+    std::vector<double>& x_axis,
+    std::vector<double>& y_axis,
+    long long modelScale,
+    smtk::io::Logger& log);
+
+  smtk::model::Vertices findOrAddModelVertices(
+    smtk::model::ManagerPtr mgr,
+    const std::vector<double>& points,
+    int numCoordsPerPt);
+
+  smtk::model::Vertex findOrAddModelVertex(
+    smtk::model::ManagerPtr mgr,
+    const Point& pt);
+
+  template<typename T>
+  model::Edge createModelEdgeFromSegments(smtk::model::ManagerPtr mgr, T begin, T end);
+
+  template<typename T>
+  std::set<Id> createModelEdgesFromPoints(T begin, T end);
+
+  bool splitModelEdgeAtPoint(smtk::model::ManagerPtr mgr, const Id& edgeId, const std::vector<double>& point);
+  bool splitModelEdgeAtModelVertex(smtk::model::ManagerPtr mgr, const Id& edgeId, const Id& vertexId);
+  bool splitModelEdgeAtModelVertex(smtk::model::ManagerPtr mgr, EdgePtr edgeToSplit, VertexPtr splitPoint, PointSeq::const_iterator location);
+
+  std::pair<Id,Id> removeModelEdgeFromEndpoints(smtk::model::ManagerPtr mgr, EdgePtr edg);
+
+  Point edgeTestPoint(const Id& edgeId, bool edgeEndPt) const;
+
+  void addEdgeTessellation(smtk::model::Edge& edgeRec, internal::EdgePtr edgeData);
+
+  double* origin() { return this->m_origin; }
+  const double* origin() const { return this->m_origin; }
+
+  double* xAxis() { return this->m_xAxis; }
+  const double* xAxis() const { return this->m_xAxis; }
+
+  double* yAxis() { return this->m_yAxis; }
+  const double* yAxis() const { return this->m_yAxis; }
+
+  double* zAxis() { return this->m_zAxis; }
+  const double* zAxis() const { return this->m_zAxis; }
+
+  double featureSize() const { return this->m_featureSize; }
+  double modelScale() const { return this->m_scale; }
+
+  Id id() const { return this->m_id; }
+  void setId(const Id& id) { this->m_id = id; }
+
+  const Session* session() const { return this->m_session; }
+  Session* session() { return this->m_session; }
+  void setSession(Session* s) { this->m_session = s; }
+
+  Id pointId(const Point& p) const;
+
+  /**\brief A convenience method to get the model vertex at \a p.
+    *
+    * This method will never create a model vertex; if one is not
+    * present at \a p, an invalid model::Vertex will be returned.
+    */
+  smtk::model::Vertex vertexAtPoint(smtk::model::ManagerPtr mgr, const Point& p) const
+    { return smtk::model::Vertex(mgr, this->pointId(p)); }
+
+  template<typename T>
+  Point projectPoint(T coordBegin, T coordEnd);
+
+  template<typename T>
+  void liftPoint(const Point& ix, T coordBegin);
+
+protected:
+  Session* m_session; // Parent session of this pmodel.
+  Id m_id;
+  long long m_scale; // Recommend this be a large composite number w/ factors 2, 3, 5 (e.g., 15360, 231000, or 1182720)
+  double m_featureSize;
+
+  double m_origin[3]; // Base point of plane for pmodel
+
+  double m_xAxis[3]; // Unit length vector in world space (m_scale model-integers long)
+  double m_yAxis[3]; // In-plane vector orthogonal to m_xAxis (also with unit length).
+  double m_zAxis[3]; // Normal vector orthogonal to m_xAxis and m_yAxis with the same length.
+
+  double m_iAxis[3]; // Vector whose length should be equal to one integer "unit" (e.g., 1 integer long)
+  double m_jAxis[3]; // In-plane vector orthogonal to m_xAxis with the same length.
+
+  PointToVertexId m_vertices;
+  //pointsToEdgeIdT m_edges;
+};
+
+      } // namespace internal
+    } // namespace polygon
+  } // namespace bridge
+} // namespace smtk
+
+#endif // __smtk_bridge_polygon_internal_model_h

--- a/smtk/bridge/polygon/internal/Model.txx
+++ b/smtk/bridge/polygon/internal/Model.txx
@@ -1,0 +1,164 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_bridge_polygon_internal_model_txx
+#define __smtk_bridge_polygon_internal_model_txx
+
+#include "smtk/model/Edge.h"
+#include "smtk/model/Manager.h"
+#include "smtk/model/Model.h"
+#include "smtk/model/Vertex.h"
+#include "smtk/bridge/polygon/Session.h"
+#include "smtk/bridge/polygon/internal/Vertex.h"
+#include "smtk/bridge/polygon/internal/Edge.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+      namespace internal {
+
+/**\brief Create a model edge from ordered segments with preconditions.
+  *
+  * + Segments must be ordered head-to-tail.
+  * + Only the initial and final points may have model vertices associated
+  *   with their locations.
+  * + If the initial and final points are not identical, then model vertices
+  *   *must* be associated with their locations and those vertices must not
+  *   have faces that overlap the edge. (This is verified before creation
+  *   but only the immediate neighborhood of the endpoints is checked by
+  *   examining face adjacencies at the location where the new edge would
+  *   be inserted into the vertex connectivity.)
+  *
+  * If these preconditions do not hold, either an invalid (empty) edge will be
+  * returned or the model will become inconsistent.
+  */
+template<typename T>
+model::Edge pmodel::createModelEdgeFromSegments(model::ManagerPtr mgr, T begin, T end)
+{
+  if (!mgr || begin == end)
+    return smtk::model::Edge();
+
+  Id vInit = this->pointId(begin->second.low());
+  Id vFini = this->pointId((begin + (end - begin - 1))->second.high());
+
+  vertex::Ptr vInitStorage = this->m_session->findStorage<vertex>(vInit);
+  vertex::Ptr vFiniStorage = this->m_session->findStorage<vertex>(vFini);
+
+  if (!vInitStorage ^ !vFiniStorage)
+    { // one but not both of the points are model vertices. Error.
+    smtkErrorMacro(this->session()->log(),
+      "Zero or both endpoints must be model vertices to create edge.");
+    return smtk::model::Edge();
+    }
+
+  internal::vertex::incident_edges::iterator whereBegin;
+  internal::vertex::incident_edges::iterator whereEnd;
+  if (vInitStorage)
+    { // Ensure edge can be inserted without splitting a face.
+    if (!vInitStorage->canInsertEdge(begin->second.high(), &whereBegin))
+      {
+      smtkErrorMacro(this->m_session->log(),
+        "Edge would overlap face in neighborhood of first vertex");
+      return smtk::model::Edge();
+      }
+    }
+
+  if (vFiniStorage)
+    { // Ensure edge can be inserted without splitting a face.
+    if (!vFiniStorage->canInsertEdge((begin + (end - begin - 1))->second.low(), &whereEnd))
+      {
+      smtkErrorMacro(this->m_session->log(),
+        "Edge would overlap face in neighborhood of last vertex");
+      return smtk::model::Edge();
+      }
+    }
+
+  // We can safely create the edge now
+  smtk::model::Edge created = mgr->addEdge();
+  internal::edge::Ptr storage = internal::edge::create();
+  storage->setParent(this);
+  storage->setId(created.entity());
+  this->m_session->addStorage(created.entity(), storage);
+  storage->m_points.clear();
+  storage->m_points.insert(storage->m_points.end(), begin->second.low());
+  for (T segIt = begin; segIt != end; ++segIt)
+    storage->m_points.insert(storage->m_points.end(), segIt->second.high());
+
+  smtk::model::Model parentModel(mgr, this->id());
+  // Insert edge at proper place in model vertex edge-lists
+  if (vInitStorage)
+    {
+    vInitStorage->insertEdgeAt(whereBegin, created.entity(), /* edge is outwards: */ true);
+    smtk::model::Vertex vert(mgr, vInit);
+    if (parentModel.isEmbedded(vert))
+      parentModel.unembedEntity(vert);
+    created.findOrAddRawRelation(vert);
+    }
+  if (vFiniStorage)
+    {
+    vFiniStorage->insertEdgeAt(whereEnd, created.entity(), /* edge is outwards: */ false);
+    smtk::model::Vertex vert(mgr, vFini);
+    if (parentModel.isEmbedded(vert))
+      parentModel.unembedEntity(vert);
+    created.findOrAddRawRelation(vert);
+    }
+  // Add tesselation to created edge using storage to lift point coordinates:
+  this->addEdgeTessellation(created, storage);
+
+  parentModel.embedEntity(created);
+  created.assignDefaultName(); // Do not move above parentModel.embedEntity() or name will suck.
+
+  return created;
+}
+
+template<typename T>
+Point pmodel::projectPoint(T coordBegin, T coordEnd)
+{
+  double xyz[3] = {0, 0, 0};
+  int i = 0;
+  // Translate to origin
+  for (T c = coordBegin; c != coordEnd && i < 3; ++i, ++c)
+    {
+    xyz[i] = *c - this->m_origin[i];
+    }
+  // Assume any unspecified coordinates are 0 and finish translating to origin
+  for (; i < 3; ++i)
+    {
+    xyz[i] = - this->m_origin[i];
+    }
+  // Project translated point to x and y axes
+  double px = 0, py = 0;
+  for (i = 0; i < 3; ++i)
+    {
+    px += xyz[i] * this->m_xAxis[i];
+    py += xyz[i] * this->m_yAxis[i];
+    }
+  // Scale point and round to integer
+  Point result(px * this->m_scale, py * this->m_scale);
+  return result;
+}
+
+template<typename T>
+void pmodel::liftPoint(const Point& ix, T coordBegin)
+{
+  T coord = coordBegin;
+  for (int i = 0; i < 3; ++i, ++coord)
+    {
+    *coord =
+      this->m_origin[i] +
+      ix.x() * this->m_iAxis[i] +
+      ix.y() * this->m_jAxis[i];
+    }
+}
+
+      } // namespace internal
+    } // namespace polygon
+  } // namespace bridge
+} // namespace smtk
+#endif // __smtk_bridge_polygon_internal_model_txx

--- a/smtk/bridge/polygon/internal/Vertex.cxx
+++ b/smtk/bridge/polygon/internal/Vertex.cxx
@@ -1,0 +1,141 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#include "smtk/bridge/polygon/internal/Vertex.h"
+#include "smtk/bridge/polygon/internal/Model.h"
+#include "smtk/bridge/polygon/Session.h"
+
+#include "smtk/io/Logger.h"
+
+#include "boost/polygon/polygon.hpp"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+      namespace internal {
+
+/**\brief Return true if the edge can be inserted.
+  *
+  * FIXME: This will have precision issues with small angles because
+  *        sqrt() is not calculated with intervals and overflow may
+  *        occur when edge neighbor-points are far from each other.
+  */
+bool vertex::canInsertEdge(const Point& neighborhood, incident_edges::iterator* where)
+{
+  // Early termination... 0 or 1 existing vertices are always in CCW order no
+  // matter where we insert
+  if (this->m_edges.size() < 2)
+    {
+    // A vertex with 1 incident edge that is part of a face has face completely
+    // surrounding the vertex; it will never be valid to insert another edge
+    // there without removing the face first.
+    if (!this->m_edges.empty() && this->m_edges.front().m_adjacentFace)
+      return false;
+    // Otherwise, it is always valid to insert a new edge anywhere.
+    if (where)
+      *where = this->m_edges.begin();
+    return true;
+    }
+
+  pmodel* model = this->parentAs<pmodel>();
+  Point pt(
+    neighborhood.x() - this->m_coords.x(),
+    neighborhood.y() - this->m_coords.y()
+  );
+
+  Point prevPt(
+    model->edgeTestPoint(
+      this->m_edges.back().m_edgeId, !this->m_edges.back().m_edgeOut));
+  Point pa(
+    prevPt.x() - this->m_coords.x(),
+    prevPt.y() - this->m_coords.y()
+  );
+  incident_edges::iterator it;
+  for (it = this->m_edges.begin(); it != this->m_edges.end(); ++it)
+    {
+    Point currPt = model->edgeTestPoint(it->m_edgeId, !it->m_edgeOut);
+    Point pb(
+      currPt.x() - this->m_coords.x(),
+      currPt.y() - this->m_coords.y()
+    );
+
+    bool inside;
+    Coord axb = pa.x() * pb.y() - pb.x() * pa.y();
+    if (axb < 0)
+      { // CCW angle between pa and pb is < 180 degrees
+      Coord axt = pa.x() * pt.y() - pt.x() * pa.y();
+      if (axt < 0)
+        inside = false; // vectors pa->pb don't bracket pt CCW
+      long double mb = sqrt(pb.x() * pb.x() + pb.y() * pb.y());
+      long double mt = sqrt(pt.x() * pt.x() + pt.y() * pt.y());
+      if (axt * mb < axb * mt)
+        { // pa->pb brackets pt CCW.
+        inside = true;
+        }
+      }
+    else
+      { // CCW angle between pa and pb is >= 180 degrees
+      Coord bxt = pb.x() * pt.y() - pt.x() * pb.y();
+      inside = (bxt < 0);
+      if (!inside)
+        {
+        Coord bxa = -axb;
+        long double ma = sqrt(pa.x() * pa.x() + pa.y() * pa.y());
+        long double mt = sqrt(pt.x() * pt.x() + pt.y() * pt.y());
+        inside = (bxt * ma > bxa * mt);
+        }
+      }
+    if (inside)
+      {
+      if (!it->m_adjacentFace)
+        { // There is no face; it's OK to add the edge here.
+        if (where)
+          *where = it;
+        return true;
+        }
+      else
+        {
+        smtkErrorMacro(model->session()->log(),
+          "Edge would split face " << it->m_adjacentFace);
+        return false;
+        }
+      }
+    pa = pb;
+    }
+  smtkErrorMacro(model->session()->log(), "Collinear edges");
+  return false;
+}
+
+/**\brief Insert the edge \a where told (by canInsertEdge).
+  *
+  * \a edgeOutwards indicates whether the forward-direction edge
+  * is outward or inward-pointing (from/to this vertex).
+  */
+void vertex::insertEdgeAt(incident_edges::iterator where, const Id& edgeId, bool edgeOutwards)
+{
+  incident_edge_data edgeData;
+  edgeData.m_edgeId = edgeId;
+  edgeData.m_edgeOut = edgeOutwards;
+  // NB: Should never insert edge where a face exists, so edgeData.m_adjacentFace should be left NULL.
+  this->m_edges.insert(where, edgeData);
+}
+
+/**\brief Remove the edge incidence record at the given position.
+  *
+  * This does not perform any updates to other incidence records.
+  */
+void vertex::removeEdgeAt(incident_edges::iterator where)
+{
+  this->m_edges.erase(where);
+}
+
+      } // namespace internal
+    } // namespace polygon
+  } // namespace bridge
+} // namespace smtk

--- a/smtk/bridge/polygon/internal/Vertex.h
+++ b/smtk/bridge/polygon/internal/Vertex.h
@@ -1,0 +1,89 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_bridge_polygon_internal_Vertex_h
+#define __smtk_bridge_polygon_internal_Vertex_h
+
+#include "smtk/SharedFromThis.h"
+#include "smtk/bridge/polygon/internal/Entity.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+      namespace internal {
+
+/**\brief A base class for all internal vertex storage.
+  *
+  * Every vertex stores a pointer to its parent and its UUID.
+  * This class uses smtkEnableSharedPtr so that all entities may be
+  * managed via one pool of shared pointers.
+  */
+class vertex : public entity
+{
+public:
+  smtkTypeMacro(vertex);
+  smtkCreateMacro(vertex);
+  smtkSharedFromThisMacro(entity);
+  virtual ~vertex() { }
+
+  struct incident_edge_data
+    {
+    Id m_edgeId; // Should never be NULL
+    Id m_adjacentFace; // Face immediately CW of m_edgeId. May be NULL.
+    bool m_edgeOut; // True when edge points outward from vertex (i.e., edge oriented so beginning vertex is this vertex)
+
+    Id edgeId() const { return this->m_edgeId; }
+    Id clockwiseFaceId() const { return this->m_adjacentFace; }
+    bool isEdgeOutgoing() const { return this->m_edgeOut; }
+    };
+  typedef std::list<incident_edge_data> incident_edges;
+
+  const Point& point() const { return this->m_coords; }
+  Point point() { return this->m_coords; }
+
+  bool canInsertEdge(const Point& neighborhood, incident_edges::iterator* where);
+  void insertEdgeAt(incident_edges::iterator where, const Id& edgeId, bool edgeOutwards);
+  void removeEdgeAt(incident_edges::iterator where);
+
+  incident_edges::const_iterator edgesBegin() const { return this->m_edges.begin(); }
+  incident_edges::const_iterator edgesEnd() const { return this->m_edges.end(); }
+
+  incident_edges::iterator edgesBegin() { return this->m_edges.begin(); }
+  incident_edges::iterator edgesEnd() { return this->m_edges.end(); }
+
+  incident_edges::const_reverse_iterator edgesRBegin() const { return this->m_edges.rbegin(); }
+  incident_edges::const_reverse_iterator edgesREnd() const { return this->m_edges.rend(); }
+
+  incident_edges::reverse_iterator edgesRBegin() { return this->m_edges.rbegin(); }
+  incident_edges::reverse_iterator edgesREnd() { return this->m_edges.rend(); }
+
+protected:
+  friend class pmodel;
+
+  vertex() { }
+
+  Point m_coords; // position in the plane.
+  incident_edges m_edges; // CCW list of incident edges
+
+  // NB: One extension to this structure would be:
+  // Ptr m_prev; // Previous model vertex located at this exact point in the plane
+  // Ptr m_next; // Next model vertex located at this exact point in the plane
+  // These would allow modeling polygons that were "topologically independent"
+  // while still allowing quick lookup of vertices by point location.
+
+  // NB: Another extension to this structure would be:
+  // Id m_containingFace; // Face that contains this model vertex as a hard point in its interior.
+};
+
+      } // namespace internal
+    } // namespace polygon
+  } // namespace bridge
+} // namespace smtk
+
+#endif // __smtk_bridge_polygon_internal_Vertex_h

--- a/smtk/bridge/polygon/operators/CreateEdge.cxx
+++ b/smtk/bridge/polygon/operators/CreateEdge.cxx
@@ -1,0 +1,372 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#include "smtk/bridge/polygon/operators/CreateEdge.h"
+
+#include "smtk/bridge/polygon/Session.h"
+#include "smtk/bridge/polygon/internal/Model.h"
+#include "smtk/bridge/polygon/internal/Model.txx"
+
+#include "smtk/io/Logger.h"
+
+#include "smtk/model/Vertex.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/DoubleItem.h"
+#include "smtk/attribute/IntItem.h"
+#include "smtk/attribute/ModelEntityItem.h"
+#include "smtk/attribute/StringItem.h"
+
+#include "smtk/bridge/polygon/CreateEdge_xml.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+typedef std::vector<std::pair<size_t, internal::Segment> > SegmentSplitsT;
+
+/*
+template<typename T>
+void printSegment(internal::pmodel::Ptr storage, const std::string& msg, T& seg)
+{
+  std::vector<double> lo(3);
+  std::vector<double> hi(3);
+  storage->liftPoint(seg.low(), lo.begin());
+  storage->liftPoint(seg.high(), hi.begin());
+  std::cout
+    << msg
+    << "    " << lo[0] << " " << lo[1] << " " << lo[2]
+    << " -> " << hi[0] << " " << hi[1] << " " << hi[2]
+    << "\n";
+}
+*/
+
+smtk::model::OperatorResult CreateEdge::operateInternal()
+{
+  smtk::bridge::polygon::Session* sess = this->polygonSession();
+  smtk::model::Manager::Ptr mgr;
+  if (!sess)
+    return this->createResult(smtk::model::OPERATION_FAILED);
+
+  mgr = sess->manager();
+  // Discover how the user wants to specify scaling.
+  smtk::attribute::IntItem::Ptr constructionMethodItem = this->findInt("construction method");
+  // This value matches CreateEdge.sbt index (and enum value):
+  int method = constructionMethodItem->discreteIndex(0);
+
+  smtk::attribute::DoubleItem::Ptr pointsItem = this->findDouble("points");
+  smtk::attribute::IntItem::Ptr coordinatesItem = this->findInt("coordinates");
+  smtk::attribute::IntItem::Ptr offsetsItem = this->findInt("offsets");
+
+  smtk::attribute::ModelEntityItem::Ptr modelItem = this->specification()->associations();
+  // Either modelItem contains a single Model or 2+ Vertex entities.
+  // If method == 0 (points), use the owningModel of any Vertex or complain
+  // If method == 1 (vertices), complain if the entities are not vertices or there are too few.
+  smtk::model::Model parentModel(modelItem->value(0));
+  if (!parentModel.isValid())
+    {
+    parentModel = modelItem->value(0).owningModel();
+    if (!parentModel.isValid() || (method == 1 && modelItem->numberOfValues() < 2))
+      {
+      smtkErrorMacro(this->log(),
+        "A model (or vertices with a valid parent model) must be associated with the operator.");
+      return this->createResult(smtk::model::OPERATION_FAILED);
+      }
+    }
+  if (method == 1 && (!modelItem->value(0).isVertex() || modelItem->numberOfValues() < 2))
+    {
+    smtkErrorMacro(this->log(),
+      "When constructing an edge from vertices,"
+      " all associated model entities must be vertices"
+      " and there must be at least 2 vertices");
+    return this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  internal::pmodel::Ptr storage =
+    sess->findStorage<internal::pmodel>(
+      parentModel.entity());
+  bool ok = true;
+  int numEdges = offsetsItem->numberOfValues();
+  int numCoordsPerPt = coordinatesItem->value(0);
+  // numPts is the number of points total (across all edges)
+  long long numPts =
+    (method == 0 ?
+     pointsItem->numberOfValues() / numCoordsPerPt : // == #pts / #coordsPerPt
+     modelItem->numberOfValues());
+  int ei;
+  smtk::model::Edges created;
+  // Process each edge individually:
+  for (ei = 0; ei < numEdges; ++ei)
+    {
+    long long edgeOffset = offsetsItem->value(ei);
+    long long edgeEnd = (ei < numEdges - 1 ? offsetsItem->value(ei + 1) : numPts);
+    long long numSegments = edgeEnd - edgeOffset - 1;
+    if (numSegments < 1 || edgeEnd > numPts)
+      {
+      smtkWarningMacro(this->log(),
+        "Ignoring input " << ei << " (offset " << edgeOffset << " to " << edgeEnd << ")" <<
+        " with not enough points or offset past end of points.");
+      continue; // skip "edges" with only 0 or 1 vertices for their entire path.
+      }
+
+    // Fill in a list of segments for the edge so we can
+    // check for self-intersections.
+    std::list<internal::Segment> edgeSegs;
+    bool edgeIsPeriodic = true;
+    switch (method)
+      {
+    case 0: // points, coordinates, offsets
+        {
+        std::vector<double> pt(numCoordsPerPt, 0.);
+        internal::Point curr;
+        internal::Point prev;
+        internal::Point orig;
+        bool first = true;
+        for (; edgeOffset < edgeEnd; ++edgeOffset, prev = curr)
+          {
+          for (int i = 0; i < numCoordsPerPt; ++i)
+            pt[i] = pointsItem->value(edgeOffset * numCoordsPerPt + i);
+          curr = storage->projectPoint(pt.begin(), pt.end());
+          if (!first)
+            {
+            edgeSegs.push_back(internal::Segment(prev, curr));
+            }
+          else
+            {
+            first = false;
+            orig = curr;
+            }
+          }
+        if (!first && orig != curr)
+          { // non-periodic edge forces endpts to be model vertices
+          smtk::model::Vertex vs = storage->findOrAddModelVertex(mgr, orig);
+          smtk::model::Vertex ve = storage->findOrAddModelVertex(mgr, curr);
+          edgeIsPeriodic = false;
+          }
+        }
+      break;
+    case 1: // vertices, offsets
+        {
+        internal::Point curr;
+        internal::Point prev;
+        bool first = true;
+        edgeIsPeriodic = (modelItem->value(edgeOffset) == modelItem->value(edgeEnd));
+        for (; edgeOffset < edgeEnd; ++edgeOffset, prev = curr)
+          {
+          internal::vertex::Ptr vert =
+            sess->findStorage<internal::vertex>(modelItem->value(edgeOffset).entity());
+          if (!vert)
+            {
+            ok = false;
+            smtkErrorMacro(
+              sess->log(),
+              "vertices item " << edgeOffset << " not a valid vertex.");
+            }
+          curr = vert->point();
+          if (!first)
+            {
+            edgeSegs.push_back(internal::Segment(prev, curr));
+            }
+          else
+            {
+            first = false;
+            }
+          }
+        }
+      break;
+    default:
+      ok = false;
+      smtkInfoMacro(log(), "Unhandled construction method " << method << ".");
+      break;
+      }
+
+    std::list<internal::Segment>::const_iterator edgeIt;
+    if (ok)
+      { // Inside here, we know we got a list of segments for this edge.
+
+      // Intersect the segments with each other.
+      // Intersection points become model vertices and cause the edge
+      // to be split into possibly-multiple actual edges.
+      SegmentSplitsT result;
+      boost::polygon::intersect_segments(result, edgeSegs.begin(), edgeSegs.end());
+      /*
+      std::cout
+        << "Intersected " << numSegments
+        << " segments of edge " << ei << "."
+        << " Result has " << result.size()
+        << " segments:\n";
+        */
+      if (result.empty())
+        {
+        smtkErrorMacro(this->log(), "Self-intersection of edge segments was empty set.");
+        return this->createResult(smtk::model::OPERATION_FAILED);
+        }
+
+      // I. Pre-process the intersected segments
+      //
+      // We perform two tasks to prepare the intersection results for
+      // edge creation:
+      //
+      // A. Reordering segments of periodic edges with model vertices
+      // When an edge is periodic (i.e., its first and last points are
+      // identical), it may get split into multiple periodic loops (if
+      // it self-intersects) or it might contain one or more pre-existing
+      // model vertices that split the edge and must serve as endpoints.
+      // In either of these circumstances, if the initial point is not a
+      // model vertex, we would rather not force it to become one; so,
+      // we move the first points that are not model vertices to the end
+      // of the intersection results.
+      //
+      // B. Reorienting inverted segments head-to-tail.
+      // We must reorder the intersected results so they match the
+      // original direction of the input edges. This is tricky because
+      // where an intersection occurs, if any one segment's record is
+      // pointing the wrong direction, all the records for the segment
+      // will be in reverse order. For example if we have edgeSegs =
+      // {{a,b}, {b,c}, {c,d}, {d,e}} we can end up with result =
+      // {0:{a,b}, 1:{c,f}, 1:{f,b}, 2:{d,c}, 3:{d,g}, 3:{g,e}}
+      // depending on the arrangement of the points a--e.
+      //
+      // What we must do is both swap endpoints of some segments
+      // reverse the order of swapped segments that share the same
+      // source (only reversing those that have been swapped) to
+      // obtain result =
+      // {0:{a,b}, 1:{b,f}, 1:{f,c}, 2:{c,d}, 3:{d,g}, 3:{g,e}}.
+
+      edgeIt = edgeSegs.begin(); // Keep an iterator pointing to the source segment of the intersected results.
+      SegmentSplitsT::iterator segStart = result.begin();
+      //printSegment(storage, "seg start", segStart->second); // DBG
+      SegmentSplitsT::iterator segEnd;
+      SegmentSplitsT::iterator firstModelVertex;
+      bool haveFirstModelVertex = false;
+      // Loop over all intersection-output segments by their input segment (edgeIt):
+      for (SegmentSplitsT::iterator sit = result.begin(); sit != result.end(); ++edgeIt)
+        {
+        std::size_t numSegsPerSrc = 0; // Number of result segs per input edge in edgeSegs
+        // Determine whether segments are reversed from the input edge:
+        //printSegment(storage, "Seg ", sit->second);
+        internal::Point deltaSrc =
+          internal::Point(
+            edgeIt->high().x() - edgeIt->low().x(),
+            edgeIt->high().y() - edgeIt->low().y());
+        internal::Point deltaDst =
+          internal::Point(
+            sit->second.high().x() - sit->second.low().x(),
+            sit->second.high().y() - sit->second.low().y());
+        // Whether the segments are reversed or not, determine which
+        // output segments correspond to a single input segment:
+        if (deltaDst.x() * deltaSrc.x() < 0 || deltaDst.y() * deltaSrc.y() < 0)
+          {
+          segStart = sit;
+          for (segEnd = sit; segEnd != result.end() && segEnd->first == segStart->first; ++segEnd)
+            {
+            internal::Segment flipped(segEnd->second.high(), segEnd->second.low());
+            segEnd->second = flipped;
+            ++numSegsPerSrc;
+            }
+          // NB: after reverse(), segStart still points to beginning...
+          // its contents are swapped with (segEnd-1):
+          std::reverse(segStart, segEnd);
+          }
+        else
+          { // Advance sit to end of entries for the input segment.
+          segStart = sit;
+          segEnd = sit;
+          for (segEnd = segStart; segEnd != result.end() && segEnd->first == segStart->first; ++segEnd)
+            ++numSegsPerSrc;
+          }
+        // Process all the output segments (i.e., [segStart,segEnd)) for the current input segment:
+        sit = segStart;
+        // If the first point in the first ouput segment for any input-segment is
+        // a model vertex, make a note of it for periodic edges:
+        if (edgeIsPeriodic && storage->pointId(sit->second.low()))
+          {
+          haveFirstModelVertex = true;
+          firstModelVertex = sit;
+          }
+        // If numSegsPerSrc > 1, we have interior model vertices where intersections occur.
+        // Promote each of those points to model vertices.
+        for (std::size_t i = 1; i < numSegsPerSrc; ++i)
+          {
+          smtk::model::Vertex vs = storage->findOrAddModelVertex(mgr, sit->second.high());
+          ++sit;
+          if (edgeIsPeriodic && !haveFirstModelVertex)
+            {
+            haveFirstModelVertex = true;
+            firstModelVertex = sit;
+            }
+          }
+        sit = segEnd;
+        }
+      // Move any non-model-vertex points on periodic edges that contain at least
+      // one model vertex to the end of the edge list.
+      if (edgeIsPeriodic && haveFirstModelVertex)
+        {
+        //result.splice(result, result.end(), result.begin(), firstModelVertex);
+        SegmentSplitsT tmp(result.begin(), firstModelVertex);
+        result.erase(result.begin(), firstModelVertex);
+        result.insert(result.end(), tmp.begin(), tmp.end());
+        }
+
+      // II. Generate edge(s) as required.
+      //
+      // All intersection points have been marked as model edges
+      // and all segments are now in proper head-to-tail order.
+      // If the edge is periodic and has any model vertices, the
+      // first segment is now guaranteed to start with a model
+      // vertex (and thus the last segment will end with one).
+
+      segStart = result.begin();
+      for (SegmentSplitsT::iterator sit = result.begin(); sit != result.end(); )
+        {
+        bool generateEdge = (storage->pointId(sit->second.high()) ? true : false);
+        ++sit;
+        // Does the current segment end with a model vertex?
+        if (generateEdge)
+          { // Generate an edge. segStart->second.low() is guaranteed to be a model vertex.
+          smtk::model::Edge edge = storage->createModelEdgeFromSegments(mgr, segStart, sit);
+          if (edge.isValid())
+            created.push_back(edge);
+          segStart = sit;
+          }
+        }
+      // Handle the case when there are no model vertices:
+      if (segStart != result.end())
+        {
+        smtk::model::Edge edge = storage->createModelEdgeFromSegments(mgr, segStart, result.end());
+        created.push_back(edge);
+        }
+      }
+    }
+
+  smtk::model::OperatorResult opResult;
+  if (ok)
+    {
+    opResult = this->createResult(smtk::model::OPERATION_SUCCEEDED);
+    this->addEntitiesToResult(opResult, created, CREATED);
+    }
+  else
+    {
+    opResult = this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  return opResult;
+}
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+smtkImplementsModelOperator(
+  SMTKPOLYGONSESSION_EXPORT,
+  smtk::bridge::polygon::CreateEdge,
+  polygon_create_edge,
+  "create edge",
+  CreateEdge_xml,
+  smtk::bridge::polygon::Session);

--- a/smtk/bridge/polygon/operators/CreateEdge.h
+++ b/smtk/bridge/polygon/operators/CreateEdge.h
@@ -1,0 +1,39 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_session_polygon_CreateEdge_h
+#define __smtk_session_polygon_CreateEdge_h
+
+#include "smtk/bridge/polygon/Operator.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+/**\brief Create one or more edges given a set of point coordinates.
+  *
+  * Self-intersecting edges are broken into multiple non-self-intersecting edges.
+  */
+class SMTKPOLYGONSESSION_EXPORT CreateEdge : public Operator
+{
+public:
+  smtkTypeMacro(CreateEdge);
+  smtkCreateMacro(CreateEdge);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+protected:
+  virtual smtk::model::OperatorResult operateInternal();
+};
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_polygon_CreateEdge_h

--- a/smtk/bridge/polygon/operators/CreateEdge.sbt
+++ b/smtk/bridge/polygon/operators/CreateEdge.sbt
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the polygon "CreateEdge" operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="create edge" BaseType="operator">
+      <BriefDescription>Create model edge(s).</BriefDescription>
+      <DetailedDescription>
+        Create one or more edges in the associated model.
+
+        Self-intersecting edges are not allowed.
+        If any edge self-intersects, then new vertices are created intersection points
+        and the edge is split at these points.
+        In this way, it is possible for specified edges
+        to be divided by this operator, resulting in an unexpected number of
+        created model edges returned.
+
+        Note that edges are not intersected with other edges (those specified here or
+        pre-existing edges in the model).
+        Any intersections between different edges are handled when faces are created.
+      </DetailedDescription>
+      <AssociationsDef Name="model" NumberOfRequiredValues="1" Extensible="yes">
+        <MembershipMask>model|cell</MembershipMask>
+        <BriefDescription>Vertices to join into an edge or the model to which edges should be added.</BriefDescription>
+        <DetailedDescription>
+          You must either (a) associate 2 or more model vertices to this
+          operator or (b) associate a model into which edges should be
+          inserted and specify points to connect into edges.
+
+          You must not specify both a model and a list of vertices.
+        </DetailedDescription>
+      </AssociationsDef>
+      <ItemDefinitions>
+        <Int Name="construction method">
+          <ChildrenDefinitions>
+            <Double Name="points" NumberOfRequiredValues="4" Extensible="yes">
+              <BriefDescription>The (x,y,z) coordinates of the edges.</BriefDescription>
+              <DetailedDescription>
+                The world coordinates of 1 or more edges.
+
+                If only 2 coordinates are specified per point, the third is assumed to be 0.
+                Be sure to set the value of the coordinates item as required.
+              </DetailedDescription>
+            </Double>
+            <Int Name="coordinates" NumberOfRequiredValues="1">
+              <BriefDescription>The number of coordinates per vertex.</BriefDescription>
+              <DetailedDescription>
+                When specifying coordinates for more than 1 vertex,
+                this dictates how values are passed.
+                When set to 2, the third coordinate is assumed to be 0 for all points.
+              </DetailedDescription>
+              <RangeInfo>
+                <Min Inclusive="true">2</Min>
+                <Max Inclusive="true">3</Max>
+              </RangeInfo>
+            </Int>
+            <Int Name="offsets" NumberOfRequiredValues="1" Extensible="true">
+              <DefaultValue>0</DefaultValue>
+              <BriefDescription>Offsets into the list of points or vertices where each edge starts.</BriefDescription>
+              <DetailedDescription>
+                Offsets into the list of points or vertices where each edge starts.
+
+                When "points" are specified, each offset value is multiplied by the value of "coordinates".
+                Thus, regardless of whether "points" or "vertices" are passed, one would specify
+                offsets equal to "[0, 3, 5]" to indicate the first edge has 3 vertices,
+                the second edge has 2 vertices, and a third edge exists at the end of these two.
+              </DetailedDescription>
+            </Int>
+          </ChildrenDefinitions>
+          <DiscreteInfo DefaultIndex="0">
+            <!-- Option 0: points, coordinates, and offsets -->
+            <Structure>
+              <Value Enum="point coordinates">0</Value>
+              <Items>
+                <Item>points</Item>
+                <Item>coordinates</Item>
+                <Item>offsets</Item>
+              </Items>
+            </Structure>
+            <Structure>
+              <Value Enum="vertex ids">0</Value>
+              <Items>
+                <!-- vertices are associated with the operator in this case -->
+                <Item>offsets</Item>
+              </Items>
+            </Structure>
+          </DiscreteInfo>
+        </Int>
+      </ItemDefinitions>
+    </AttDef>
+    <!-- Result -->
+    <AttDef Type="result(create edge)" BaseType="result">
+      <ItemDefinitions>
+        <!-- The edges created are reported in the base result's "created" item. -->
+      </ItemDefinitions>
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeSystem>

--- a/smtk/bridge/polygon/operators/CreateFaces.cxx
+++ b/smtk/bridge/polygon/operators/CreateFaces.cxx
@@ -1,0 +1,130 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#include "smtk/bridge/polygon/operators/CreateFaces.h"
+
+#include "smtk/bridge/polygon/Session.h"
+#include "smtk/bridge/polygon/internal/Model.h"
+
+#include "smtk/io/Logger.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/DoubleItem.h"
+#include "smtk/attribute/IntItem.h"
+#include "smtk/attribute/ModelEntityItem.h"
+#include "smtk/attribute/StringItem.h"
+
+#include "smtk/bridge/polygon/CreateFaces_xml.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+smtk::model::OperatorResult CreateFaces::operateInternal()
+{
+  // Discover how the user wants to specify scaling.
+  smtk::attribute::IntItem::Ptr constructionMethodItem = this->findInt("construction method");
+  int method = constructionMethodItem->discreteIndex(0);
+
+  smtk::attribute::DoubleItem::Ptr pointsItem = this->findDouble("points");
+  smtk::attribute::IntItem::Ptr coordinatesItem = this->findInt("coordinates");
+  smtk::attribute::IntItem::Ptr offsetsItem = this->findInt("offsets");
+
+  smtk::attribute::ModelEntityItem::Ptr edgesItem = this->findModelEntity("edges");
+
+  smtk::attribute::ModelEntityItem::Ptr modelItem = this->specification()->associations();
+
+  internal::pmodel::Ptr storage; // Look up from session = internal::pmodel::create();
+  bool ok = true;
+  // These case values match CreateFaces.sbt indices (and enum values):
+  switch (method)
+    {
+  case 0: // points, coordinates, offsets
+      {
+      // create holes (as specified by offsets)
+      // create polygon_with_holes
+      //   make sure to *not* generate keyhole edges
+      // traverse resulting polygon
+      //   identify pre-existing edges and split them as required?
+      }
+    break;
+  case 1: // edges, offsets
+      {
+      // create holes
+      // create polygon_with_holes
+      //   make sure to *not* generate keyhole edges
+      // traverse resulting polygon
+      //   identify pre-existing edges and split them as required?
+      }
+    break;
+  case 2: // all non-overlapping
+      {
+      // Create a union-find struct
+      // for each "model" vertex
+      //   for each edge attached to each vertex
+      //     add 2 union-find entries (UFEs), 1 per co-edge
+      //     merge adjacent pairs of UFEs
+      //     store UFEs on edges
+      // For each loop, discover nestings and merge UFEs
+      // For each edge
+      //   For each unprocessed (nesting-wise) UFE
+      //     Discover nesting via ray test
+      //     Merge parent and child UFEs (if applicable)
+      //     Add an (edge, coedge sign) tuple to a "face" identified by the given UFE
+      // FIXME: Test for self-intersections?
+      // FIXME: Deal w/ pre-existing faces?
+      }
+    break;
+  default:
+    ok = false;
+    smtkInfoMacro(log(), "Unhandled construction method " << method << ".");
+    break;
+    }
+
+  smtk::model::OperatorResult result;
+  /*
+  if (ok)
+    {
+    smtk::bridge::polygon::Session* sess = this->polygonSession();
+    smtk::model::Manager::Ptr mgr;
+    if (sess)
+      {
+      mgr = sess->manager();
+      smtk::model::Model model = mgr->addModel(/ * par. dim. * / 2, / * emb. dim. * / 3, "model");
+      storage->setId(model.entity());
+      result = this->createResult(smtk::model::OPERATION_SUCCEEDED);
+      this->addEntityToResult(result, model, CREATED);
+      model.setFloatProperty("x axis", smtk::model::FloatList(storage->xAxis(), storage->xAxis() + 3));
+      model.setFloatProperty("y axis", smtk::model::FloatList(storage->yAxis(), storage->yAxis() + 3));
+      model.setFloatProperty("normal", smtk::model::FloatList(storage->zAxis(), storage->zAxis() + 3));
+      model.setFloatProperty("origin", smtk::model::FloatList(storage->origin(), storage->origin() + 3));
+      model.setFloatProperty("feature size", storage->featureSize());
+      model.setIntegerProperty("model scale", storage->modelScale());
+      }
+    }
+  */
+  if (!result)
+    {
+    result = this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  return result;
+}
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+smtkImplementsModelOperator(
+  SMTKPOLYGONSESSION_EXPORT,
+  smtk::bridge::polygon::CreateFaces,
+  polygon_create_faces,
+  "create faces",
+  CreateFaces_xml,
+  smtk::bridge::polygon::Session);

--- a/smtk/bridge/polygon/operators/CreateFaces.h
+++ b/smtk/bridge/polygon/operators/CreateFaces.h
@@ -1,0 +1,38 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_session_polygon_CreateFaces_h
+#define __smtk_session_polygon_CreateFaces_h
+
+#include "smtk/bridge/polygon/Operator.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+/**\brief Create a face given a set of point coordinates or edges (but not both).
+  *
+  */
+class SMTKPOLYGONSESSION_EXPORT CreateFaces : public Operator
+{
+public:
+  smtkTypeMacro(CreateFaces);
+  smtkCreateMacro(CreateFaces);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+protected:
+  virtual smtk::model::OperatorResult operateInternal();
+};
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_polygon_CreateFaces_h

--- a/smtk/bridge/polygon/operators/CreateFaces.sbt
+++ b/smtk/bridge/polygon/operators/CreateFaces.sbt
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the polygon "CreateFaces" operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="create faces" BaseType="operator">
+      <BriefDescription>Create model faces.</BriefDescription>
+      <DetailedDescription>
+        Create one or more faces in the given model.
+
+        Faces with intersecting edges will cause new (split) edges to be created
+        and used in place of those specifying the face.
+      </DetailedDescription>
+      <AssociationsDef Name="model" NumberOfRequiredValues="1">
+        <MembershipMask>model</MembershipMask>
+        <BriefDescription>The model to which faces should be added.</BriefDescription>
+        <DetailedDescription>
+          The model to which faces should be added.
+
+          This is required in order to project point coordinates into
+          the model plane properly and perform intersection tests.
+        </DetailedDescription>
+      </AssociationsDef>
+      <ItemDefinitions>
+        <Int Name="construction method">
+          <ChildrenDefinitions>
+            <Double Name="points" NumberOfRequiredValues="6" Extensible="yes">
+              <BriefDescription>The (x,y,z) coordinates of the face points.</BriefDescription>
+              <DetailedDescription>
+                The world coordinates of 3 or more points forming 1 or more faces.
+                Multiple faces may be created by specifying "offsets".
+                If the default offsets are used, all points are assumed to be
+                on the outer loop of a single face.
+
+                If only 2 coordinates are specified per point, the third is assumed to be 0.
+                Be sure to set the value of the coordinates item as required.
+              </DetailedDescription>
+            </Double>
+            <Int Name="coordinates" NumberOfRequiredValues="1">
+              <BriefDescription>The number of coordinates per vertex.</BriefDescription>
+              <DetailedDescription>
+                Specify whether 2 or 3 coordinates are provided per vertex.
+                When set to 2, the third coordinate is assumed to be 0 for all points.
+              </DetailedDescription>
+              <DefaultValue>2</DefaultValue>
+              <RangeInfo>
+                <Min Inclusive="true">2</Min>
+                <Max Inclusive="true">3</Max>
+              </RangeInfo>
+            </Int>
+            <ModelEntity Name="edges" NumberOfRequiredValues="1" Extensible="true">
+              <BriefDescription>The edges defining the boundary of the model face(s).</BriefDescription>
+              <DetailedDescription>
+                By default, all edges create a single face.
+                The first edge passed for each face must be on the outer loop of the face.
+                All other loops are considered holes.
+                If offsets are specified, then multiple disjoint faces will be created.
+              </DetailedDescription>
+            </ModelEntity>
+            <Int Name="offsets" NumberOfRequiredValues="1" Extensible="true">
+              <DefaultValue>0</DefaultValue>
+              <BriefDescription>Offsets into the list of points or edges where each face and its holes start.</BriefDescription>
+              <DetailedDescription>
+                Offsets into the list of points or edges where each face and its holes start.
+
+                The first number specifies an offset into the list of points or edges
+                for the first face's outer loop.
+                This is followed by the number of holes for the face, followed by an
+                integer offset for each hole relative to the start of the face.
+                The pattern can be repeated for additional faces.
+
+                An example would be [0, 0,  3, 2, 2, 4,  10, 0].
+                This example corresponds to 3 faces.
+                The first face has 3 edges in its outer loop and no holes.
+                The second face has 2 edges in its outer loop and 2 holes: one hole with 2 edges and another with 3 edges.
+                The third face has no holes and uses the remainder of the edges in its outer loop.
+
+                When "points" are specified instead of "edges",
+                offset values (except values specifying the number of holes)
+                are internally multiplied by the value of "coordinates".
+                (Offsets should count the number of points, not coordinates.)
+              </DetailedDescription>
+            </Int>
+          </ChildrenDefinitions>
+          <DiscreteInfo DefaultIndex="0">
+            <!-- Option 0: points, coordinates, and offsets -->
+            <Structure>
+              <Value Enum="point coordinates">0</Value>
+              <Items>
+                <Item>points</Item>
+                <Item>coordinates</Item>
+                <Item>offsets</Item>
+              </Items>
+            </Structure>
+            <!-- Option 1: edges and offsets -->
+            <Structure>
+              <Value Enum="edge ids">1</Value>
+              <Items>
+                <Item>edges</Item>
+                <Item>offsets</Item>
+              </Items>
+            </Structure>
+            <!-- Option 2: all possible faces -->
+            <Structure>
+              <Value Enum="all non-overlapping faces">2</Value>
+              <Items/>
+            </Structure>
+          </DiscreteInfo>
+        </Int>
+      </ItemDefinitions>
+    </AttDef>
+    <!-- Result -->
+    <AttDef Type="result(create faces)" BaseType="result">
+      <ItemDefinitions>
+        <!-- The faces created are reported in the base result's "created" item. -->
+      </ItemDefinitions>
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeSystem>

--- a/smtk/bridge/polygon/operators/CreateModel.cxx
+++ b/smtk/bridge/polygon/operators/CreateModel.cxx
@@ -1,0 +1,120 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#include "smtk/bridge/polygon/operators/CreateModel.h"
+
+#include "smtk/bridge/polygon/Session.h"
+#include "smtk/bridge/polygon/internal/Model.h"
+
+#include "smtk/io/Logger.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/DoubleItem.h"
+#include "smtk/attribute/IntItem.h"
+#include "smtk/attribute/ModelEntityItem.h"
+#include "smtk/attribute/StringItem.h"
+
+#include "smtk/bridge/polygon/CreateModel_xml.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+smtk::model::OperatorResult CreateModel::operateInternal()
+{
+  // Discover how the user wants to specify scaling.
+  smtk::attribute::IntItem::Ptr constructionMethodItem = this->findInt("construction method");
+  int method = constructionMethodItem->discreteIndex(0);
+
+  smtk::attribute::DoubleItem::Ptr originItem = this->findDouble("origin");
+  smtk::attribute::DoubleItem::Ptr xAxisItem = this->findDouble("x axis");
+  smtk::attribute::DoubleItem::Ptr yAxisItem = this->findDouble("y axis");
+  smtk::attribute::DoubleItem::Ptr zAxisItem = this->findDouble("z axis");
+  smtk::attribute::DoubleItem::Ptr featureSizeItem = this->findDouble("feature size");
+  smtk::attribute::IntItem::Ptr modelScaleItem = this->findInt("model scale");
+
+  internal::pmodel::Ptr storage = internal::pmodel::create();
+  bool ok = true;
+  // These case values match CreateModel.sbt indices (and enum values):
+  switch (method)
+    {
+  case 0: // origin, 2 axes, and feature size
+      {
+      std::vector<double> origin(originItem->begin(), originItem->end());
+      std::vector<double> x_axis(xAxisItem->begin(), xAxisItem->end());
+      std::vector<double> y_axis(yAxisItem->begin(), yAxisItem->end());
+      ok = storage->computeModelScaleAndNormal(
+        origin, x_axis, y_axis, featureSizeItem->value(0), this->log());
+      }
+    break;
+  case 1: // origin, normal, x axis, and feature size
+      {
+      std::vector<double> origin(originItem->begin(), originItem->end());
+      std::vector<double> x_axis(xAxisItem->begin(), xAxisItem->end());
+      std::vector<double> z_axis(zAxisItem->begin(), zAxisItem->end());
+      ok = storage->computeModelScaleAndYAxis(
+        origin, x_axis, z_axis, featureSizeItem->value(0), this->log());
+      }
+    break;
+  case 2: // origin, 2 axes, and model scale
+      {
+      std::vector<double> origin(originItem->begin(), originItem->end());
+      std::vector<double> x_axis(xAxisItem->begin(), xAxisItem->end());
+      std::vector<double> y_axis(yAxisItem->begin(), yAxisItem->end());
+      ok = storage->computeFeatureSizeAndNormal(
+        origin, x_axis, y_axis, modelScaleItem->value(0), this->log());
+      }
+    break;
+  default:
+    ok = false;
+    smtkInfoMacro(log(), "Unhandled construction method " << method << ".");
+    break;
+    }
+
+  smtk::model::OperatorResult result;
+  if (ok)
+    {
+    smtk::bridge::polygon::Session* sess = this->polygonSession();
+    smtk::model::Manager::Ptr mgr;
+    if (sess)
+      {
+      mgr = sess->manager();
+      smtk::model::Model model = mgr->addModel(/* par. dim. */ 2, /* emb. dim. */ 3, "model");
+      storage->setId(model.entity());
+      storage->setSession(sess);
+      sess->addStorage(model.entity(), storage);
+      result = this->createResult(smtk::model::OPERATION_SUCCEEDED);
+      this->addEntityToResult(result, model, CREATED);
+      model.setFloatProperty("x axis", smtk::model::FloatList(storage->xAxis(), storage->xAxis() + 3));
+      model.setFloatProperty("y axis", smtk::model::FloatList(storage->yAxis(), storage->yAxis() + 3));
+      model.setFloatProperty("normal", smtk::model::FloatList(storage->zAxis(), storage->zAxis() + 3));
+      model.setFloatProperty("origin", smtk::model::FloatList(storage->origin(), storage->origin() + 3));
+      model.setFloatProperty("feature size", storage->featureSize());
+      model.setIntegerProperty("model scale", storage->modelScale());
+      }
+    }
+  if (!result)
+    {
+    result = this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  return result;
+}
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+smtkImplementsModelOperator(
+  SMTKPOLYGONSESSION_EXPORT,
+  smtk::bridge::polygon::CreateModel,
+  polygon_create_model,
+  "create model",
+  CreateModel_xml,
+  smtk::bridge::polygon::Session);

--- a/smtk/bridge/polygon/operators/CreateModel.h
+++ b/smtk/bridge/polygon/operators/CreateModel.h
@@ -1,0 +1,49 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_session_polygon_CreateModel_h
+#define __smtk_session_polygon_CreateModel_h
+
+#include "smtk/bridge/polygon/Operator.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+/**\brief Create a polygonal model made up of vertices, edges, and faces.
+  *
+  * The geometry in the model is all planar.
+  * By default, points are assumed to lie in the x-y plane with an
+  * origin of (0,0), but you may provide any base point and axes you prefer.
+  *
+  * Coordinates are discretized to integers; you must pass either a feature
+  * size or a model scale to control how fine the approximation is.
+  *
+  * Each polygonal modeling session may have multiple models but no
+  * geometric entities may be shared between them;
+  * attempting to share points across different discretizations on different
+  * projected planes would be error-prone at best.
+  */
+class SMTKPOLYGONSESSION_EXPORT CreateModel : public Operator
+{
+public:
+  smtkTypeMacro(CreateModel);
+  smtkCreateMacro(CreateModel);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+protected:
+  virtual smtk::model::OperatorResult operateInternal();
+};
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_polygon_CreateModel_h

--- a/smtk/bridge/polygon/operators/CreateModel.sbt
+++ b/smtk/bridge/polygon/operators/CreateModel.sbt
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the Polygon "CreateModel" Operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="create model" BaseType="operator">
+      <BriefDescription>Create a planar model.</BriefDescription>
+      <DetailedDescription>
+        Create a model given a set of coordinate axes in 3D and a minimum feature size.
+      </DetailedDescription>
+      <ItemDefinitions>
+        <Int Name="construction method">
+          <ChildrenDefinitions>
+            <Double Name="origin" NumberOfRequiredValues="3" Optional="true">
+              <DefaultValue>0., 0., 0.</DefaultValue>
+              <BriefDescription>The base point (origin) of the model in 3D world coordinates.</BriefDescription>
+              <DetailedDescription>
+                This vector specifies where the model's origin lies in 3D.
+                The x axis and y axis properties specify the planar coordinate system eminating from the origin.
+              </DetailedDescription>
+            </Double>
+            <Double Name="x axis" NumberOfRequiredValues="3" Optional="true">
+              <DefaultValue>1., 0., 0.</DefaultValue>
+              <BriefDescription>Direction and length of planar unit-length x-axis in world coordinates.</BriefDescription>
+              <DetailedDescription>
+                The direction along which x varies in the planar model.
+                This vector may not be zero.
+
+                The length of this vector is ignored when _feature size_ is specified.
+                When _model scale_ is specified instead of _feature size_, then the length of this
+                vector in 3D corresponds to _model scale_ units in the planar model.
+              </DetailedDescription>
+            </Double>
+            <Double Name="y axis" NumberOfRequiredValues="3" Optional="true">
+              <DefaultValue>0., 1., 0.</DefaultValue>
+              <BriefDescription>Direction and length of planar unit-length y-axis in world coordinates.</BriefDescription>
+              <DetailedDescription>
+                The direction along which y varies in the planar model.
+                This vector may not be zero.
+
+                The length of this vector is ignored when _feature size_ is specified.
+                When _model scale_ is specified instead of _feature size_, then the length of this
+                vector in 3D corresponds to _model scale_ units in the planar model.
+              </DetailedDescription>
+            </Double>
+            <Double Name="z axis" NumberOfRequiredValues="3" Optional="true">
+              <DefaultValue>0., 0., 1.</DefaultValue>
+              <BriefDescription>Normal to the model plane in world coordinates.</BriefDescription>
+              <DetailedDescription>
+                The direction perpendicular to the planar model.
+                This vector may not be zero but need not be normalized.
+              </DetailedDescription>
+            </Double>
+            <Double Name="feature size" NumberOfRequiredValues="1">
+              <DefaultValue>1e-8</DefaultValue>
+              <BriefDescription>The smallest resolvable edge length in world coordinates.</BriefDescription>
+              <DetailedDescription>
+                This is the smallest world-coordinate edge length that you wish
+                resolved across all edges in a model.
+
+                It is **not** a guarantee that vertices closer than this
+                distance will be snapped together.
+                It is **not** a guarantee that edges must always be longer than this.
+                It **is** a guarantee that vertices further apart than the feature size
+                and edges longer than the feature size will be properly resolved.
+
+                This is not equivalent to a difference of 1 in the integer
+                coordinate system used by the modeling session as then
+                intersection points along short (but not feature-sized or
+                smaller) lines would have unacceptable chord errors.
+              </DetailedDescription>
+            </Double>
+            <Int Name="model scale" NumberOfRequiredValues="1">
+              <DefaultValue>231000</DefaultValue>
+              <BriefDescription>The denominator .</BriefDescription>
+              <DetailedDescription>
+                The length along which the associated entities should be swept.
+
+                This parameter is optional.
+                If unspecified or set to zero,
+                the sweep distance is determined by the length of the
+                "extrusion direction" item
+                (or fails when the "extrusion direction" is ill-defined).
+              </DetailedDescription>
+            </Int>
+          </ChildrenDefinitions>
+          <DiscreteInfo DefaultIndex="0">
+            <!-- Option 0: base point, x-axis, y-axis, and feature size -->
+            <Structure>
+              <Value Enum="origin, 2 axes, and feature size">0</Value>
+              <Items>
+                <Item>origin</Item>
+                <Item>x axis</Item>
+                <Item>y axis</Item>
+                <Item>feature size</Item>
+              </Items>
+            </Structure>
+            <!-- Option 1: base point, x-axis, y-axis, and feature size -->
+            <Structure>
+              <Value Enum="origin, normal, x axis, and feature size">1</Value>
+              <Items>
+                <Item>origin</Item>
+                <Item>x axis</Item>
+                <Item>z axis</Item>
+                <Item>feature size</Item>
+              </Items>
+            </Structure>
+            <!-- Option 2: base point, x-axis, y-axis, and integer divisor -->
+            <Structure>
+              <Value Enum="origin, 2 axes, and model scale">1</Value>
+              <Items>
+                <Item>origin</Item>
+                <Item>x axis</Item>
+                <Item>y axis</Item>
+                <Item>model scale</Item>
+              </Items>
+            </Structure>
+          </DiscreteInfo>
+        </Int>
+      </ItemDefinitions>
+    </AttDef>
+    <!-- Result -->
+    <AttDef Type="result(create model)" BaseType="result">
+      <ItemDefinitions>
+        <!-- The created model is returned in the base result's "created" item. -->
+      </ItemDefinitions>
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeSystem>

--- a/smtk/bridge/polygon/operators/CreateVertices.cxx
+++ b/smtk/bridge/polygon/operators/CreateVertices.cxx
@@ -1,0 +1,80 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#include "smtk/bridge/polygon/operators/CreateVertices.h"
+
+#include "smtk/bridge/polygon/Session.h"
+#include "smtk/bridge/polygon/internal/Model.h"
+
+#include "smtk/io/Logger.h"
+
+#include "smtk/model/Vertex.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/DoubleItem.h"
+#include "smtk/attribute/IntItem.h"
+#include "smtk/attribute/ModelEntityItem.h"
+#include "smtk/attribute/StringItem.h"
+
+#include "smtk/bridge/polygon/CreateVertices_xml.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+smtk::model::OperatorResult CreateVertices::operateInternal()
+{
+  smtk::attribute::DoubleItem::Ptr pointsItem = this->findDouble("points");
+  smtk::attribute::IntItem::Ptr coordinatesItem = this->findInt("coordinates");
+  int numCoordsPerPt = coordinatesItem->value(0);
+  numCoordsPerPt =
+    (numCoordsPerPt < 2 ? 2 :
+     (numCoordsPerPt > 3 ? 3 :
+      numCoordsPerPt));
+
+  smtk::attribute::ModelEntityItem::Ptr modelItem = this->specification()->associations();
+
+  smtk::bridge::polygon::Session* sess = this->polygonSession();
+  smtk::model::OperatorResult result;
+  if (sess)
+    {
+    smtk::model::Manager::Ptr mgr = sess->manager();
+    smtk::model::Model model = modelItem->value(0);
+    internal::pmodel::Ptr storage =
+      sess->findStorage<internal::pmodel>(
+        model.entity());
+    std::vector<double> pcoords(pointsItem->begin(), pointsItem->end());
+    smtk::model::Vertices verts =
+      storage->findOrAddModelVertices(mgr, pcoords, numCoordsPerPt);
+    result = this->createResult(smtk::model::OPERATION_SUCCEEDED);
+    this->addEntitiesToResult(result, verts, CREATED);
+    for (smtk::model::Vertices::const_iterator it = verts.begin(); it != verts.end(); ++it)
+      { // Add raw relationships from model to/from vertex:
+      model.addCell(*it);
+      }
+    }
+  if (!result)
+    {
+    result = this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  return result;
+}
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+smtkImplementsModelOperator(
+  SMTKPOLYGONSESSION_EXPORT,
+  smtk::bridge::polygon::CreateVertices,
+  polygon_create_vertices,
+  "create vertices",
+  CreateVertices_xml,
+  smtk::bridge::polygon::Session);

--- a/smtk/bridge/polygon/operators/CreateVertices.h
+++ b/smtk/bridge/polygon/operators/CreateVertices.h
@@ -1,0 +1,38 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_session_polygon_CreateVertices_h
+#define __smtk_session_polygon_CreateVertices_h
+
+#include "smtk/bridge/polygon/Operator.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+/**\brief Create a face given a set of point coordinates or edges (but not both).
+  *
+  */
+class SMTKPOLYGONSESSION_EXPORT CreateVertices : public Operator
+{
+public:
+  smtkTypeMacro(CreateVertices);
+  smtkCreateMacro(CreateVertices);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+protected:
+  virtual smtk::model::OperatorResult operateInternal();
+};
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_polygon_CreateVertices_h

--- a/smtk/bridge/polygon/operators/CreateVertices.sbt
+++ b/smtk/bridge/polygon/operators/CreateVertices.sbt
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the polygon "CreateVertices" operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="create vertices" BaseType="operator">
+      <BriefDescription>Create model vertices.</BriefDescription>
+      <DetailedDescription>
+        Create one or more vertices in the associated model.
+      </DetailedDescription>
+      <AssociationsDef Name="model" NumberOfRequiredValues="1">
+        <MembershipMask>model</MembershipMask>
+        <BriefDescription>The model to which edges should be added.</BriefDescription>
+        <DetailedDescription>
+          The model to which vertices should be added.
+
+          This is required in order to project point coordinates into
+          the model plane.
+        </DetailedDescription>
+      </AssociationsDef>
+      <ItemDefinitions>
+        <Double Name="points" NumberOfRequiredValues="2" Extensible="yes">
+          <BriefDescription>The (x,y,z) coordinates of the vertices.</BriefDescription>
+          <DetailedDescription>
+            The world coordinates of 1 or more vertices.
+            If only 2 coordinates are specified, the third is assumed to be 0.
+
+            If more than one vertex's coordinates are given,
+            be sure to set the value of the coordinates item as required.
+          </DetailedDescription>
+        </Double>
+        <Int Name="coordinates" NumberOfRequiredValues="1">
+          <BriefDescription>The number of coordinates per vertex.</BriefDescription>
+          <DetailedDescription>
+            When specifying coordinates for more than 1 vertex,
+            this dictates how values are passed.
+            When set to 2, the third coordinate is assumed to be 0 for all points.
+          </DetailedDescription>
+          <RangeInfo>
+            <Min Inclusive="true">2</Min>
+            <Max Inclusive="true">3</Max>
+          </RangeInfo>
+        </Int>
+      </ItemDefinitions>
+    </AttDef>
+    <!-- Result -->
+    <AttDef Type="result(create vertices)" BaseType="result">
+      <ItemDefinitions>
+        <!-- The vertices created are reported in the base result's "created" item. -->
+      </ItemDefinitions>
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeSystem>

--- a/smtk/bridge/polygon/operators/SplitEdge.cxx
+++ b/smtk/bridge/polygon/operators/SplitEdge.cxx
@@ -1,0 +1,89 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#include "smtk/bridge/polygon/operators/SplitEdge.h"
+
+#include "smtk/bridge/polygon/Session.h"
+#include "smtk/bridge/polygon/internal/Model.h"
+#include "smtk/bridge/polygon/internal/Model.txx"
+
+#include "smtk/io/Logger.h"
+
+#include "smtk/model/Vertex.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/DoubleItem.h"
+#include "smtk/attribute/IntItem.h"
+#include "smtk/attribute/ModelEntityItem.h"
+#include "smtk/attribute/StringItem.h"
+
+#include "smtk/bridge/polygon/SplitEdge_xml.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+smtk::model::OperatorResult SplitEdge::operateInternal()
+{
+  smtk::bridge::polygon::Session* sess = this->polygonSession();
+  smtk::model::Manager::Ptr mgr;
+  if (!sess)
+    return this->createResult(smtk::model::OPERATION_FAILED);
+
+  mgr = sess->manager();
+
+  smtk::attribute::DoubleItem::Ptr pointItem = this->findDouble("point");
+  smtk::attribute::ModelEntityItem::Ptr edgeItem = this->specification()->associations();
+  smtk::model::Edge edgeToSplit(edgeItem->value(0));
+  if (!edgeToSplit.isValid())
+    {
+    smtkErrorMacro(this->log(),
+      "The input edge (" << edgeToSplit.entity() << ") is invalid.");
+      return this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  internal::edge::Ptr storage =
+    sess->findStorage<internal::edge>(
+      edgeToSplit.entity());
+  internal::pmodel* mod = storage->parentAs<internal::pmodel>();
+  if (!storage || !mod)
+    {
+    smtkErrorMacro(this->log(),
+      "The input edge has no storage or no parent model set.");
+    return this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  std::vector<double> point(pointItem->begin(), pointItem->end());
+  bool ok = mod->splitModelEdgeAtPoint(mgr, edgeToSplit.entity(), point);
+  smtk::model::OperatorResult opResult;
+  if (ok)
+    {
+    opResult = this->createResult(smtk::model::OPERATION_SUCCEEDED);
+    //this->addEntitiesToResult(opResult, created, CREATED);
+    }
+  else
+    {
+    smtkErrorMacro(this->log(), "Failed to split edge.");
+    opResult = this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  return opResult;
+}
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+smtkImplementsModelOperator(
+  SMTKPOLYGONSESSION_EXPORT,
+  smtk::bridge::polygon::SplitEdge,
+  polygon_split_edge,
+  "split edge",
+  SplitEdge_xml,
+  smtk::bridge::polygon::Session);

--- a/smtk/bridge/polygon/operators/SplitEdge.h
+++ b/smtk/bridge/polygon/operators/SplitEdge.h
@@ -1,0 +1,39 @@
+//=============================================================================
+// Copyright (c) Kitware, Inc.
+// All rights reserved.
+// See LICENSE.txt for details.
+//
+// This software is distributed WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE.  See the above copyright notice for more information.
+//=============================================================================
+#ifndef __smtk_session_polygon_SplitEdge_h
+#define __smtk_session_polygon_SplitEdge_h
+
+#include "smtk/bridge/polygon/Operator.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace polygon {
+
+/**\brief Create one or more edges given a set of point coordinates.
+  *
+  * Self-intersecting edges are broken into multiple non-self-intersecting edges.
+  */
+class SMTKPOLYGONSESSION_EXPORT SplitEdge : public Operator
+{
+public:
+  smtkTypeMacro(SplitEdge);
+  smtkCreateMacro(SplitEdge);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+protected:
+  virtual smtk::model::OperatorResult operateInternal();
+};
+
+    } // namespace polygon
+  } //namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_polygon_SplitEdge_h

--- a/smtk/bridge/polygon/operators/SplitEdge.sbt
+++ b/smtk/bridge/polygon/operators/SplitEdge.sbt
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the polygon "SplitEdge" operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="split edge" BaseType="operator">
+      <BriefDescription>Split a model edge at the given point.</BriefDescription>
+      <DetailedDescription>
+        Split a model edge in two at the given point.
+
+        The given point must be a non-model-vertex point of the model edge.
+        If the model edge has no model vertices, the result will be a single
+        new edge with the given point promoted to a model vertex.
+        Otherwise 2 new edges are created.
+        Regardless, the input edge is always destroyed; it is never modified.
+      </DetailedDescription>
+      <AssociationsDef Name="edge" NumberOfRequiredValues="1" Extensible="yes">
+        <MembershipMask>edge</MembershipMask>
+        <BriefDescription>The edge to split.</BriefDescription>
+        <DetailedDescription>
+          This is a model edge containing at least one point that is not a model-vertex.
+          The edge will be removed and replaced by one or two new edges whose endpoint(s)
+          are the model vertex.
+
+          When the input edge is a loop with no model vertices,
+          then the result is a new edge that has the model vertex as both endpoints;
+          otherwise, 2 new model edges will be created.
+        </DetailedDescription>
+      </AssociationsDef>
+      <ItemDefinitions>
+        <Double Name="point" NumberOfRequiredValues="2" Extensible="yes">
+          <BriefDescription>The point where the edge should be split.</BriefDescription>
+          <DetailedDescription>
+            The world coordinates of the point where the edge should be split.
+          </DetailedDescription>
+        </Double>
+      </ItemDefinitions>
+    </AttDef>
+    <!-- Result -->
+    <AttDef Type="result(split edge)" BaseType="result">
+      <ItemDefinitions>
+        <!-- The edge(s) created are reported in the base result's "created" item. -->
+        <!-- The input edge is destroyed and reported in the base result's "expunged" item. -->
+      </ItemDefinitions>
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeSystem>

--- a/smtk/bridge/polygon/plugin/CMakeLists.txt
+++ b/smtk/bridge/polygon/plugin/CMakeLists.txt
@@ -1,0 +1,23 @@
+include(${PARAVIEW_USE_FILE})
+include(ParaViewPlugins)
+
+# We need to add the current value of VTK_MODULES_DIR to the module path
+# so that when the plugins are built all the modules can be found. Otherwise,
+# modules that aren't loaded as direct dependencies of CMB modules will
+# not be found.
+list(APPEND CMAKE_MODULE_PATH "${VTK_MODULES_DIR}")
+
+add_paraview_plugin(
+  smtkPolygonSessionPlugin "1.0"
+  SERVER_SOURCES sessionInit.cxx
+)
+
+target_link_libraries(smtkPolygonSessionPlugin
+  LINK_PUBLIC
+    smtkCore
+    smtkPolygonSession
+    vtkPVServerManagerApplication
+  LINK_PRIVATE
+    vtkPVServerManagerApplicationCS
+)
+smtk_install_library(smtkPolygonSessionPlugin)

--- a/smtk/bridge/polygon/plugin/sessionInit.cxx
+++ b/smtk/bridge/polygon/plugin/sessionInit.cxx
@@ -1,0 +1,14 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+
+#include "smtk/Options.h"
+#include "smtk/AutoInit.h"
+
+smtkComponentInitMacro(smtk_polygon_session);

--- a/smtk/bridge/polygon/testing/CMakeLists.txt
+++ b/smtk/bridge/polygon/testing/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(cxx)
+
+if(SMTK_ENABLE_PYTHON_WRAPPING AND Shiboken_FOUND)
+  add_subdirectory(python)
+endif()

--- a/smtk/bridge/polygon/testing/python/CMakeLists.txt
+++ b/smtk/bridge/polygon/testing/python/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(smtkPolygonSessionPythonTests
+)
+
+# Additional tests that require SMTK_DATA_DIR
+set(smtkPolygonSessionPythonDataTests
+  polygonCreate
+  #polygonReadFile
+)
+
+foreach (test ${smtkPolygonSessionPythonTests})
+  add_test(${test}Py ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py)
+  set_tests_properties(${test}Py
+    PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${VTKPY_DIR}${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
+  )
+endforeach()
+
+if (SMTK_DATA_DIR AND EXISTS ${SMTK_DATA_DIR}/ReadMe.mkd)
+  foreach (test ${smtkPolygonSessionPythonDataTests})
+    add_test(${test}Py
+      ${PYTHON_EXECUTABLE}
+      ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py
+      -D "${SMTK_DATA_DIR}"
+    )
+    set_tests_properties(${test}Py
+      PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${VTKPY_DIR}${SHIBOKEN_SMTK_PYTHON};${LIB_ENV_VAR}"
+    )
+  endforeach()
+endif()

--- a/smtk/bridge/polygon/testing/python/polygonCreate.py
+++ b/smtk/bridge/polygon/testing/python/polygonCreate.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python
+import sys
+#=============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+#=============================================================================
+import smtk
+from smtk.simple import *
+import smtk.testing
+
+class TestPolygonCreation(smtk.testing.TestCase):
+
+  def setUp(self):
+    self.writeJSON = False
+    self.mgr = smtk.model.Manager.create()
+    sess = self.mgr.createSession('polygon')
+    brg = sess.session()
+    print sess
+    print brg
+    sess.assignDefaultName()
+    SetActiveSession(sess)
+    print '\n\n%s: type "%s" %s %s' % \
+      (sess.name(), brg.name(), sess.flagSummary(0), brg.sessionId())
+    print '  Site: %s' % (sess.site() or 'local')
+
+    # We could evaluate the session tag as JSON, but most of
+    # the information is available through methods above that
+    # we needed to test:
+    sessiontag = sess.tag()
+    print '\n'
+
+    #opnames = sess.operatorNames()
+    #print opnames
+
+  def checkModel(self, mod, origin, x_axis, y_axis, normal, feature_size, model_scale):
+
+    self.assertEqual(mod.floatProperty('origin'), origin, 'Bad origin')
+    [self.assertAlmostEqual(mod.floatProperty('x axis')[i], x_axis[i], 'Bad x axis') for i in range(3)]
+    self.assertEqual(mod.floatProperty('y axis'), y_axis, 'Bad y axis')
+    self.assertEqual(mod.floatProperty('normal'), normal, 'Bad normal')
+    self.assertEqual(mod.floatProperty('feature size'), [feature_size,], 'Bad feature size')
+    self.assertEqual(mod.integerProperty('model scale'), [int(model_scale / feature_size),], 'Bad model scale')
+
+    #print smtk.io.ExportJSON.fromModelManager(self.mgr, smtk.io.JSON_DEFAULT)
+
+    # Print a summary of the model:
+    print 'Model ', mod.entity()
+    print '  x axis  ', ('  {:.3g}'*3).format(*mod.floatProperty('x axis'))
+    print '  y axis  ', ('  {:.3g}'*3).format(*mod.floatProperty('y axis'))
+    print '  normal  ', ('  {:.3g}'*3).format(*mod.floatProperty('normal'))
+    print '  feature size  {:14.3g}'.format(mod.floatProperty('feature size')[0])
+    print '  model scale   {:14d}'.format(mod.integerProperty('model scale')[0])
+
+    # Create vertices and test that they are correct
+    # NB: 2.000000005 is chosen below since it is within 1e-8/231000 of 2.0
+    #     and thus should result in two identical points for all of the models
+    #     in testCreation().
+    testVerts = [[1,1], [2,1], [2,2,0], [1,2], [2.00000000000001, 2, 0]]
+    vlist = CreateVertices(testVerts, mod)
+    print '  Created vertices\n   ', '\n    '.join([x.name() for x in vlist])
+
+    self.assertEqual(len(vlist), 5, 'Expected 5 model vertices reported.')
+    for vi in range(len(testVerts)):
+      vert = vlist[vi]
+      vx = smtk.model.Vertex(vert).coordinates()
+      print '  {name} {x:.5f} {y:.5f} {z:.5f}'.format(
+          name=vert.name(), x=vx[0], y=vx[1], z=vx[2])
+      [self.assertAlmostEqual(vx[i], testVerts[vi][i],
+        msg='Bad vertex {vi} coordinate {i}'.format(vi=vi,i=i))
+        for i in range(2)]
+    self.assertEqual(vlist[2], vlist[4],
+        'Expected vertices with nearly-identical coordinates to be equivalent.')
+
+    # Test a simple case: a non-periodic edge of one segment
+    # whose ends must be promoted to model vertices. Note that
+    # the edge goes from right to left, so we check that the
+    # endpoints are ordered properly.
+    openEdgeTestVerts = [[4,3.5], [3,3.5]]
+    elist = CreateEdge(openEdgeTestVerts, model=mod)
+    edge = smtk.model.Edge(elist)
+    self.assertIsNotNone(edge, 'Expected a single edge.')
+    self.assertEqual(len(edge.vertices()), 2, 'Expected two vertices bounding edge.')
+    # NB. We cannot test direction of edge using order of edge.vertices() because
+    #     they will be ordered by UUID, not parameter value.
+    #     Should we start creating edge and vertex uses, plus "vertex chains",
+    #     we can then use the SMTK API to properly fetch edge direction. But
+    #     arguably, these records should not exist until edges are actually used
+    #     by a higher-dimensional entity.
+
+    # Test non-periodic edge of multiple segments whose
+    # ends must be promoted to model vertices. Note that
+    # the final segment has reversed order relative to
+    # boost.polygon's left-right, bottom-top order, so we
+    # are verifying that endpoints are computed correctly.
+    # This prevents an observed regression.
+    openEdgeTestVerts = [[3,4], [3,5], [4,5], [4,4],  [0, 1.5], [1, 2.5]]
+    openEdgeTestOffsets = [0, 4]
+    elist = CreateEdge(openEdgeTestVerts, offsets=openEdgeTestOffsets, model=mod)
+
+    # Test multiple edge insertion.
+    # Test invalid edge connectivity.
+    # Test self-intersecting edges.
+    # Test periodic edges with non-model-vertex at first point.
+    edgeTestVerts = [[0,0], [1,1], [0,1], [1,0],   [3,0], [3,3], [4,3], [2,0], [3,0], [10,10]]
+    edgeTestOffsets = [0, 4, 9, 9, 12]; # Only first 2 edges are valid
+    elist = CreateEdge(edgeTestVerts, offsets=edgeTestOffsets, model=mod)
+    # Make sure that warnings are generated for invalid edge offsets.
+    res = GetLastResult()
+    logStr = res.findString('log').value(0)
+    log = smtk.io.Logger()
+    smtk.io.ImportJSON.ofLog(logStr, log)
+    print log.convertToString()
+    self.assertEqual(
+        log.numberOfRecords(), 3,
+        'Expected 3 warnings due to invalid offsets, got\n' + log.convertToString())
+    #print elist
+
+    # Test creation of periodic edge with no model vertices.
+    # Verify that no model vertices are created.
+    periodicEdgeVerts = [[0, 4], [1, 4], [1, 5], [0, 5], [0, 4]]
+    elist = CreateEdge(periodicEdgeVerts, model=mod)
+
+    # Test creation of a second periodic edge with no model vertices
+    # but which shares a point with the previous edge.
+    # Verify that no model vertices are created.
+    # However, if the two edges are used as holes for a containing face
+    # or unioned, then the shared point should become a model vertex.
+    periodicEdgeVerts = [[1, 3], [2, 3], [2, 4], [1, 4], [1, 3]]
+    elist = CreateEdge(periodicEdgeVerts, model=mod)
+    edge = smtk.model.Edge(elist)
+    self.assertIsNotNone(edge, 'Expected a single edge.')
+    self.assertEqual(edge.vertices(), [], 'Expected no model vertices bounding edge.')
+
+    arf = SplitEdge(elist, [2, 4])
+
+    #smtk.io.ExportJSON.fromModelManagerToFile(self.mgr, '/tmp/poly.json')
+
+  def testCreation(self):
+    mod = CreateModel()
+    self.checkModel(mod, [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], 1e-8, 231000)
+
+    mod = CreateModel(x_axis=[1,0,0], y_axis=[0,1,0], model_scale=231000)
+    self.checkModel(mod, [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], 1, 231000)
+
+    mod = CreateModel(x_axis=[1,0,0], y_axis=[0,1,0], feature_size=1e-8)
+    self.checkModel(mod, [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], 1e-8, 231000)
+
+    mod = CreateModel(x_axis=[1,0,0], normal=[0,0,1], feature_size=1e-8)
+    self.checkModel(mod, [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], 1e-8, 231000)
+
+    mod = CreateModel(x_axis=[1,0,0], normal=[0,0,1], model_scale=1182720)
+    self.checkModel(mod, [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], 1, 1182720)
+
+    if self.haveVTK() and self.haveVTKExtension():
+
+      self.startRenderTest()
+
+      mod = smtk.model.Model(mod)
+      [mod.addCell(x) for x in self.mgr.findEntitiesOfType(smtk.model.CELL_ENTITY, False)]
+      ms, vs, mp, ac = self.addModelToScene(mod)
+      ac.GetProperty().SetLineWidth(2)
+      ac.GetProperty().SetPointSize(6)
+
+      cam = self.renderer.GetActiveCamera()
+      cam.SetFocalPoint(5,5,0)
+      cam.SetPosition(5,5,5)
+      cam.SetViewUp(0,1,0)
+      self.renderer.ResetCamera()
+      self.renderWindow.Render()
+      # Skip the image match if we don't have a baseline.
+      # This allows the test to succeed even on systems without the test
+      # data but requires a match on systems with the test data.
+      self.assertImageMatchIfFileExists(['baselines', 'polygon', 'creation.png'])
+      self.interact()
+
+    else:
+      self.assertFalse(
+        self.haveVTKExtension(),
+        'Could not import vtk. Python path is {pp}'.format(pp=sys.path))
+
+
+if __name__ == '__main__':
+  smtk.testing.process_arguments()
+  smtk.testing.main()

--- a/smtk/bridge/polygon/typesystem.xml
+++ b/smtk/bridge/polygon/typesystem.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<typesystem package="@TYPESYSTEM_NAME@">
+
+  @EXTRA_TYPESYSTEMS@
+
+  <!-- Ignore Shiboken notice that polygon lives inside SMTK namespace -->
+  <suppress-warning text="Duplicate type entry: 'smtk'"/>
+
+  <!-- Ignore the internal polygon namespace -->
+  <suppress-warning text="namespace 'smtk::bridge::polygon::internal' does not have a type entry"/>
+
+  <!-- Ignore miscellaneous crufty warnings -->
+  <suppress-warning text="skipping function 'smtk::bridge::polygon::Session::addStorage', unmatched parameter type 'smtk::bridge::polygon::internal::entity::Ptr'"/>
+  <suppress-warning text="skipping function 'smtk::bridge::polygon::Session::create', unmatched return type 'smtk::shared_ptr&lt;smtk::bridge::polygon::Session::SelfType&gt;'"/>
+  <suppress-warning text="skipping function 'smtk::bridge::polygon::Session::findOperatorConstructor', unmatched return type 'smtk::model::OperatorConstructor'"/>
+  <suppress-warning text="skipping function 'smtk::bridge::polygon::Session::findStorage', unmatched return type 'T::Ptr'"/>
+  <suppress-warning text="skipping function 'smtk::bridge::polygon::Session::findOrAddStorage', unmatched return type 'T'"/>
+  <suppress-warning text="skipping function 'smtk::bridge::polygon::Session::registerOperator', unmatched parameter type 'smtk::model::OperatorConstructor'"/>
+  <suppress-warning text="skipping function 'smtk::bridge::polygon::Session::registerStaticOperator', unmatched parameter type 'smtk::model::OperatorConstructor'"/>
+  <suppress-warning text="skipping function 'smtk::bridge::polygon::Session::shared_from_this', unmatched return type 'smtk::shared_ptr&lt;const smtk::bridge::polygon::Session::SelfType&gt;'"/>
+  <suppress-warning text="skipping function 'smtk::bridge::polygon::Session::shared_from_this', unmatched return type 'smtk::shared_ptr&lt;smtk::bridge::polygon::Session::SelfType&gt;'"/>
+  <suppress-warning text="skipping field 'Session::m_storage' with unmatched type 'internal::EntityIdToPtr'"/>
+  <suppress-warning text="skipping field 'Session::s_operators' with unmatched type 'std::map&lt;std::string,smtk::model::StaticOperatorInfo&gt;'"/>
+
+  <!-- Additional objects to be wrapped when building with polygon -->
+  <namespace-type name="smtk" generate = "no">
+    <namespace-type name="bridge" generate = "no">
+      <namespace-type name="polygon" generate = "yes">
+
+        <object-type name="Session">
+          <include file-name="smtk/bridge/polygon/Session.h" location="local"/>
+        </object-type>
+
+      </namespace-type>
+    </namespace-type>
+  </namespace-type>
+
+  <value-type template="smtk::shared_ptr" args="smtk::bridge::polygon::Session">
+  </value-type>
+
+  @EXTRA_OBJECTS@
+
+</typesystem>

--- a/smtk/common/UUID.h
+++ b/smtk/common/UUID.h
@@ -17,6 +17,7 @@
 #ifndef _MSC_VER
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored"-Wshadow"
+#  pragma GCC diagnostic ignored"-Wdeprecated-register"
 #endif
 #ifndef SHIBOKEN_SKIP
 #include <boost/uuid/uuid.hpp>

--- a/smtk/extension/qt/qtCheckItemComboBox.cxx
+++ b/smtk/extension/qt/qtCheckItemComboBox.cxx
@@ -132,31 +132,34 @@ void qtModelEntityItemCombo::init()
   tmpGrp.setMembershipMask(itemDef->membershipMask());
 
   int row=1;
-  for (smtk::model::UUIDWithEntity it = modelManager->topology().begin();
-      it != modelManager->topology().end(); ++it)
+  if (modelManager)
     {
+    for (smtk::model::UUIDWithEntity it = modelManager->topology().begin();
+      it != modelManager->topology().end(); ++it)
+      {
 
-    smtk::model::EntityRef entref(modelManager, it->first);
-    if (entref.isValid() && !entref.isUseEntity() &&
+      smtk::model::EntityRef entref(modelManager, it->first);
+      if (entref.isValid() && !entref.isUseEntity() &&
         // if the mask is only groups, get all groups from manager
         ((onlyGroups && entref.isGroup()) ||
-        // else, check the membership constraints
+         // else, check the membership constraints
          (!onlyGroups && tmpGrp.meetsMembershipConstraints(entref))))
-      {
-      QStandardItem* item = new QStandardItem;
-      std::string entName = entref.name();
-      item->setText(entName.c_str());
-      item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-      //item->setData(this->Internals->AttSelections[keyName], Qt::CheckStateRole);
-      item->setData(Qt::Unchecked, Qt::CheckStateRole);
-      item->setCheckable(true);
-      item->setCheckState(ModelEntityItem->has(entref) ? Qt::Checked : Qt::Unchecked);
+        {
+        QStandardItem* item = new QStandardItem;
+        std::string entName = entref.name();
+        item->setText(entName.c_str());
+        item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        //item->setData(this->Internals->AttSelections[keyName], Qt::CheckStateRole);
+        item->setData(Qt::Unchecked, Qt::CheckStateRole);
+        item->setCheckable(true);
+        item->setCheckState(ModelEntityItem->has(entref) ? Qt::Checked : Qt::Unchecked);
 
-      item->setData(entref.entity().toString().c_str(), Qt::UserRole);
-      itemModel->insertRow(row, item);
+        item->setData(entref.entity().toString().c_str(), Qt::UserRole);
+        itemModel->insertRow(row, item);
+        }
       }
+    itemModel->sort(0);
     }
-  itemModel->sort(0);
 
   connect(this->model(),
     SIGNAL(dataChanged ( const QModelIndex&, const QModelIndex&)),

--- a/smtk/extension/qt/testing/cxx/CMakeLists.txt
+++ b/smtk/extension/qt/testing/cxx/CMakeLists.txt
@@ -16,7 +16,7 @@ qt4_use_modules(browseModel Core Gui)
 target_link_libraries(browseModel smtkCore smtkCoreModelTesting smtkQtExt)
 
 #add in the attribute preview executable
-add_executable(qtAttributePreview qtAttributePreview.cxx)
+add_executable(qtAttributePreview MACOSX_BUNDLE qtAttributePreview.cxx)
 target_link_libraries(qtAttributePreview LINK_PUBLIC smtkQtExt)
 
 

--- a/smtk/io/ImportJSON.cxx
+++ b/smtk/io/ImportJSON.cxx
@@ -968,6 +968,18 @@ int ImportJSON::ofDanglingEntities(cJSON* node, ManagerPtr context)
   return 1;
 }
 
+/**\brief Append all of the entries in \a jsonStr (a string containing a JSON array of arrays) to the \a log.
+  *
+  * See the other variant for details.
+  */
+int ImportJSON::ofLog(const char* jsonStr, smtk::io::Logger& log)
+{
+  cJSON* json = cJSON_Parse(jsonStr);
+  int stat = ImportJSON::ofLog(json, log);
+  cJSON_Delete(json);
+  return stat;
+}
+
 /**\brief Append all of the entries in \a logrecordarray (an array of arrays) to the \a log.
   *
   * This returns the number of records (whether or not they were actually

--- a/smtk/io/ImportJSON.h
+++ b/smtk/io/ImportJSON.h
@@ -50,6 +50,7 @@ public:
   static int ofOperatorResult(cJSON* node, smtk::model::OperatorResult& resOut, smtk::model::RemoteOperatorPtr op);
   static int ofDanglingEntities(cJSON* node, smtk::model::ManagerPtr context);
 
+  static int ofLog(const char* jsonStr, smtk::io::Logger& log);
   static int ofLog(cJSON* logrecordarray, smtk::io::Logger& log);
 
   //write all mesh collections that have associations to a model

--- a/smtk/model/Model.h
+++ b/smtk/model/Model.h
@@ -44,6 +44,7 @@ public:
   template<typename T> T cellsAs() const;
   template<typename T> T groupsAs() const;
   template<typename T> T submodelsAs() const;
+  template<typename T> void appendCells(T& container) const;
 
   Model& addCell(const CellEntity& c);
   Model& removeCell(const CellEntity& c);
@@ -69,6 +70,7 @@ public:
 /// Return the top-level (free) cells of this model in a container of the template type.
 template<typename T> T Model::cellsAs() const
 {
+  // TODO: This could be done more efficiently without a copy.
   CellEntities tmp = this->cells();
   return T(tmp.begin(), tmp.end());
 }
@@ -76,6 +78,7 @@ template<typename T> T Model::cellsAs() const
 /// Return the top-level (free) groups of this model in a container of the template type.
 template<typename T> T Model::groupsAs() const
 {
+  // TODO: This could be done more efficiently without a copy.
   Groups tmp = this->groups();
   return T(tmp.begin(), tmp.end());
 }
@@ -83,8 +86,17 @@ template<typename T> T Model::groupsAs() const
 /// Return the child models of this model in a container of the template type.
 template<typename T> T Model::submodelsAs() const
 {
+  // TODO: This could be done more efficiently without a copy.
   Models tmp = this->submodels();
   return T(tmp.begin(), tmp.end());
+}
+
+/// Append free cells of this model to the given \a container. Only valid cells are inserted.
+template<typename T> void Model::appendCells(T& container) const
+{
+  // TODO: This could be done more efficiently without a copy.
+  CellEntities tmp = this->cells();
+  container.insert(container.end(), tmp.begin(), tmp.end());
 }
 
 /// Add all the free cells in \a container to this model.

--- a/smtk/model/Operator.h
+++ b/smtk/model/Operator.h
@@ -55,7 +55,7 @@ enum OperatorOutcome
   static std::string operatorName; \
   virtual std::string name() const { return operatorName; } \
   virtual std::string className() const; \
-  static smtk::model::OperatorPtr baseCreate();
+  static smtk::model::OperatorPtr baseCreate()
 
 /**\brief Declare that a class implements an operator for solid models.
   *

--- a/smtk/model/Session.h
+++ b/smtk/model/Session.h
@@ -111,7 +111,7 @@ public: \
   virtual std::string findOperatorXML(const std::string& opName) const; \
   virtual smtk::model::OperatorConstructor findOperatorConstructor( \
     const std::string& opName) const; \
-  virtual bool inheritsOperators() const;
+  virtual bool inheritsOperators() const
 
 /**\brief Implement methods declared by smtkDeclareOperatorRegistration().
   *
@@ -125,6 +125,7 @@ public: \
     const std::string& opName, const char* opDescrXML, \
     smtk::model::OperatorConstructor opCtor) \
   { \
+    std::cerr << "Register " << opName << " w/ " << #Cls << "\n"; \
     bool result = Cls ::registerStaticOperator(opName, opDescrXML, opCtor); \
     if (opDescrXML) \
       this->importOperatorXML(opDescrXML); \
@@ -197,7 +198,7 @@ public: \
   static std::string staticClassName(); \
   virtual std::string name() const { return sessionName; } \
   virtual std::string className() const; \
-  smtkDeclareOperatorRegistration();
+  smtkDeclareOperatorRegistration()
 
 /**\brief Declare that a class implements a session to a solid modeling kernel.
   *

--- a/smtk/model/testing/cxx/unitEntity.cxx
+++ b/smtk/model/testing/cxx/unitEntity.cxx
@@ -307,6 +307,13 @@ int TestEntityIOSpecs()
     { "vertex_use", smtk::model::VERTEX_USE },
     { "volume",     smtk::model::VOLUME },
     { "volume_use", smtk::model::VOLUME_USE },
+    // Test all the values of Entity.cxx's entityTypeNames array:
+    { "model|cell", smtk::model::MODEL_ENTITY | smtk::model::CELL_ENTITY },
+    { "use|shell",  smtk::model::SHELL_ENTITY | smtk::model::USE_ENTITY },
+    { "group|instance", smtk::model::GROUP_ENTITY | smtk::model::INSTANCE_ENTITY },
+    { "session|model", smtk::model::SESSION | smtk::model::MODEL_ENTITY },
+    { "instance|session", smtk::model::SESSION | smtk::model::INSTANCE_ENTITY },
+    { "model|shell",  smtk::model::MODEL_ENTITY | smtk::model::SHELL_ENTITY },
   };
   static int numTestToValValues = sizeof(testToValValues) / sizeof(testToValValues[0]);
   std::cout << "\nTesting Entity::specifierStringToFlag()\n\n";
@@ -362,6 +369,7 @@ int TestEntityIOSpecs()
     { "none|4",                smtk::model::DIMENSION_4 },
     { "none|014",              smtk::model::DIMENSION_0 | smtk::model::DIMENSION_1 | smtk::model::DIMENSION_4 },
     { "cell|open|0",           smtk::model::VERTEX | smtk::model::OPEN },
+    { "cell|model|nodim",      smtk::model::MODEL_ENTITY | smtk::model::CELL_ENTITY }, // > 1 entity type (e.g., membership mask)
   };
   static int numTestToSpecValues = sizeof(testToSpecValues) / sizeof(testToSpecValues[0]);
   std::cout << "\nTesting Entity::flagToSpecifierString()\n\n";

--- a/smtk/smtk/__init__.py
+++ b/smtk/smtk/__init__.py
@@ -124,6 +124,16 @@ try:
     _temp = _tempmain
 
   try:
+    _tempdis = __import__('smtkPolygonSessionPython', globals(), locals(), [], -1)
+    _temp = _tempdis
+    __import_shared_ptrs__()
+    btuple.append(('polygon', _tempdis.polygon))
+  except:
+    failed += ['polygon']
+  finally:
+    _temp = _tempmain
+
+  try:
     _tempremote = __import__('smtkRemoteSessionPython', globals(), locals(), [], -1)
     _temp = _tempremote
     __import_shared_ptrs__()

--- a/smtk/smtk/testing.py
+++ b/smtk/smtk/testing.py
@@ -177,6 +177,7 @@ class TestCase:
       ac.SetMapper(mp)
       mp.SetInputConnection(vsource.GetOutputPort())
       self.renderer.AddActor(ac)
+      return [msource, vsource, mp, ac]
 
     def addModelToScene(self, model):
         import vtkSMTKExtPython
@@ -184,8 +185,7 @@ class TestCase:
         mbs.SetModelManager(self.mgr.pointerAsString())
         mbs.SetModelEntityID(str(model.entity()))
         #mbs.ShowAnalysisTessellationOff()
-        self.addToScene(mbs)
-        return mbs
+        return self.addToScene(mbs)
 
     def interactive(self):
         """Return false if the test should exit at completion."""

--- a/smtk/typesystem.xml
+++ b/smtk/typesystem.xml
@@ -48,9 +48,10 @@
   <suppress-warning text="skipping function 'smtk::model::EntityRef::instances', unmatched return type 'T'"/>
   <suppress-warning text="skipping function 'smtk::model::EntityRef::removeMemberEntities', unmatched parameter type 'T'"/>
   <suppress-warning text="skipping function 'smtk::model::EntityRef::addMemberEntities', unmatched parameter type 'T'"/>
+  <suppress-warning text="skipping function 'smtk::model::EntityRef::relationsAs', unmatched return type 'T'"/>
   <suppress-warning text="skipping function 'smtk::model::Group::addEntities', unmatched parameter type 'T const&amp;'"/>
   <suppress-warning text="skipping function 'smtk::model::Model::addSubmodels', unmatched parameter type 'T const&amp;'"/>
-  <suppress-warning text="skipping function 'smtk::model::EntityRef::relationsAs', unmatched return type 'T'"/>
+  <suppress-warning text="skipping function 'smtk::model::Model::appendCells', unmatched parameter type 'T&amp;'"/>
   <suppress-warning text="skipping function 'smtk::model::Model::removeSubmodels', unmatched parameter type 'T const&amp;'"/>
   <suppress-warning text="skipping function 'smtk::model::Model::removeGroups', unmatched parameter type 'T const&amp;'"/>
   <suppress-warning text="skipping function 'smtk::model::Model::removeCells', unmatched parameter type 'T const&amp;'"/>
@@ -1498,6 +1499,15 @@
       <value-type name="Vertex" hash-function="smtk::model::entityrefHash">
         <include file-name="smtk/model/Vertex.h" location="local"/>
         <modify-function signature="isValid(smtk::model::Entity**) const" remove="all"/>
+        <add-function
+          signature="coordinates()" static="no"
+          return-type="std::vector&lt; double &gt;">
+          <inject-code>
+            const double* x = %CPPSELF->coordinates();
+            std::vector&lt; double &gt; result(x, x + 3);
+            return %CONVERTTOPYTHON[ std::vector&lt; double &gt; ](result);
+          </inject-code>
+        </add-function>
       </value-type>
 
       <value-type name="VertexUse" hash-function="smtk::model::entityrefHash">

--- a/thirdparty/moab/src/DualTool.cpp
+++ b/thirdparty/moab/src/DualTool.cpp
@@ -1536,7 +1536,9 @@ ErrorCode DualTool::atomic_pillow(EntityHandle odedge, EntityHandle &quad1,
   result = mbImpl->create_element(MBHEX, &tmp_verts[0], 8, new_hexes[1]); RR;
 
     // set the global id tag on the new hexes
-  int new_hex_ids[2] = {++maxHexId, ++maxHexId};
+  int new_hex_ids[2];
+  for (int ix = 0; ix < 2; ++ix)
+    new_hex_ids[ix] = ++maxHexId;
   result = mbImpl->tag_set_data(globalId_tag(), new_hexes, 2, new_hex_ids);
   if (MB_SUCCESS != result) return result;
 

--- a/thirdparty/moab/src/TupleList.cpp
+++ b/thirdparty/moab/src/TupleList.cpp
@@ -342,7 +342,7 @@ int TupleList::find(unsigned int key_num, ulong value)
 
 int TupleList::find(unsigned int key_num, realType value)
 {
-  if (!key_num > mr)
+  if (!(key_num > mr))
   {
     // Sequential search: TupleList cannot be sorted by reals
     for (uint index = 0; index < n; index++)


### PR DESCRIPTION
New Modeling Kernel
-------------------

This commit adds a new modeling kernel based on [Boost.polygon](http://www.boost.org/doc/libs/1_58_0/libs/polygon/doc/index.htm). It currently supports a very limited set of operations:

+ Creation a model.
+ Creation of model vertices.
+ Creation of model edges.

Internally, an edge split operation is provided but not yet exposed.

Miscellany
----------

+ Fix a bug in attribute association.
  Because model entity items in attributes may have a membership mask,
  calling `setValue()` does not guarantee that the association will
  occur. Return the proper boolean or infinite recursion will occur
  inside `Attribute::associateEntity()`.
+ Add a Python-callable variant of ImportJSON::ofLog.
+ Have `smtk.simple` hang on to operator results so that scripts can access them if they need to. 
+ Fix error log printout in `smtk.simple` API.
+ Have python test `addToScene()` method return pipeline objects.