### PR TITLE
polygon: install Python module to the right place

### DIFF
--- a/smtk/bridge/polygon/CMakeLists.txt
+++ b/smtk/bridge/polygon/CMakeLists.txt
@@ -56,6 +56,7 @@ if(SMTK_ENABLE_PYTHON_WRAPPING AND Shiboken_FOUND)
 
   # Extract the headers from polygon library we built to give them to shiboken
   sbk_wrap_library(smtkPolygonSession
+    PACKAGE smtk
     GENERATOR_ARGS --avoid-protected-hack
     WORKING_DIRECTORY ${SMTK_SOURCE_DIR}/smtk
     LOCAL_INCLUDE_DIRECTORIES


### PR DESCRIPTION
---
@vibraphone @robertmaynard Should also go into `release-v1`.