### PR TITLE
Allow overrides of widgets used to present Items of Attributes; expand Exodus session

### DIFF
--- a/smtk/bridge/exodus/CMakeLists.txt
+++ b/smtk/bridge/exodus/CMakeLists.txt
@@ -9,6 +9,7 @@ set(exodusSrcs
   SessionExodusIOJSON.cxx
   Operator.cxx
   ReadOperator.cxx
+  WriteOperator.cxx
 )
 
 set(exodusHeaders
@@ -16,6 +17,7 @@ set(exodusHeaders
   SessionExodusIOJSON.h
   Operator.h
   ReadOperator.h
+  WriteOperator.h
 )
 
 install(FILES PointerDefs.h DESTINATION include/smtk/${SMTK_VERSION}/smtk/bridge/exodus)
@@ -56,6 +58,7 @@ smtk_install_library(smtkExodusSession)
 # to exodusOperatorXML) since the operators themselves include
 # the header in their implementations.
 smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/ReadOperator.sbt" exodusOperatorXML)
+smtk_operator_xml("${CMAKE_CURRENT_SOURCE_DIR}/WriteOperator.sbt" exodusOperatorXML)
 smtk_session_json("${CMAKE_CURRENT_SOURCE_DIR}/Session.json" exodusSessionJSON)
 
 # Install the headers

--- a/smtk/bridge/exodus/CMakeLists.txt
+++ b/smtk/bridge/exodus/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(smtkExodusSession
     vtkIOExodus
     vtkIONetCDF
     vtkIOXML
+    vtkImagingCore
     vtkFiltersGeneral
     vtkIOParallelExodus
     vtkFiltersGeometry

--- a/smtk/bridge/exodus/CMakeLists.txt
+++ b/smtk/bridge/exodus/CMakeLists.txt
@@ -29,6 +29,8 @@ target_link_libraries(smtkExodusSession
   LINK_PRIVATE
     vtkIOExodus
     vtkIONetCDF
+    vtkIOXML
+    vtkFiltersGeneral
     vtkIOParallelExodus
     vtkFiltersGeometry
     vtkCommonDataModel

--- a/smtk/bridge/exodus/ReadOperator.cxx
+++ b/smtk/bridge/exodus/ReadOperator.cxx
@@ -33,6 +33,7 @@
 #include "vtkUnsignedCharArray.h"
 #include "vtkImageData.h"
 #include "vtkStringArray.h"
+#include "vtkTypeInt32Array.h"
 #include "vtkInformation.h"
 #include "vtkUnstructuredGrid.h"
 
@@ -317,6 +318,19 @@ int DiscoverLabels(vtkDataSet* obj, std::string& labelname, std::set<double>& la
       labelArray = dsa->GetScalars();
       }
     }
+  if (!labelArray || !vtkTypeInt32Array::SafeDownCast(labelArray))
+    {
+    int numArrays = dsa->GetNumberOfArrays();
+    for (int i = 0; i < numArrays; ++i)
+      {
+      if (vtkTypeInt32Array::SafeDownCast(dsa->GetArray(i)))
+        {
+        labelArray = dsa->GetArray(i);
+        std::cout << "Found labels: \"" << labelArray->GetName() << "\"\n";
+        break;
+        }
+      }
+    }
 
   if (!labelArray)
     { // No scalars or array of the given name? Create one.
@@ -413,6 +427,7 @@ smtk::model::OperatorResult ReadOperator::readLabelMap()
     brdg->addModel(modelOut);
   smtkModelOut.setStringProperty("url", filename);
   smtkModelOut.setStringProperty("type", "label map");
+  smtkModelOut.setStringProperty("label array", labelname);
 
   // Now set model for session and transcribe everything.
   smtk::model::OperatorResult result = this->createResult(

--- a/smtk/bridge/exodus/ReadOperator.cxx
+++ b/smtk/bridge/exodus/ReadOperator.cxx
@@ -23,10 +23,18 @@
 
 #include "vtkExodusIIReader.h"
 #include "vtkSLACReader.h"
+#include "vtkXMLImageDataReader.h"
+#include "vtkContourFilter.h"
+#include "vtkThreshold.h"
 #include "vtkFieldData.h"
 #include "vtkDataArray.h"
+#include "vtkDataSetAttributes.h"
+#include "vtkPointData.h"
+#include "vtkUnsignedCharArray.h"
+#include "vtkImageData.h"
 #include "vtkStringArray.h"
 #include "vtkInformation.h"
+#include "vtkUnstructuredGrid.h"
 
 #include "boost/filesystem.hpp"
 
@@ -53,6 +61,8 @@ smtk::model::OperatorResult ReadOperator::operateInternal()
     std::string ext = path(filename).extension().string();
     if (ext == ".nc" || ext == ".ncdf")
       filetype = "slac";
+    else if (ext == ".vti")
+      filetype = "label map";
     else if (ext == ".exo" || ext == ".g" || ext == ".ex2" || ext == ".exii")
       filetype = "exodus";
     }
@@ -62,6 +72,8 @@ smtk::model::OperatorResult ReadOperator::operateInternal()
 
   if (filetype == "slac")
     return this->readSLAC();
+  else if (filetype == "label map")
+    return this->readLabelMap();
 
   // The default is to assume it is an Exodus file:
   return this->readExodus();
@@ -265,6 +277,142 @@ smtk::model::OperatorResult ReadOperator::readSLAC()
     brdg->addModel(modelOut);
   smtkModelOut.setStringProperty("url", filename);
   smtkModelOut.setStringProperty("type", "slac");
+
+  // Now set model for session and transcribe everything.
+  smtk::model::OperatorResult result = this->createResult(
+    smtk::model::OPERATION_SUCCEEDED);
+  smtk::attribute::ModelEntityItem::Ptr resultModels =
+    result->findModelEntity("model");
+  resultModels->setValue(smtkModelOut);
+  smtk::attribute::ModelEntityItem::Ptr created =
+    result->findModelEntity("created");
+  created->setNumberOfValues(1);
+  created->setValue(smtkModelOut);
+  created->setIsEnabled(true);
+
+  return result;
+}
+
+int DiscoverLabels(vtkDataSet* obj, std::string& labelname, std::set<double>& labelSet)
+{
+  if (!obj)
+    return 0;
+
+  vtkDataSetAttributes* dsa = obj->GetPointData();
+  vtkIdType card = obj->GetNumberOfPoints();
+
+  if (card < 1 || !dsa)
+    return 0;
+
+  vtkDataArray* labelArray;
+  if (labelname.empty())
+    {
+    labelArray = dsa->GetScalars();
+    }
+  else
+    {
+    labelArray = dsa->GetArray(labelname.c_str());
+    if (!labelArray)
+      {
+      labelArray = dsa->GetScalars();
+      }
+    }
+
+  if (!labelArray)
+    { // No scalars or array of the given name? Create one.
+    vtkNew<vtkUnsignedCharArray> arr;
+    arr->SetName(labelname.empty() ? "label map" : labelname.c_str());
+    labelname = arr->GetName(); // Upon output, labelname must be valid
+    arr->SetNumberOfTuples(card);
+    arr->FillComponent(0, 0.0);
+    dsa->SetScalars(arr.GetPointer());
+
+    labelSet.insert(0.0); // We have one label. It is zero.
+    return 1;
+    }
+
+  labelname = labelArray->GetName();
+  for (vtkIdType i = 0; i < card; ++i)
+    {
+    labelSet.insert(labelArray->GetTuple1(i));
+    }
+  return labelSet.size();
+}
+
+smtk::model::OperatorResult ReadOperator::readLabelMap()
+{
+  smtk::attribute::FileItem::Ptr filenameItem =
+    this->specification()->findFile("filename");
+
+  smtk::attribute::StringItem::Ptr labelItem =
+    this->specification()->findString("label map");
+
+  std::string filename = filenameItem->value();
+  std::string labelname = labelItem->value();
+  if (labelname.empty())
+    labelname = "label map";
+
+  vtkNew<vtkXMLImageDataReader> rdr;
+  rdr->SetFileName(filenameItem->value(0).c_str());
+
+  // Read in the data and discover the labels:
+  rdr->Update();
+  vtkNew<vtkImageData> img;
+  img->ShallowCopy(rdr->GetOutput());
+  int imgDim = img->GetDataDimension();
+  std::set<double> labelSet;
+  int numLabels = DiscoverLabels(img.GetPointer(), labelname, labelSet);
+  // Upon exit, labelname will be a point-data array in img.
+
+  // Prepare the children of the image (holding contour data)
+  vtkNew<vtkContourFilter> bdyFilt;
+  vtkInformation* info = img->GetInformation();
+  Session::SMTK_CHILDREN()->Resize(info, numLabels);
+  int i = 0;
+  bdyFilt->SetInputDataObject(0, img.GetPointer());
+  bdyFilt->SetInputArrayToProcess(
+    0, 0, 0, vtkDataObject::FIELD_ASSOCIATION_POINTS, labelname.c_str());
+  bdyFilt->UseScalarTreeOn();
+  bdyFilt->ComputeNormalsOn();
+  bdyFilt->ComputeGradientsOn();
+  bdyFilt->SetNumberOfContours(1);
+  for (std::set<double>::iterator it = labelSet.begin(); it != labelSet.end(); ++it, ++i)
+    {
+    bdyFilt->SetValue(0, *it);
+    bdyFilt->Update();
+    vtkNew<vtkPolyData> childData;
+    childData->ShallowCopy(bdyFilt->GetOutput());
+    Session::SMTK_CHILDREN()->Set(info, childData.GetPointer(), i);
+    childData->GetInformation()->Set(Session::SMTK_LABEL_VALUE(), *it);
+
+    std::ostringstream cname;
+    cname << "label " << i; // << " (" << *it << ")";
+    MarkMeshInfo(childData.GetPointer(), imgDim, cname.str().c_str(), EXO_LABEL, int(*it));
+    if (*it == 0.0)
+      childData->GetInformation()->Set(Session::SMTK_OUTER_LABEL(), 1);
+    }
+
+  vtkSmartPointer<vtkMultiBlockDataSet> modelOut =
+    vtkSmartPointer<vtkMultiBlockDataSet>::New();
+
+  modelOut->SetNumberOfBlocks(1);
+  modelOut->SetBlock(0, img.GetPointer());
+
+  MarkMeshInfo(modelOut.GetPointer(), imgDim, path(filename).stem().c_str(), EXO_MODEL, -1);
+  MarkMeshInfo(img.GetPointer(), imgDim, labelname.c_str(), EXO_LABEL_MAP, -1);
+  for (int i = 0; i < numLabels; ++i)
+    {
+    this->exodusSession()->ensureChildParentMapEntry(
+      vtkDataObject::SafeDownCast(Session::SMTK_CHILDREN()->Get(info, i)),
+      img.GetPointer(),
+      i);
+    }
+
+  Session* brdg = this->exodusSession();
+  smtk::model::Model smtkModelOut =
+    brdg->addModel(modelOut);
+  smtkModelOut.setStringProperty("url", filename);
+  smtkModelOut.setStringProperty("type", "label map");
 
   // Now set model for session and transcribe everything.
   smtk::model::OperatorResult result = this->createResult(

--- a/smtk/bridge/exodus/ReadOperator.h
+++ b/smtk/bridge/exodus/ReadOperator.h
@@ -28,6 +28,7 @@ protected:
   virtual smtk::model::OperatorResult operateInternal();
   virtual smtk::model::OperatorResult readExodus();
   virtual smtk::model::OperatorResult readSLAC();
+  virtual smtk::model::OperatorResult readLabelMap();
 };
 
     } // namespace exodus

--- a/smtk/bridge/exodus/ReadOperator.sbt
+++ b/smtk/bridge/exodus/ReadOperator.sbt
@@ -7,7 +7,7 @@
       <ItemDefinitions>
         <File Name="filename" NumberOfRequiredValues="1"
           ShouldExist="true"
-          FileFilters="Exodus II Datasets (*.e *.exo *.ex2);;NetCDF files (*.nc *.ncdf);;All files (*.*)">
+          FileFilters="Exodus II Datasets (*.e *.exo *.ex2);;Label maps (*.vti);; NetCDF files (*.nc *.ncdf);;All files (*.*)">
         </File>
         <String Name="filetype" NumberOfRequiredValues="1"/>
         <Int Name="readSLACVolumes" NumberOfRequiredValues="1">
@@ -17,6 +17,11 @@
             <Structure><Value Enum="yes">1</Value></Structure>
           </DiscreteInfo>
         </Int>
+        <String Name="label map" NumberOfRequiredValues="1">
+          <BriefDescription>
+            The name of a scalar cell-data array indicating which segment each cell belongs to.
+          </BriefDescription>
+        </String>
       </ItemDefinitions>
     </AttDef>
     <!-- Result -->

--- a/smtk/bridge/exodus/Session.cxx
+++ b/smtk/bridge/exodus/Session.cxx
@@ -23,8 +23,11 @@
 #include "vtkInformation.h"
 #include "vtkInformationIntegerKey.h"
 #include "vtkInformationIntegerVectorKey.h"
+#include "vtkInformationObjectBaseVectorKey.h"
 #include "vtkInformationStringKey.h"
+#include "vtkInformationDoubleKey.h"
 #include "vtkPoints.h"
+#include "vtkImageData.h"
 #include "vtkPolyData.h"
 #include "vtkUnsignedIntArray.h"
 
@@ -39,7 +42,10 @@ vtkInformationKeyMacro(Session,SMTK_DIMENSION,Integer);
 vtkInformationKeyMacro(Session,SMTK_VISIBILITY,Integer);
 vtkInformationKeyMacro(Session,SMTK_GROUP_TYPE,Integer);
 vtkInformationKeyMacro(Session,SMTK_PEDIGREE,Integer);
+vtkInformationKeyMacro(Session,SMTK_OUTER_LABEL,Integer);
 vtkInformationKeyMacro(Session,SMTK_UUID_KEY,String);
+vtkInformationKeyMacro(Session,SMTK_CHILDREN,ObjectBaseVector);
+vtkInformationKeyMacro(Session,SMTK_LABEL_VALUE,Double);
 
 enum smtkCellTessRole {
   SMTK_ROLE_VERTS,
@@ -61,6 +67,10 @@ std::string EntityTypeNameString(EntityType etype)
   case EXO_BLOCKS:    return "element blocks";
   case EXO_SIDE_SETS: return "side sets";
   case EXO_NODE_SETS: return "node sets";
+
+  case EXO_LABEL_MAP: return "label map";
+  case EXO_LABEL:     return "label";
+
   default: break;
     }
   return "invalid";
@@ -80,7 +90,7 @@ EntityHandle::EntityHandle(int emod, vtkDataObject* obj, Session* sess)
 }
 
 /// Construct a possibly-valid handle (of a non-top-level entity).
-EntityHandle::EntityHandle(int emod, vtkDataObject* obj, vtkMultiBlockDataSet* parent, int idxInParent, Session* sess)
+EntityHandle::EntityHandle(int emod, vtkDataObject* obj, vtkDataObject* parent, int idxInParent, Session* sess)
   : m_modelNumber(emod), m_object(obj), m_session(sess)
 {
   if (sess && obj && parent && idxInParent > 0)
@@ -270,6 +280,8 @@ SessionInfoBits Session::transcribeInternal(
       mutableEntityRef.setIntegerProperty(
         SMTK_GEOM_STYLE_PROP, smtk::model::DISCRETE);
       break;
+    case EXO_LABEL_MAP:
+    case EXO_LABEL:
     case EXO_BLOCK:
       entityDimBits = Entity::dimensionToDimensionBits(dim);
       mutableEntityRef.manager()->insertGroup(
@@ -408,6 +420,18 @@ SessionInfoBits Session::transcribeInternal(
     case EXO_SIDE_SETS:
       mutableEntityRef.setStringProperty("_simple type", "side set collection");
       break;
+
+    case EXO_LABEL:
+      mutableEntityRef.setStringProperty("_simple type", "label");
+      mutableEntityRef.as<smtk::model::Group>().setMembershipMask(DIMENSION_3 | MODEL_DOMAIN);
+      mutableEntityRef.setIntegerProperty("pedigree id", handle.pedigree());
+      break;
+    case EXO_LABEL_MAP:
+      mutableEntityRef.setStringProperty("_simple type", "label map");
+      mutableEntityRef.as<smtk::model::Group>().setMembershipMask(DIMENSION_3 | MODEL_DOMAIN);
+      mutableEntityRef.setIntegerProperty("pedigree id", handle.pedigree());
+      break;
+
     case EXO_MODEL:
       mutableEntityRef.setStringProperty("_simple type", "file");
       break;
@@ -489,6 +513,42 @@ static void AddCellsToTessellation(
     }
 }
 
+static void AddBoxToTessellation(
+  vtkImageData* img,
+  smtk::model::Tessellation& tess)
+{
+  if (!img)
+    return;
+
+  int boxpts[8];
+  double bds[6];
+  double x[3];
+  img->GetBounds(bds);
+  for (int i = 0; i < 2; ++i)
+    {
+    x[2] = i ? bds[5] : bds[4];
+    x[0] = bds[0]; x[1] = bds[2]; boxpts[4*i + 0] = tess.addCoords(x);
+    x[0] = bds[1]; x[1] = bds[2]; boxpts[4*i + 1] = tess.addCoords(x);
+    x[0] = bds[1]; x[1] = bds[3]; boxpts[4*i + 2] = tess.addCoords(x);
+    x[0] = bds[0]; x[1] = bds[3]; boxpts[4*i + 3] = tess.addCoords(x);
+    }
+  int edge[12][2] = {
+      { 0, 1 }, { 1, 2 }, { 2, 3 }, { 3, 0 },
+      { 4, 5 }, { 5, 6 }, { 6, 7 }, { 7, 4 },
+      { 0, 4 }, { 1, 5 }, { 2, 6 }, { 3, 7 }
+  };
+  std::vector<int> tconn(4);
+  tconn[0] = TESS_POLYLINE;
+  tconn[1] = 2;
+  //size_t np = sizeof(tconn) / sizeof(tconn[0]);
+  for (size_t i = 0; i < 12; ++i)
+    {
+    tconn[2] = boxpts[edge[i][0]];
+    tconn[3] = boxpts[edge[i][1]];
+    tess.insertNextCell(tconn);
+    }
+}
+
 bool Session::addTessellation(
   const smtk::model::EntityRef& entityref,
   const EntityHandle& handle)
@@ -503,11 +563,25 @@ bool Session::addTessellation(
   if (vtkMultiBlockDataSet::SafeDownCast(data))
     return false; // Don't try to tessellate parent groups of leaf nodes.
 
-  vtkNew<vtkGeometryFilter> bdyFilter;
-  bdyFilter->MergingOff();
-  bdyFilter->SetInputDataObject(data);
-  bdyFilter->Update();
-  vtkPolyData* bdy = bdyFilter->GetOutput();
+  // Don't tessellate image data that is serving as a label map.
+  EntityType etype = static_cast<EntityType>(
+    data->GetInformation()->Get(SMTK_GROUP_TYPE()));
+  if (etype == EXO_LABEL_MAP)
+    return false;
+
+  vtkPolyData* bdy = NULL;
+  if (etype == EXO_LABEL)
+    {
+    bdy = vtkPolyData::SafeDownCast(data);
+    }
+  else
+    {
+    vtkNew<vtkGeometryFilter> bdyFilter;
+    bdyFilter->MergingOff();
+    bdyFilter->SetInputDataObject(data);
+    bdyFilter->Update();
+    bdy = bdyFilter->GetOutput();
+    }
 
   if (!bdy)
     return SESSION_NOTHING;
@@ -517,12 +591,16 @@ bool Session::addTessellation(
   vtkPoints* pts = bdy->GetPoints();
   AddCellsToTessellation(pts, bdy->GetVerts(), SMTK_ROLE_VERTS, vertMap, tess);
   AddCellsToTessellation(pts, bdy->GetLines(), SMTK_ROLE_LINES, vertMap, tess);
+  if (data->GetInformation()->Get(Session::SMTK_OUTER_LABEL()))
+    { // In many/most label maps, there is an outermost label that will have an empty tessellation. Mark it with an outline.
+    AddBoxToTessellation(handle.parent().object<vtkImageData>(), tess);
+    }
   AddCellsToTessellation(pts, bdy->GetPolys(), SMTK_ROLE_POLYS, vertMap, tess);
   if (bdy->GetStrips() && bdy->GetStrips()->GetNumberOfCells() > 0)
     {
     std::cerr << "Warning: Triangle strips in discrete cells are unsupported. Ignoring.\n";
     }
-  if (!vertMap.empty())
+  if (!tess.coords().empty())
     entityref.manager()->setTessellation(entityref.entity(), tess);
 
   return true;
@@ -534,13 +612,13 @@ size_t Session::numberOfModels() const
 }
 
 /// Return the model owning the given handle, \a h.
-vtkMultiBlockDataSet* Session::modelOfHandle(const EntityHandle& h) const
+vtkDataObject* Session::modelOfHandle(const EntityHandle& h) const
 {
   return (h.isValid() ? this->m_models[h.modelNumber()] : NULL);
 }
 
 /// Return the parent dataset of \a obj.
-vtkMultiBlockDataSet* Session::parent(vtkDataObject* obj) const
+vtkDataObject* Session::parent(vtkDataObject* obj) const
 {
   ChildParentMap_t::const_iterator it = this->m_cpMap.find(obj);
   if (it == this->m_cpMap.end())
@@ -559,7 +637,7 @@ int Session::parentIndex(vtkDataObject* obj) const
   return it->second.second;
 }
 
-bool Session::ensureChildParentMapEntry(vtkDataObject* child, vtkMultiBlockDataSet* parent, int idxInParent)
+bool Session::ensureChildParentMapEntry(vtkDataObject* child, vtkDataObject* parent, int idxInParent)
 {
   return this->m_cpMap.insert(ChildParentMap_t::value_type(child, ParentAndIndex_t(parent, idxInParent))).second;
 }

--- a/smtk/bridge/exodus/Session.json
+++ b/smtk/bridge/exodus/Session.json
@@ -6,6 +6,7 @@
       "filetypes": [
         ".exo (Exodus files)",
         ".ex2 (Exodus-II files)",
+        ".vti (Label map files)",
         ".nc  (SLAC files)",
         ".ncdf (SLAC files)"
       ]

--- a/smtk/bridge/exodus/WriteOperator.cxx
+++ b/smtk/bridge/exodus/WriteOperator.cxx
@@ -1,0 +1,248 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/bridge/exodus/WriteOperator.h"
+
+#include "smtk/bridge/exodus/Session.h"
+
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/DoubleItem.h"
+#include "smtk/attribute/FileItem.h"
+#include "smtk/attribute/IntItem.h"
+#include "smtk/attribute/ModelEntityItem.h"
+#include "smtk/attribute/StringItem.h"
+
+#include "smtk/model/Group.h"
+#include "smtk/model/Manager.h"
+#include "smtk/model/Model.h"
+
+#include "vtkDataSetWriter.h"
+#include "vtkXMLImageDataWriter.h"
+#include "vtkContourFilter.h"
+#include "vtkThreshold.h"
+#include "vtkFieldData.h"
+#include "vtkDataArray.h"
+#include "vtkDataSetAttributes.h"
+#include "vtkPointData.h"
+#include "vtkUnsignedCharArray.h"
+#include "vtkImageData.h"
+#include "vtkStringArray.h"
+#include "vtkTypeInt32Array.h"
+#include "vtkInformation.h"
+#include "vtkUnstructuredGrid.h"
+
+#include "vtkVector.h"
+#include "vtkVectorOperators.h"
+
+#include "boost/filesystem.hpp"
+
+using namespace smtk::model;
+using namespace smtk::common;
+using namespace boost::filesystem;
+
+namespace smtk {
+  namespace bridge {
+    namespace exodus {
+
+smtk::model::OperatorResult WriteOperator::operateInternal()
+{
+  smtk::attribute::FileItem::Ptr filenameItem =
+    this->specification()->findFile("filename");
+  smtk::attribute::StringItem::Ptr filetypeItem =
+    this->specification()->findString("filetype");
+
+  std::string filename = filenameItem->value();
+  std::string filetype = filetypeItem->value();
+
+  if (filetype.empty())
+    { // Infer file type from name
+    std::string ext = path(filename).extension().string();
+    if (ext == ".nc" || ext == ".ncdf")
+      filetype = "slac";
+    else if (ext == ".vtk" || ext == ".vti")
+      filetype = "label map";
+    else if (ext == ".exo" || ext == ".g" || ext == ".ex2" || ext == ".exii")
+      filetype = "exodus";
+    }
+
+  // Downcase the filetype (especially for when we did not infer it):
+  std::transform(filetype.begin(), filetype.end(), filetype.begin(), ::tolower);
+
+  if (filetype == "slac")
+    return this->writeSLAC();
+  else if (filetype == "label map")
+    return this->writeLabelMap();
+
+  // The default is to assume it is an Exodus file:
+  return this->writeExodus();
+}
+
+smtk::model::OperatorResult WriteOperator::writeExodus()
+{
+  smtk::model::OperatorResult result = this->createResult(
+    smtk::model::OPERATION_FAILED);
+  return result;
+}
+
+smtk::model::OperatorResult WriteOperator::writeSLAC()
+{
+  smtk::model::OperatorResult result = this->createResult(
+    smtk::model::OPERATION_FAILED);
+  return result;
+}
+
+template<typename T>
+void RewriteLabels(
+  vtkImageData* img,
+  T* lblp,
+  double thresh,
+
+  vtkVector3d& scenter,
+  double sradius,
+
+  vtkVector3d& basept,
+  vtkVector3d& normal
+  )
+{
+  enum SimulationVoxelCodes {
+    VOXEL_VOID = -1,
+    AIRWAY = 0,
+    ATMOSPHERE = 0, // "Antechamber to the airway"
+    INLET = 100,
+    OUTLET = 200
+  };
+  // Density array
+  vtkDataArray* den = img->GetPointData()->GetArray("scalars");
+  vtkIdType numPts = img->GetNumberOfPoints();
+  vtkVector3d x;
+  vtkVector3d spacing;
+  img->GetSpacing(spacing.GetData());
+  double delta = 0.; // sqrt(spacing.Dot(spacing));
+  for (int i = 0; i < 3; ++i)
+    if (delta < spacing[i])
+      delta = spacing[i];
+  for (vtkIdType p = 0; p < numPts; ++p)
+    {
+    vtkVector3d ray;
+    double dist;
+    bool invitro;
+    img->GetPoint(p, x.GetData());
+    if ((dist = (x - basept).Dot(normal)) < -delta) // Below the lower cutoff plane?
+      lblp[p] = VOXEL_VOID;
+    else if ((dist < delta) && (lblp[p] == 1)) // "On" the lower cutoff plane?
+      lblp[p] = OUTLET;
+    else if ((dist = sqrt((ray = (x - scenter)).Dot(ray)) - sradius) < delta) // In or on the nose sphere?
+      {
+      invitro = den->GetTuple1(p) < thresh ? false : true;
+      // In or on the nose sphere, anything marked "airway" must stay that way:
+      if (lblp[p] == 1)
+        lblp[p] = AIRWAY;
+      else
+        { // ... otherwise, it becomes "atmosphere" or "void":
+        if (invitro) // In the body? Void.
+          lblp[p] = VOXEL_VOID;
+        else // Outside the body? Make "atmosphere" or "inlet":
+          lblp[p] = dist < -delta ? ATMOSPHERE : INLET;
+        }
+      }
+    else // We are not near the nostril and above the cut-plane:
+      lblp[p] = (lblp[p] == 1 ? AIRWAY : VOXEL_VOID); // Preserve the airway; all else is void.
+    }
+}
+
+smtk::model::OperatorResult WriteOperator::writeLabelMap()
+{
+  smtk::attribute::FileItem::Ptr filenameItem =
+    this->specification()->findFile("filename");
+
+  smtk::attribute::DoubleItem::Ptr noseSphereItem =
+    this->specification()->findDouble("nose sphere");
+
+  smtk::attribute::DoubleItem::Ptr lowerPlaneItem =
+    this->specification()->findDouble("lower plane");
+
+  smtk::model::Models datasets =
+    this->specification()->associatedModelEntities<smtk::model::Models>();
+  if (datasets.empty())
+    {
+    smtkErrorMacro(this->log(), "No models to save.");
+    return this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  smtk::model::Model dataset = datasets[0];
+  std::string labelStr;
+  StringData const& stringProps(dataset.stringProperties());
+  StringData::const_iterator sit;
+  if (
+    (sit = stringProps.find("type")) == stringProps.end() ||
+    sit->second.empty() ||
+    sit->second[0] != "label map" ||
+    (sit = stringProps.find("label array")) == stringProps.end() ||
+    sit->second.empty() ||
+    (labelStr = sit->second[0]).empty())
+    {
+    smtkErrorMacro(this->log(), "Model is not a label map or has no label array.");
+    return this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  EntityHandle handle = this->exodusHandle(dataset);
+  vtkMultiBlockDataSet* mbds = handle.object<vtkMultiBlockDataSet>();
+  vtkImageData* img;
+  vtkDataArray* lbl;
+  if (
+    !mbds ||
+    mbds->GetNumberOfBlocks() < 1 ||
+    !(img = vtkImageData::SafeDownCast(mbds->GetBlock(0))) ||
+    !(lbl = img->GetPointData()->GetArray(labelStr.c_str()))
+    )
+    {
+    smtkErrorMacro(this->log(), "Model does not have image data with labels attached.");
+    return this->createResult(smtk::model::OPERATION_FAILED);
+    }
+
+  vtkVector3d scenter(&(*noseSphereItem->begin()));
+  double sradius = noseSphereItem->value(3);
+  vtkVector3d basept(&(*lowerPlaneItem->begin()));
+  vtkVector3d normal;
+  for (int i = 0; i < 3; ++i)
+    normal[i] = lowerPlaneItem->value(i + 3);
+  switch (lbl->GetDataType())
+    {
+    vtkTemplateMacro(
+      RewriteLabels(img, static_cast<VTK_TT*>(lbl->GetVoidPointer(0)), -500.0, scenter, sradius, basept, normal));
+    }
+
+  std::string filename = filenameItem->value();
+
+  // Write out the data
+  vtkNew<vtkDataSetWriter> wri;
+  wri->SetFileName(filenameItem->value(0).c_str());
+  wri->SetInputDataObject(img);
+  wri->SetFileTypeToBinary();
+  wri->Write();
+
+  smtk::model::OperatorResult result = this->createResult(
+    smtk::model::OPERATION_SUCCEEDED);
+  return result;
+}
+
+    } // namespace exodus
+  } //namespace bridge
+} // namespace smtk
+
+#include "smtk/bridge/exodus/WriteOperator_xml.h"
+#include "smtk/bridge/exodus/Exports.h"
+
+smtkImplementsModelOperator(
+  SMTKEXODUSSESSION_EXPORT,
+  smtk::bridge::exodus::WriteOperator,
+  exodus_write,
+  "write",
+  WriteOperator_xml,
+  smtk::bridge::exodus::Session);

--- a/smtk/bridge/exodus/WriteOperator.h
+++ b/smtk/bridge/exodus/WriteOperator.h
@@ -1,0 +1,38 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#ifndef __smtk_session_exodus_WriteOperator_h
+#define __smtk_session_exodus_WriteOperator_h
+
+#include "smtk/bridge/exodus/Operator.h"
+
+namespace smtk {
+  namespace bridge {
+    namespace exodus {
+
+class SMTKEXODUSSESSION_EXPORT WriteOperator : public Operator
+{
+public:
+  smtkTypeMacro(WriteOperator);
+  smtkCreateMacro(WriteOperator);
+  smtkSharedFromThisMacro(Operator);
+  smtkDeclareModelOperator();
+
+protected:
+  virtual smtk::model::OperatorResult operateInternal();
+  virtual smtk::model::OperatorResult writeExodus();
+  virtual smtk::model::OperatorResult writeSLAC();
+  virtual smtk::model::OperatorResult writeLabelMap();
+};
+
+    } // namespace exodus
+  } // namespace bridge
+} // namespace smtk
+
+#endif // __smtk_session_exodus_WriteOperator_h

--- a/smtk/bridge/exodus/WriteOperator.sbt
+++ b/smtk/bridge/exodus/WriteOperator.sbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Description of the Exodus "Write" Operator -->
+<SMTK_AttributeSystem Version="2">
+  <Definitions>
+    <!-- Operator -->
+    <AttDef Type="write" BaseType="operator">
+      <AssociationsDef Name="Model(s)" NumberOfRequiredValues="1" Extensible="true">
+        <MembershipMask>model</MembershipMask>
+      </AssociationsDef>
+      <ItemDefinitions>
+        <File Name="filename" NumberOfRequiredValues="1"
+          ShouldExist="false"
+          FileFilters="Exodus II Datasets (*.e *.exo *.ex2);;Label maps (*.vti);; NetCDF files (*.nc *.ncdf);;All files (*.*)">
+        </File>
+        <String Name="filetype" NumberOfRequiredValues="1"/>
+        <Double Name="nose sphere" NumberOfRequiredValues="4"/>
+        <Double Name="lower plane" NumberOfRequiredValues="6"/>
+      </ItemDefinitions>
+    </AttDef>
+    <!-- Result -->
+    <AttDef Type="result(write)" BaseType="result">
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeSystem>

--- a/smtk/extension/qt/CMakeLists.txt
+++ b/smtk/extension/qt/CMakeLists.txt
@@ -5,6 +5,7 @@ set(QAttrLibSrcs
   qtUIManager.cxx
   qtAttribute.cxx
   qtAttributeDisplay.cxx
+  qtAttributeItemWidgetFactory.cxx
   qtBaseView.cxx
   qtCheckItemComboBox.cxx
   qtEntityItemDelegate.cxx
@@ -44,7 +45,7 @@ set(QAttrLibUIs
 )
 
 
-set(QAttrLibHeaders
+set(QAttrLibMocHeaders
   qtUIManager.h
   qtAttribute.h
   qtAttributeDisplay.h
@@ -80,10 +81,15 @@ set(QAttrLibHeaders
   qtOperatorDockWidget.h
 )
 
+set(QAttrLibHeaders
+  ${QAttrLibMocHeaders}
+  qtAttributeItemWidgetFactory.h
+)
+
 #install the headers
 smtk_public_headers(${QAttrLibHeaders})
 
-qt4_wrap_cpp(MOC_BUILT_SOURCES ${QAttrLibHeaders})
+qt4_wrap_cpp(MOC_BUILT_SOURCES ${QAttrLibMocHeaders})
 qt4_wrap_ui(SMTKQTEXT_UI_BUILT_SOURCES ${QAttrLibUIs})
 qt4_add_resources(RCS_RESOURCES qtEntityItemModelIcons.qrc qtAttributeIcons.qrc)
 

--- a/smtk/extension/qt/qtAttribute.h
+++ b/smtk/extension/qt/qtAttribute.h
@@ -22,13 +22,14 @@
 class qtAttributeInternals;
 class QWidget;
 
-namespace smtk
-{
-  namespace attribute
-  {
-  class qtItem;
+namespace smtk {
+  namespace attribute {
+
+  class qtAttributeItemWidgetFactory;
   class qtBaseView;
-    class SMTKQTEXT_EXPORT qtAttribute : public QObject
+  class qtItem;
+
+  class SMTKQTEXT_EXPORT qtAttribute : public QObject
     {
       Q_OBJECT
 
@@ -52,6 +53,9 @@ namespace smtk
       static qtItem* createItem(smtk::attribute::ItemPtr item, QWidget* p, qtBaseView* view,
         Qt::Orientation enVectorItemOrient = Qt::Horizontal);
 
+      static void setItemWidgetFactory(qtAttributeItemWidgetFactory* f);
+      static qtAttributeItemWidgetFactory* itemWidgetFactory();
+
     public slots:
       virtual void onRequestEntityAssociation();
 
@@ -61,12 +65,13 @@ namespace smtk
       virtual void createWidget();
 
       QPointer<QWidget> m_widget;
+      static qtAttributeItemWidgetFactory* s_factory;
+
     private:
+      qtAttributeInternals* m_internals;
+    };
 
-      qtAttributeInternals *m_internals;
-
-    }; // class
-  }; // namespace attribute
-}; // namespace smtk
+  } // namespace attribute
+} // namespace smtk
 
 #endif

--- a/smtk/extension/qt/qtAttributeItemWidgetFactory.cxx
+++ b/smtk/extension/qt/qtAttributeItemWidgetFactory.cxx
@@ -1,0 +1,109 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/extension/qt/qtAttributeItemWidgetFactory.h"
+
+#include "smtk/extension/qt/qtAttributeRefItem.h"
+#include "smtk/extension/qt/qtInputsItem.h"
+#include "smtk/extension/qt/qtFileItem.h"
+#include "smtk/extension/qt/qtFileItem.h"
+#include "smtk/extension/qt/qtGroupItem.h"
+#include "smtk/extension/qt/qtVoidItem.h"
+#include "smtk/extension/qt/qtModelEntityItem.h"
+#include "smtk/extension/qt/qtMeshSelectionItem.h"
+
+#include "smtk/attribute/DirectoryItem.h"
+#include "smtk/attribute/GroupItem.h"
+#include "smtk/attribute/FileItem.h"
+#include "smtk/attribute/ModelEntityItem.h"
+#include "smtk/attribute/MeshSelectionItem.h"
+#include "smtk/attribute/RefItem.h"
+#include "smtk/attribute/ValueItem.h"
+#include "smtk/attribute/VoidItem.h"
+
+using namespace smtk::attribute;
+
+/**\brief Create a widget that illustrates an item referencing another attribute.
+  *
+  * The referenced attribute will be displayed inline as if it were a child of the
+  * current attribute's item.
+  * Subclasses might wish to provide other representations, such as a
+  * clickable "link" to the referenced attribute.
+  */
+qtItem* qtAttributeItemWidgetFactory::createRefItemWidget(
+  RefItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient)
+{
+  return new qtAttributeRefItem(smtk::dynamic_pointer_cast<RefItem>(item), p, bview, orient);
+}
+
+/**\brief Create a widget that illustrates an item whose value is a primitive type.
+  *
+  */
+qtItem* qtAttributeItemWidgetFactory::createValueItemWidget(
+  ValueItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient)
+{
+  return new qtInputsItem(smtk::dynamic_pointer_cast<ValueItem>(item), p, bview, orient);
+}
+
+/**\brief Create a widget that illustrates an item whose value is a directory.
+  *
+  */
+qtItem* qtAttributeItemWidgetFactory::createDirectoryItemWidget(
+  DirectoryItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient)
+{
+  return new qtFileItem(smtk::dynamic_pointer_cast<DirectoryItem>(item), p, bview, orient);
+}
+
+/**\brief Create a widget that illustrates an item whose value is a file.
+  *
+  */
+qtItem* qtAttributeItemWidgetFactory::createFileItemWidget(
+  FileItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient)
+{
+  return new qtFileItem(smtk::dynamic_pointer_cast<FileItem>(item), p, bview, orient);
+}
+
+/**\brief Create a widget that illustrates an item whose value is a group of model entities.
+  *
+  */
+qtItem* qtAttributeItemWidgetFactory::createGroupItemWidget(
+  GroupItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient)
+{
+  return new qtGroupItem(smtk::dynamic_pointer_cast<GroupItem>(item), p, bview, orient);
+}
+
+/**\brief Create a widget that illustrates an item that is either enabled/present or disabled/absent but has no value.
+  *
+  */
+qtItem* qtAttributeItemWidgetFactory::createVoidItemWidget(
+  VoidItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient)
+{
+  (void)orient;
+  return new qtVoidItem(smtk::dynamic_pointer_cast<VoidItem>(item), p, bview);
+}
+
+/**\brief Create a widget that illustrates an item whose value is a geometric model entity.
+  *
+  */
+qtItem* qtAttributeItemWidgetFactory::createModelEntityItemWidget(
+  ModelEntityItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient)
+{
+  return new qtModelEntityItem(
+    smtk::dynamic_pointer_cast<ModelEntityItem>(item), p, bview, orient);
+}
+
+/**\brief Create a widget that illustrates an item whose value is a set of geometric mesh entities.
+  *
+  */
+qtItem* qtAttributeItemWidgetFactory::createMeshSelectionItemWidget(
+  MeshSelectionItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient)
+{
+  return new qtMeshSelectionItem(
+    smtk::dynamic_pointer_cast<MeshSelectionItem>(item), p, bview, orient);
+}

--- a/smtk/extension/qt/qtAttributeItemWidgetFactory.h
+++ b/smtk/extension/qt/qtAttributeItemWidgetFactory.h
@@ -1,0 +1,57 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#ifndef __smtk_extension_qt_qtAttributeItemWidgetFactory_h
+#define __smtk_extension_qt_qtAttributeItemWidgetFactory_h
+
+#include "smtk/extension/qt/Exports.h"
+#include "smtk/PublicPointerDefs.h"
+
+#include <QWidget>
+
+namespace smtk {
+  namespace attribute {
+
+class qtItem;
+class qtBaseView;
+
+/**\brief Create widgets for attribute items.
+  *
+  * This class serves as a delegate to qtAttribute for creating the qtItem widgets
+  * that allow users to modify items owned by an attribute.
+  *
+  * As a view requests the qtAttribute for widgets to expose items owned by
+  * the attribute, this factory is called to create the widgets.
+  * The factory can then inspect the item and view to determine
+  * what widget the item should be presented with.
+  *
+  * An instance of this class (or a subclass) is owned by the qtAttribute class
+  * (as a static member variable, not on a per-qtAttribute-instance basis).
+  * Subclasses may be used to provide application-specific interactions for
+  * setting item values.
+  */
+class SMTKQTEXT_EXPORT qtAttributeItemWidgetFactory
+{
+public:
+  virtual ~qtAttributeItemWidgetFactory() { }
+
+  virtual qtItem* createRefItemWidget(RefItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient);
+  virtual qtItem* createValueItemWidget(ValueItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient);
+  virtual qtItem* createDirectoryItemWidget(DirectoryItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient);
+  virtual qtItem* createFileItemWidget(FileItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient);
+  virtual qtItem* createGroupItemWidget(GroupItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient);
+  virtual qtItem* createVoidItemWidget(VoidItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient);
+  virtual qtItem* createModelEntityItemWidget(ModelEntityItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient);
+  virtual qtItem* createMeshSelectionItemWidget(MeshSelectionItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient);
+};
+
+  } // namespace attribute
+} // namespace smtk
+
+#endif // __smtk_extension_qt_qtAttributeItemWidgetFactory_h

--- a/smtk/extension/qt/qtInputsItem.cxx
+++ b/smtk/extension/qt/qtInputsItem.cxx
@@ -40,6 +40,8 @@
 #include "smtk/attribute/ValueItemDefinition.h"
 #include "smtk/attribute/ValueItemTemplate.h"
 
+//#include "pqApplicationCore.h"
+
 using namespace smtk::attribute;
 
 //----------------------------------------------------------------------------
@@ -86,6 +88,8 @@ void qtInputsItem::setLabelVisible(bool visible)
 //----------------------------------------------------------------------------
 void qtInputsItem::createWidget()
 {
+  //pqApplicationCore* paraViewApp = pqApplicationCore::instance();
+  //std::cout << "PV app: " << paraViewApp << "\n";
   smtk::attribute::ItemPtr dataObj = this->getObject();
   if(!dataObj || !this->passAdvancedCheck() || (this->baseView() &&
     !this->baseView()->uiManager()->passItemCategoryCheck(

--- a/smtk/extension/qt/testing/cxx/CMakeLists.txt
+++ b/smtk/extension/qt/testing/cxx/CMakeLists.txt
@@ -1,11 +1,17 @@
+##
+## Create browseModel to test browsing model entity tree:
 
-#add in the browseModel test executable
 qt4_wrap_ui(browseModel_UI_BUILT_SOURCES ModelBrowser.ui)
 
 add_executable(browseModel MACOSX_BUNDLE
   browseModel.cxx
   ModelBrowser.cxx
   ${browseModel_UI_BUILT_SOURCES})
+target_link_libraries(browseModel
+  smtkCore
+  smtkCoreModelTesting
+  smtkQtExt
+)
 
 set_target_properties(
   browseModel PROPERTIES AUTOMOC TRUE
@@ -13,12 +19,26 @@ set_target_properties(
 
 qt4_use_modules(browseModel Core Gui)
 
-target_link_libraries(browseModel smtkCore smtkCoreModelTesting smtkQtExt)
+##
+## Create an application to test attribute editing
 
-#add in the attribute preview executable
 add_executable(qtAttributePreview MACOSX_BUNDLE qtAttributePreview.cxx)
-target_link_libraries(qtAttributePreview LINK_PUBLIC smtkQtExt)
+target_link_libraries(qtAttributePreview
+  smtkQtExt
+)
 
+##
+## Test attribute item-widget factory
+
+add_executable(testItemFactory MACOSX_BUNDLE testItemFactory.cxx)
+target_link_libraries(testItemFactory PUBLIC smtkQtExt)
+add_test(
+  NAME testItemFactory
+  COMMAND $<TARGET_FILE:testItemFactory>
+)
+
+##
+## Test model browsing (for crashes only, not behavior)
 
 if (NOT WIN32 AND SMTK_DATA_DIR AND EXISTS ${SMTK_DATA_DIR}/ReadMe.mkd)
   add_test(

--- a/smtk/extension/qt/testing/cxx/testItemFactory.cxx
+++ b/smtk/extension/qt/testing/cxx/testItemFactory.cxx
@@ -1,0 +1,119 @@
+//=========================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//=========================================================================
+#include "smtk/extension/qt/qtAttributeRefItem.h"
+#include "smtk/extension/qt/qtInputsItem.h"
+#include "smtk/extension/qt/qtFileItem.h"
+#include "smtk/extension/qt/qtFileItem.h"
+#include "smtk/extension/qt/qtGroupItem.h"
+#include "smtk/extension/qt/qtVoidItem.h"
+#include "smtk/extension/qt/qtModelEntityItem.h"
+#include "smtk/extension/qt/qtMeshSelectionItem.h"
+#include "smtk/extension/qt/qtAttribute.h"
+#include "smtk/extension/qt/qtBaseView.h"
+#include "smtk/extension/qt/qtUIManager.h"
+#include "smtk/extension/qt/qtAttributeItemWidgetFactory.h"
+
+#include "smtk/attribute/DirectoryItem.h"
+#include "smtk/attribute/GroupItem.h"
+#include "smtk/attribute/FileItem.h"
+#include "smtk/attribute/ModelEntityItem.h"
+#include "smtk/attribute/MeshSelectionItem.h"
+#include "smtk/attribute/RefItem.h"
+#include "smtk/attribute/ValueItem.h"
+#include "smtk/attribute/VoidItem.h"
+
+#include "smtk/attribute/System.h"
+#include "smtk/attribute/Definition.h"
+#include "smtk/attribute/Attribute.h"
+#include "smtk/attribute/StringItemDefinition.h"
+
+#include "smtk/common/View.h"
+
+#include "smtk/common/testing/cxx/helpers.h"
+
+#include "smtk/PublicPointerDefs.h"
+
+#include <QApplication>
+#include <QWidget>
+
+#include <iostream>
+
+using namespace smtk::attribute;
+
+static int numDeleted = 0;
+
+// A "dummy" class to verify that creating/deleting factories works as required.
+class testItemWidgetFactory : public qtAttributeItemWidgetFactory
+{
+public:
+  virtual ~testItemWidgetFactory()
+    {
+    ++numDeleted;
+    }
+
+  virtual qtItem* createValueItemWidget(ValueItemPtr item, QWidget* p, qtBaseView* bview, Qt::Orientation orient)
+    {
+    // TODO: Need to create an attribute view and see that this gets called.
+    return new qtInputsItem(smtk::dynamic_pointer_cast<ValueItem>(item), p, bview, orient);
+    }
+
+};
+
+AttributePtr createAttribForTest(System& system)
+{
+  DefinitionPtr def = system.createDefinition("test def");
+  StringItemDefinitionPtr stringChild =
+    def->addItemDefinition<StringItemDefinitionPtr>("test string");
+
+  AttributePtr att = system.createAttribute("testAtt", "test def");
+  double color[] = {3,24,12,6};
+  att->setColor(color);
+  att->setAppliesToBoundaryNodes(true);
+  att->setAppliesToInteriorNodes(true);
+  return att;
+}
+
+int testLifecycle()
+{
+  qtAttribute::setItemWidgetFactory(
+    new testItemWidgetFactory());
+  test(numDeleted == 0, "Bad initial value for numDeleted.");
+  qtAttribute::setItemWidgetFactory(
+    new testItemWidgetFactory());
+  test(numDeleted == 1, "Expected to delete the old test factory.");
+  qtAttribute::setItemWidgetFactory(NULL);
+  test(numDeleted == 2, "Expected to delete the new test factory.");
+
+  // This should not crash even though the factory is null
+  // (because a new default factory should be created on demand).
+  smtk::attribute::System system;
+  AttributePtr att = createAttribForTest(system);
+  qtUIManager* mgr = new qtUIManager(system);
+  QWidget* w = new QWidget;
+  qtBaseView* v = new qtBaseView(
+    smtk::common::View::New("base", "test view"),
+    w, mgr);
+  qtAttribute* qatt = new qtAttribute(att, w, v);
+
+  delete qatt;
+  delete w;
+  return 0;
+}
+
+int main(int argc, char* argv[])
+{
+  QApplication app(argc, argv);
+  (void)argc;
+  (void)argv;
+  // Verify that widget factory lifecycle management is done properly.
+  return testLifecycle();
+}
+
+


### PR DESCRIPTION
This commit adds 2 new features without changing the existing SMTK API:

+ The Exodus session (which should probably be renamed) can read `vti` image data and use integer scalars as an image segmentation. Each unique label is presented as its own group and has a tessellation that is an isocontour.
+ The `qtAttribute` class now owns a reference to an *item factory* that applications can replace with a factory that will create different (application-specific) widgets. This is useful for CMB, which can use ParaView 3D widgets to enable visual selection of points/planes.