### PR TITLE
Redesign the way Collections store associations to a smtk::model.

### DIFF
--- a/smtk/io/ImportJSON.cxx
+++ b/smtk/io/ImportJSON.cxx
@@ -1158,7 +1158,7 @@ int ImportJSON::ofMeshesOfModel(cJSON* node,
 
       if(!associatedModelId.isNull())
         {
-        collection->associateModel(associatedModelId);
+        collection->associateToModel(associatedModelId);
         }
       //write properties to the new collection
       status = ImportJSON::ofMeshProperties(child, collection);

--- a/smtk/io/ModelToMesh.cxx
+++ b/smtk/io/ModelToMesh.cxx
@@ -373,9 +373,14 @@ smtk::mesh::CollectionPtr ModelToMesh::operator()(const smtk::mesh::ManagerPtr& 
       //now create a mesh from those cells
       smtk::mesh::CellSet cellsForMesh(collection, i->second);
       smtk::mesh::MeshSet ms = collection->createMesh(cellsForMesh);
-      collection->addAssociation(i->first, ms);
+      collection->setAssociation(i->first, ms);
       }
-    // collection->addAssociation(ModelEntityRef, all_ms);
+
+    EntityRefs currentModels = modelManager->entitiesMatchingFlagsAs<EntityRefs>( smtk::model::MODEL_ENTITY);
+    if(currentModels.size() > 0)
+      {
+      collection->associateToModel(currentModels.begin()->entity());
+      }
     }
   }
 

--- a/smtk/mesh/Collection.cxx
+++ b/smtk/mesh/Collection.cxx
@@ -402,13 +402,13 @@ smtk::mesh::CellSet Collection::findAssociatedCells( const smtk::model::EntityRe
 
 
 //----------------------------------------------------------------------------
-bool Collection::addAssociation( const smtk::model::EntityRef& eref ,
+bool Collection::setAssociation( const smtk::model::EntityRef& eref ,
                                  const smtk::mesh::MeshSet& meshset )
 {
   const smtk::mesh::InterfacePtr& iface = this->m_internals->mesh_iface();
   // This causes the eref to become a meshset with the tag MODEL;
   // then all meshsets in m_range become child meshsets of eref:
-  return iface->addAssociation( eref.entity(), meshset.m_range );
+  return iface->setAssociation( eref.entity(), meshset.m_range );
 }
 
 //----------------------------------------------------------------------------
@@ -421,6 +421,26 @@ bool Collection::hasAssociations( ) const
 
   smtk::common::UUIDArray associations = iface->computeModelEntities(entities);
   return !associations.empty();
+}
+
+//----------------------------------------------------------------------------
+bool Collection::associateToModel(const smtk::common::UUID& uuid)
+{
+  const smtk::mesh::InterfacePtr& iface = this->m_internals->mesh_iface();
+  return iface->setRootAssociation( uuid );
+}
+
+//----------------------------------------------------------------------------
+bool Collection::isAssociatedToModel() const
+{
+  return this->associatedModel() != smtk::common::UUID::null();
+}
+
+//----------------------------------------------------------------------------
+smtk::common::UUID Collection::associatedModel() const
+{
+  const smtk::mesh::InterfacePtr& iface = this->m_internals->mesh_iface();
+  return iface->rootAssociation( );
 }
 
 //----------------------------------------------------------------------------
@@ -576,33 +596,6 @@ bool Collection::setNeumannOnMeshes(const smtk::mesh::MeshSet& meshes,
     return iface->setNeumann(meshes.m_range,n);
     }
   return false;
-}
-
-//----------------------------------------------------------------------------
-bool Collection::associateModel(const smtk::common::UUID& uuid)
-{
-  if(m_modelEntity == uuid)
-    return true;
-  this->m_modelEntity = uuid;
-
-  return this->m_internals->mesh_iface()->setModelEntity(
-            HandleRange(this->m_internals->mesh_root_handle(),
-                        this->m_internals->mesh_root_handle()), uuid);
-}
-
-//----------------------------------------------------------------------------
-smtk::common::UUID Collection::associatedModel() const
-{
-  return m_modelEntity;
-/*
-  smtk::common::UUIDArray associatedModels =
-    this->m_internals->mesh_iface()->computeModelEntities(
-      HandleRange(this->m_internals->mesh_root_handle(),
-                  this->m_internals->mesh_root_handle()));
-
-  return associatedModels.size() > 0 ?
-         associatedModels[0] : smtk::common::UUID();
-*/
 }
 
 //----------------------------------------------------------------------------

--- a/smtk/mesh/Collection.h
+++ b/smtk/mesh/Collection.h
@@ -27,6 +27,7 @@
 
 #include "smtk/model/EntityRef.h"
 #include "smtk/model/Manager.h"
+#include "smtk/model/Model.h"
 
 #include <vector>
 
@@ -139,10 +140,19 @@ public:
   smtk::mesh::CellSet   findAssociatedCells( const smtk::model::EntityRef& eref, smtk::mesh::CellType cellType );
   smtk::mesh::CellSet   findAssociatedCells( const smtk::model::EntityRef& eref, smtk::mesh::DimensionType dim );
 
-  bool addAssociation( const smtk::model::EntityRef& eref, const smtk::mesh::MeshSet& meshset );
+  bool setAssociation( const smtk::model::EntityRef& eref, const smtk::mesh::MeshSet& meshset );
 
   //determine if this collection has any associations to a model
   bool hasAssociations() const;
+
+  // Associate a model to the collection.
+  bool associateToModel(const smtk::common::UUID& uuid);
+
+  // Find if the collection has an associated model
+  bool isAssociatedToModel() const;
+
+  // Return the uuid of the associated model
+  smtk::common::UUID associatedModel() const;
 
   //----------------------------------------------------------------------------
   // Construction of new meshes
@@ -218,9 +228,6 @@ public:
   void setModelManager(smtk::model::ManagerPtr mgr) { this->m_modelManager = mgr; }
   smtk::model::ManagerPtr modelManager() const { return this->m_modelManager.lock(); }
 
-  // Associate a model to the collection.
-  bool associateModel(const smtk::common::UUID& uuid);
-  smtk::common::UUID associatedModel() const;
 
   //----------------------------------------------------------------------------
   // Float, String, Integer properties for a meshset given its handle range.
@@ -272,7 +279,6 @@ private:
   std::string m_writeLocation;
 
   smtk::model::WeakManagerPtr m_modelManager;
-  smtk::common::UUID m_modelEntity;
   smtk::shared_ptr<MeshFloatData> m_floatData;
   smtk::shared_ptr<MeshStringData> m_stringData;
   smtk::shared_ptr<MeshIntegerData> m_integerData;

--- a/smtk/mesh/Interface.h
+++ b/smtk/mesh/Interface.h
@@ -244,18 +244,29 @@ public:
                           const smtk::mesh::Neumann& neumann) const = 0;
 
   //----------------------------------------------------------------------------
-  virtual bool setModelEntity(
-    const smtk::mesh::HandleRange& meshsets,
-    const smtk::common::UUID& uuid) const = 0;
+  // Specify for a given sets of handles what the associated model entity is.
+  // This allows for a model region, face, or edge to be associated with a
+  // given set of meshes.
+  // Note: Only MeshSets can have associations applied. Other elements will cause
+  // undefined behavior
+  //
+  virtual bool setAssociation(const smtk::common::UUID& modelUUID,
+                              const smtk::mesh::HandleRange& meshsets) const = 0;
 
   //----------------------------------------------------------------------------
-  virtual smtk::mesh::HandleRange findAssociations(
-    const smtk::mesh::Handle& root,
-    const smtk::common::UUID& modelUUID) = 0;
+  // For a given handle root, find all meshsets that have an association to
+  // the given model uuid
+  virtual smtk::mesh::HandleRange findAssociations(const smtk::mesh::Handle& root,
+                                                   const smtk::common::UUID& modelUUID) const = 0;
 
   //----------------------------------------------------------------------------
-  virtual bool addAssociation(const smtk::common::UUID& modelUUID,
-                              const smtk::mesh::HandleRange& range) = 0;
+  // Specify the model uuid that the root of this interface is associated too
+  // This represents generally is the MODEL_ENTITY that owns all associations
+  // with this interface
+  virtual bool setRootAssociation(const smtk::common::UUID& modelUUID) const = 0;
+
+  //----------------------------------------------------------------------------
+  virtual smtk::common::UUID rootAssociation() const = 0;
 
   //----------------------------------------------------------------------------
   virtual smtk::mesh::HandleRange rangeIntersect(const smtk::mesh::HandleRange& a,

--- a/smtk/mesh/MeshSet.cxx
+++ b/smtk/mesh/MeshSet.cxx
@@ -228,10 +228,10 @@ smtk::model::EntityRefArray MeshSet::modelEntities() const
 /**\brief Set the model entity for each meshset member to \a ent.
   *
   */
-bool MeshSet::setModelEntities(const smtk::model::EntityRef& ent)
+bool MeshSet::setModelEntity(const smtk::model::EntityRef& ent)
 {
   const smtk::mesh::InterfacePtr& iface = this->m_parent->interface();
-  return iface->setModelEntity(this->m_range, ent.entity());
+  return iface->setAssociation(ent.entity(), this->m_range);
 }
 
 /**\brief Get the parent collection that this meshset belongs to.

--- a/smtk/mesh/MeshSet.h
+++ b/smtk/mesh/MeshSet.h
@@ -96,7 +96,7 @@ public:
 
   smtk::common::UUIDArray modelEntityIds() const;
   smtk::model::EntityRefArray modelEntities() const;
-  bool setModelEntities(const smtk::model::EntityRef&);
+  bool setModelEntity(const smtk::model::EntityRef&);
 
   std::vector< std::string > names() const;
   smtk::mesh::TypeSet types() const;

--- a/smtk/mesh/json/Interface.cxx
+++ b/smtk/mesh/json/Interface.cxx
@@ -34,14 +34,16 @@ smtk::mesh::json::InterfacePtr make_interface()
 
 //----------------------------------------------------------------------------
 Interface::Interface():
-  m_meshInfo()
+  m_meshInfo(),
+  m_associated_model( smtk::common::UUID::null() )
 {
 
 }
 
 //----------------------------------------------------------------------------
 Interface::Interface( const std::vector<smtk::mesh::json::MeshInfo>& info ):
-  m_meshInfo(info)
+  m_meshInfo(info),
+  m_associated_model( smtk::common::UUID::null() )
 {
 
 }
@@ -474,9 +476,8 @@ bool Interface::setNeumann(const smtk::mesh::HandleRange& meshsets,
 //----------------------------------------------------------------------------
 /**\brief Set the model entity assigned to each meshset member to \a ent.
   */
-bool Interface::setModelEntity(
-  const smtk::mesh::HandleRange& meshsets,
-  const smtk::common::UUID& uuid) const
+bool Interface::setAssociation(const smtk::common::UUID& modelUUID,
+                               const smtk::mesh::HandleRange& meshsets) const
 {
   return false;
 }
@@ -487,7 +488,7 @@ bool Interface::setModelEntity(
   */
 smtk::mesh::HandleRange Interface::findAssociations(
   const smtk::mesh::Handle& root,
-  const smtk::common::UUID& modelUUID)
+  const smtk::common::UUID& modelUUID) const
 {
   smtk::mesh::HandleRange result;
   if (!modelUUID)
@@ -508,10 +509,19 @@ smtk::mesh::HandleRange Interface::findAssociations(
 }
 
 //----------------------------------------------------------------------------
-bool Interface::addAssociation(const smtk::common::UUID& modelUUID,
-                               const smtk::mesh::HandleRange& range)
+/**\brief Set the model entity assigned to the root of this interface.
+  */
+bool Interface::setRootAssociation(const smtk::common::UUID& modelUUID) const
 {
-  return false;
+  this->m_associated_model = modelUUID;
+  return true;
+}
+//----------------------------------------------------------------------------
+/**\brief Get the model entity assigned to the root of this interface.
+  */
+smtk::common::UUID Interface::rootAssociation() const
+{
+  return this->m_associated_model;
 }
 
 //----------------------------------------------------------------------------

--- a/smtk/mesh/json/Interface.h
+++ b/smtk/mesh/json/Interface.h
@@ -188,18 +188,19 @@ public:
                   const smtk::mesh::Neumann& neumann) const;
 
   //----------------------------------------------------------------------------
-  bool setModelEntity(
-    const smtk::mesh::HandleRange& meshsets,
-    const smtk::common::UUID& uuid) const;
+  bool setAssociation(const smtk::common::UUID& modelUUID,
+                      const smtk::mesh::HandleRange& meshsets) const;
+
 
   //----------------------------------------------------------------------------
-  smtk::mesh::HandleRange findAssociations(
-    const smtk::mesh::Handle& root,
-    const smtk::common::UUID& modelUUID);
+  smtk::mesh::HandleRange findAssociations(const smtk::mesh::Handle& root,
+                                           const smtk::common::UUID& modelUUID) const;
 
   //----------------------------------------------------------------------------
-  bool addAssociation(const smtk::common::UUID& modelUUID,
-                      const smtk::mesh::HandleRange& range);
+  bool setRootAssociation(const smtk::common::UUID& modelUUID) const;
+
+  //----------------------------------------------------------------------------
+  smtk::common::UUID rootAssociation() const;
 
   //----------------------------------------------------------------------------
   smtk::mesh::HandleRange rangeIntersect(const smtk::mesh::HandleRange& a,
@@ -245,6 +246,11 @@ private:
   MeshInfoVecType::const_iterator find(smtk::mesh::Handle handle) const;
 
   std::vector<smtk::mesh::json::MeshInfo> m_meshInfo;
+
+  //this is ugly, but as this is the only state we have I am going to roll
+  //with it. If we start adding more member variables, we should offload it
+  //all to an internal class
+  mutable smtk::common::UUID m_associated_model;
 };
 
 }

--- a/smtk/mesh/moab/Interface.cxx
+++ b/smtk/mesh/moab/Interface.cxx
@@ -158,6 +158,29 @@ T computeDenseOpaqueTagValues(
 }
 
 //----------------------------------------------------------------------------
+template<typename T, typename U>
+T computeDenseOpaqueTagValue(
+  U tag,
+  const smtk::mesh::Handle& handle,
+  ::moab::Interface* iface)
+{
+  std::vector<unsigned char> tag_values;
+  tag_values.resize(tag.size());
+  void* tag_v_ptr = &tag_values[0];
+
+  // Fetch the tag for each item in the range in bulk
+  ::moab::ErrorCode rval = iface->tag_get_data(tag.moabTag(), &handle, 1, tag_v_ptr);
+
+  T result;
+  if(rval == ::moab::MB_SUCCESS)
+    {
+    std::vector<unsigned char>::const_iterator i = tag_values.begin();
+    result = T( &(*i), &(*i)+tag.size() );
+    }
+  return result;
+}
+
+//----------------------------------------------------------------------------
 template<typename T>
 bool setDenseTagValues(T tag, const smtk::mesh::HandleRange& handles,
                        ::moab::Interface* iface)
@@ -173,6 +196,7 @@ bool setDenseTagValues(T tag, const smtk::mesh::HandleRange& handles,
   return (rval == ::moab::MB_SUCCESS);
 }
 
+//----------------------------------------------------------------------------
 template<typename T>
 bool setDenseOpaqueTagValues(T tag, const smtk::mesh::HandleRange& handles,
                        ::moab::Interface* iface)
@@ -187,6 +211,23 @@ bool setDenseOpaqueTagValues(T tag, const smtk::mesh::HandleRange& handles,
   ::moab::ErrorCode rval =
     iface->tag_set_data(
       tag.moabTag(), handles, tag_v_ptr);
+  return (rval == ::moab::MB_SUCCESS);
+}
+
+//----------------------------------------------------------------------------
+template<typename T>
+bool setDenseOpaqueTagValue(T tag, const smtk::mesh::Handle& handle,
+                           ::moab::Interface* iface)
+{
+  //create a vector the same value so we can assign a tag
+  std::vector<unsigned char> values;
+  values.resize(tag.size());
+  memcpy(&values[0], tag.value(), tag.size());
+  const void* tag_v_ptr = &values[0];
+
+  ::moab::ErrorCode rval =
+    iface->tag_set_data(
+      tag.moabTag(), &handle, 1, tag_v_ptr);
   return (rval == ::moab::MB_SUCCESS);
 }
 
@@ -670,12 +711,13 @@ std::vector< smtk::mesh::Neumann > Interface::computeNeumannValues(const smtk::m
                                                             this->moabInterface());
 }
 
+//----------------------------------------------------------------------------
 /**\brief Return the set of all UUIDs set on all entities in the meshsets.
   *
   */
 smtk::common::UUIDArray Interface::computeModelEntities(const smtk::mesh::HandleRange& meshsets) const
 {
-  tag::QueryModelTag mtag(this->moabInterface());
+  tag::QueryEntRefTag mtag(this->moabInterface());
   return detail::computeDenseOpaqueTagValues<smtk::common::UUIDArray>(
     mtag, meshsets, this->moabInterface());
 }
@@ -860,82 +902,94 @@ bool Interface::setNeumann(const smtk::mesh::HandleRange& meshsets,
   return tagged;
 }
 
+//----------------------------------------------------------------------------
 /**\brief Set the model entity assigned to each meshset member to \a ent.
   */
-bool Interface::setModelEntity(
-  const smtk::mesh::HandleRange& meshsets,
-  const smtk::common::UUID& uuid) const
-{
-  if (meshsets.empty())
-    return true;
-
-  tag::QueryModelTag mtag(uuid, this->moabInterface());
-
-  // I. Tag the meshsets
-  bool tagged = detail::setDenseOpaqueTagValues(
-    mtag, meshsets, this->moabInterface());
-
-  // II. Tag the cells
-  tagged &= detail::setDenseOpaqueTagValues(
-    mtag, this->getCells(meshsets), this->moabInterface());
-  return tagged;
-}
-
-/**\brief Find mesh entities associated with the given model entity.
-  *
-  */
-smtk::mesh::HandleRange Interface::findAssociations(
-  const smtk::mesh::Handle& root,
-  const smtk::common::UUID& modelUUID)
-{
-  smtk::mesh::HandleRange result;
-  if (!modelUUID)
-    return result;
-
-  ::moab::Tag model_tag;
-  m_iface->tag_get_handle(
-    "MODEL", smtk::common::UUID::size(),
-    ::moab::MB_TYPE_OPAQUE, model_tag,
-    ::moab::MB_TAG_BYTES| ::moab::MB_TAG_CREAT| ::moab::MB_TAG_SPARSE);
-
-  const void* tag_v_ptr = &modelUUID;
-
-  ::moab::ErrorCode rval = m_iface->get_entities_by_type_and_tag(
-    root, ::moab::MBENTITYSET, &model_tag, &tag_v_ptr, 1, result);
-  (void)rval;
-  return result;
-}
-
-//----------------------------------------------------------------------------
-bool Interface::addAssociation(const smtk::common::UUID& modelUUID,
-                               const smtk::mesh::HandleRange& range)
+bool Interface::setAssociation(const smtk::common::UUID& modelUUID,
+                               const smtk::mesh::HandleRange& range) const
 {
   if(range.empty() || !modelUUID)
     { //if empty range or invalid uuid
     return false;
     }
 
-  // Set the value of the MODEL tag to the modelUUID for every item in the range
-  ::moab::Tag model_tag;
-  m_iface->tag_get_handle("MODEL",
-                          smtk::common::UUID::size(), //this should be 128 bits
-                          ::moab::MB_TYPE_OPAQUE,
-                          model_tag,
-                          ::moab::MB_TAG_BYTES| ::moab::MB_TAG_CREAT| ::moab::MB_TAG_SPARSE);
+  tag::QueryEntRefTag mtag(modelUUID, this->moabInterface());
 
-  const void* tag_v_ptr = &modelUUID;
-  bool valid = true;
-  typedef smtk::mesh::HandleRange::const_iterator cit;
-  for(cit i=range.begin(); i!=range.end() && valid;++i)
+  //Tag the meshsets
+  bool tagged = detail::setDenseOpaqueTagValues(mtag,
+                                                range,
+                                                this->moabInterface());
+  return tagged;
+}
+
+//----------------------------------------------------------------------------
+/**\brief Find mesh entities associated with the given model entity.
+  *
+  */
+smtk::mesh::HandleRange Interface::findAssociations(
+  const smtk::mesh::Handle& root,
+  const smtk::common::UUID& modelUUID) const
+{
+  smtk::mesh::HandleRange result;
+  if (!modelUUID)
     {
-    const ::moab::EntityHandle& currentHandle = *i;
-    ::moab::ErrorCode rval = m_iface->tag_set_data(model_tag,
-                                                   &currentHandle,
-                                                   1,
-                                                   tag_v_ptr);
-    valid = (rval == ::moab::MB_SUCCESS);
+    return result;
     }
-  return valid;
+
+  tag::QueryEntRefTag mtag(modelUUID, this->moabInterface());
+
+  ::moab::ErrorCode rval;
+  rval = m_iface->get_entities_by_type_and_tag(root,
+                                               ::moab::MBENTITYSET,
+                                               mtag.moabTagPtr(),
+                                               mtag.moabTagValuePtr(),
+                                               1,
+                                               result);
+  if(rval != ::moab::MB_SUCCESS)
+    {
+    result.clear();
+    }
+  return result;
+}
+
+//----------------------------------------------------------------------------
+// brief Set the model entity assigned to the root of this interface.
+//
+bool Interface::setRootAssociation(const smtk::common::UUID& modelUUID) const
+{
+  if (!modelUUID)
+    {
+    return false;
+    }
+
+  smtk::mesh::Handle root = m_iface->get_root_set();
+  tag::QueryRootModelEntTag mtag(modelUUID, this->moabInterface());
+
+  //Tag the root
+  bool tagged = detail::setDenseOpaqueTagValue(mtag,
+                                               root,
+                                               this->moabInterface());
+  return tagged;
+}
+
+//----------------------------------------------------------------------------
+/// brief Get the model entity assigned to the root of this interface.
+//
+smtk::common::UUID Interface::rootAssociation() const
+{
+  //first we need to verify that we have a ROOT_MODEL tag first
+  std::vector< ::moab::Tag > tag_handles;
+  smtk::mesh::Handle root = m_iface->get_root_set();
+  m_iface->tag_get_tags_on_entity(root,tag_handles);
+
+  if(tag_handles.size() > 0)
+    {
+    tag::QueryRootModelEntTag mtag(this->moabInterface());
+    return detail::computeDenseOpaqueTagValue<smtk::common::UUID>(mtag,
+                                                                  root,
+                                                                  this->moabInterface());
+    }
+  return smtk::common::UUID::null();
 }
 
 //----------------------------------------------------------------------------

--- a/smtk/mesh/moab/Interface.h
+++ b/smtk/mesh/moab/Interface.h
@@ -196,18 +196,18 @@ public:
                   const smtk::mesh::Neumann& neumann) const;
 
   //----------------------------------------------------------------------------
-  bool setModelEntity(
-    const smtk::mesh::HandleRange& meshsets,
-    const smtk::common::UUID& uuid) const;
+  bool setAssociation(const smtk::common::UUID& modelUUID,
+                      const smtk::mesh::HandleRange& range) const;
 
   //----------------------------------------------------------------------------
-  smtk::mesh::HandleRange findAssociations(
-    const smtk::mesh::Handle& root,
-    const smtk::common::UUID& modelUUID);
+  smtk::mesh::HandleRange findAssociations(const smtk::mesh::Handle& root,
+                                           const smtk::common::UUID& modelUUID) const;
 
   //----------------------------------------------------------------------------
-  bool addAssociation(const smtk::common::UUID& modelUUID,
-                      const smtk::mesh::HandleRange& range);
+  bool setRootAssociation(const smtk::common::UUID& modelUUID) const;
+
+  //----------------------------------------------------------------------------
+  smtk::common::UUID rootAssociation() const;
 
   //----------------------------------------------------------------------------
   smtk::mesh::HandleRange rangeIntersect(const smtk::mesh::HandleRange& a,

--- a/smtk/mesh/moab/Tags.h
+++ b/smtk/mesh/moab/Tags.h
@@ -159,15 +159,34 @@ public:
   const char* value() const { return this->m_value; }
 };
 
-class QueryModelTag: public QueryOpaqueTag<smtk::common::UUID::SIZE>
+class QueryEntRefTag: public QueryOpaqueTag<smtk::common::UUID::SIZE>
 {
 public:
-  QueryModelTag(::moab::Interface* iface)
-    : QueryOpaqueTag("MODEL",reinterpret_cast<const char*>(smtk::common::UUID::null().begin()),iface)
+  QueryEntRefTag(::moab::Interface* iface)
+    : QueryOpaqueTag("ENT_REF",reinterpret_cast<const char*>(smtk::common::UUID::null().begin()),iface)
     {
     }
-  QueryModelTag(const smtk::common::UUID& v, ::moab::Interface* iface)
-    : QueryOpaqueTag("MODEL",reinterpret_cast<const char*>(v.begin()),iface)
+  QueryEntRefTag(const smtk::common::UUID& v, ::moab::Interface* iface)
+    : QueryOpaqueTag("ENT_REF",reinterpret_cast<const char*>(v.begin()),iface)
+    {
+    }
+  smtk::common::UUID uuid() const
+    {
+    return smtk::common::UUID(
+      reinterpret_cast<const unsigned char*>(this->value()),
+      reinterpret_cast<const unsigned char*>(this->value()) + smtk::common::UUID::SIZE);
+    }
+};
+
+class QueryRootModelEntTag: public QueryOpaqueTag<smtk::common::UUID::SIZE>
+{
+public:
+  QueryRootModelEntTag(::moab::Interface* iface)
+    : QueryOpaqueTag("ROOT_MODEL_ENT",reinterpret_cast<const char*>(smtk::common::UUID::null().begin()),iface)
+    {
+    }
+  QueryRootModelEntTag(const smtk::common::UUID& v, ::moab::Interface* iface)
+    : QueryOpaqueTag("ROOT_MODEL_ENT",reinterpret_cast<const char*>(v.begin()),iface)
     {
     }
   smtk::common::UUID uuid() const

--- a/smtk/mesh/testing/cxx/UnitTestManager.cxx
+++ b/smtk/mesh/testing/cxx/UnitTestManager.cxx
@@ -152,14 +152,16 @@ void verify_has_association()
   smtk::model::EntityRef invalidModelRef;
 
   //verify that the null uuid isn't part of a collection
-  test( mgr->isAssociatedToACollection( invalidModelRef ) == false );
+  test( mgr->isAssociatedToACollection( invalidModelRef ) == false,
+        "invalid model ref associated to collection" );
 
   //add some empty collection to the manager
   const int size=256;
   for( int i=0 ; i < size; ++i) { mgr->makeCollection(); }
 
   //verify that at this point no collections have associations
-  test(mgr->collectionsWithAssociations().size() == 0);
+  test(mgr->collectionsWithAssociations().size() == 0,
+       "new empty collections reporting they have associations");
 
   //next we are going to create a simple smtk model
   smtk::model::ManagerPtr modelManager = smtk::model::Manager::create();
@@ -171,11 +173,13 @@ void verify_has_association()
   test( mgr->numberOfCollections() == (size+1) );
 
   //now verify that the manager can see the association
-  test(mgr->collectionsWithAssociations().size() == 1);
+  test(mgr->collectionsWithAssociations().size() == 1,
+       "only one collection should have an association");
 
   //verify that the null uuid isn't part of a collection even after we
   //have an association
-  test( mgr->isAssociatedToACollection( invalidModelRef ) == false );
+  test( mgr->isAssociatedToACollection( invalidModelRef ) == false,
+        "invalid model ref associated to collection");
 
   //walk the model and verify that we can query the Manager to get the
   //collection that is associated to it.
@@ -198,7 +202,8 @@ void verify_has_association()
       test( assocCollections[0] == collectionWithAssoc);
       }
     }
-  test( num_models == count );
+
+  test( (num_models + num_volumes_in_model) == count, "incorrect number of associations");
 
   //walk all the collections and get the model uuids that is aware of
   smtk::mesh::MeshSet meshes = collectionWithAssoc->meshes();

--- a/smtk/mesh/testing/cxx/UnitTestModelToMesh.cxx
+++ b/smtk/mesh/testing/cxx/UnitTestModelToMesh.cxx
@@ -126,6 +126,32 @@ void verify_empty_model()
 }
 
 //----------------------------------------------------------------------------
+void verify_model_association()
+{
+  smtk::mesh::ManagerPtr meshManager = smtk::mesh::Manager::create();
+  smtk::model::ManagerPtr modelManager = smtk::model::Manager::create();
+
+  create_simple_model(modelManager);
+
+  smtk::io::ModelToMesh convert;
+  smtk::mesh::CollectionPtr c = convert(meshManager,modelManager);
+
+  //we need to verify that the collection is now has an associated model
+  test( c->hasAssociations(), "collection should have associations");
+  test( (c->associatedModel() != smtk::common::UUID()), "collection should be associated to a real model");
+  test( (c->isAssociatedToModel()), "collection should be associated to a real model");
+
+  //verify the MODEL_ENTITY is correct
+  smtk::model::EntityRefs currentModels = modelManager->entitiesMatchingFlagsAs<
+                                            smtk::model::EntityRefs>( smtk::model::MODEL_ENTITY);
+  if(currentModels.size() > 0)
+    { //presuming only a single model in the model manager
+    test( (c->associatedModel() == currentModels.begin()->entity()), "collection associated model should match model manager");
+    }
+}
+
+
+//----------------------------------------------------------------------------
 template<int Dim>
 void testFindAssociations(smtk::mesh::CollectionPtr c, smtk::model::EntityIterator& it, std::size_t correct)
 {
@@ -328,6 +354,7 @@ int UnitTestModelToMesh(int, char**)
 {
   verify_null_managers();
   verify_empty_model();
+  verify_model_association();
   verify_cell_conversion();
   verify_vertex_conversion();
   verify_cell_have_points();


### PR DESCRIPTION
Previously a smtk::mesh::Collection would only store the association
to a model in a member variable, and not inside the backend interface.
Now with these changes we have added support for the backend interface
to hold the model uuid that we are associated too.

This means that once a collection is stored to disk, loading back the collection
will restore all the proper relationships to the model.