### PR TITLE
Disable CS wrapping for vtkSMTKDiscreteModel

### DIFF
--- a/smtk/bridge/discrete/kernel/CMakeLists.txt
+++ b/smtk/bridge/discrete/kernel/CMakeLists.txt
@@ -250,6 +250,9 @@ smtk_public_headers(${DiscreteModelHeaders})
 smtk_install_library(vtkSMTKDiscreteModel)
 
 if (SMTK_ENABLE_PARAVIEW_SUPPORT)
-  vtk_add_cs_wrapping(${vtk-module})
+  # This module currently has source files located in its sub directories,
+  # so it will not be CS wrapped properly, and generate a lot of warning at CMake configure time.
+  # Therefore we disable CS wrapping until the issue with source files in sub directories is addressed.
+  # vtk_add_cs_wrapping(${vtk-module})
   smtk_install_library(${vtk-module}CS)
 endif ()


### PR DESCRIPTION
The vtkSMTKDiscreteModel module currently has source files located in its sub directories,
so it will not be CS wrapped properly, and generate a lot of warning at CMake configure time.
Therefore we disable its CS wrapping until the issue with source files in sub directories is addressed.