### PR TITLE
BUG: Fixed deleting attributes in QtAttributeView

### DIFF
--- a/smtk/attribute/RefItem.cxx
+++ b/smtk/attribute/RefItem.cxx
@@ -272,7 +272,7 @@ bool RefItem::assign(ConstItemPtr &sourceItem, unsigned int options)
                                     options & Item::COPY_MODEL_ASSOCIATIONS, options);
         if (!att)
           {
-          std::cerr << "Could not copy Attribute:"
+          std::cerr << "ERROR: Could not copy Attribute:"
                     << sourceRefItem->value()->name() << " referenced by item: "
                     << sourceItem->name() << "\n";
           return false; // Something went wrong!

--- a/smtk/attribute/ValueItem.cxx
+++ b/smtk/attribute/ValueItem.cxx
@@ -323,7 +323,7 @@ bool ValueItem::assign(ConstItemPtr &sourceItem, unsigned int options)
                                       options & Item::COPY_MODEL_ASSOCIATIONS, options);
           if (!att)
             {
-            std::cerr << "EROOR:Could not copy Attribute:"
+            std::cerr << "ERROR: Could not copy Attribute:"
                       << sourceValueItem->expression(i)->name()
                       << " used as an expression by item: "
                       << sourceItem->name() << "\n";

--- a/smtk/extension/qt/qtAttributeView.cxx
+++ b/smtk/extension/qt/qtAttributeView.cxx
@@ -423,6 +423,8 @@ void qtAttributeView::onListBoxSelectionChanged()
     }
   else
     {
+    delete this->Internals->CurrentAtt;
+    this->Internals->CurrentAtt = NULL;
     this->updateAssociationEnableState(smtk::attribute::AttributePtr());
     }
 


### PR DESCRIPTION
It now clears the editing panel when the last attribute is deleted.