### PR TITLE
Fixed a bug in copying attribute associations with isUnique defined

### DIFF
--- a/smtk/attribute/System.cxx
+++ b/smtk/attribute/System.cxx
@@ -776,7 +776,7 @@ System::copyAttribute(const smtk::attribute::AttributePtr sourceAtt,
     }
   // Copy model associations if requested and the attribute is not Unique
   // with respects to the model entitiy
-  if (copyModelAssocs && !sourceAtt->definition()->isUnique())
+  if (copyModelAssocs && !(sameSystem && sourceAtt->definition()->isUnique()))
     {
     smtk::common::UUIDs uuidSet = sourceAtt->associatedModelEntityIds();
     smtk::common::UUIDs::const_iterator it;


### PR DESCRIPTION
The model operations are broken due to changes in copying attribute. The model associations are not being copied when serializing operator attribute.

If the new attribute is in another System, the modelAssociation should be copied even the definition isUnique. This is exactly the case when serializing the operator specification between client and server (see cJSON_AddAttributeSpec in ExportJSON.cxx.
