### PR TITLE
More conventional syntax of -I command line argument in Tool `cpp_to_pybind`

### DIFF
--- a/doc/userguide/bindings/generating-pybind11-bindings.rst
+++ b/doc/userguide/bindings/generating-pybind11-bindings.rst
@@ -14,8 +14,8 @@ the module.
 To generate a C++ header file for a new SMTK class, use
 ``[smtk-root-directory]/utilities/python/cpp_to_pybind11.py`` with the
 appropriate arguments for the header file, project root directory,
-include directories (e.g. ``-I "[smtk-build-directory]
-[smtk-root-directory]/thirdparty/cJSON path/to/vtk/include"``) and
+include directories (e.g. ``-I [smtk-build-directory]
+-I [smtk-root-directory]/thirdparty/cJSON path/to/vtk/include``) and
 generated file prefix; the module's binding source file (also located
 in the ``pybind`` subdirectory of the module) must then be updated to
 call the functions defined in the generated header file. To generate

--- a/utilities/python/cpp_to_pybind11.py
+++ b/utilities/python/cpp_to_pybind11.py
@@ -22,6 +22,7 @@ directory of C++ header files.
 
 import os
 import sys
+from typing import List
 
 # Find out the file location within the sources tree
 this_module_dir_path = os.path.abspath(
@@ -231,7 +232,7 @@ def get_includes(global_ns, filename, project_source_directory):
     return sorted(includes)
 
 
-def parse_file(filename, project_source_directory, include_directories,
+def parse_file(filename, project_source_directory, include_directories: List[str],
                declaration_names, stream):
     """
     Entry point for parsing a file
@@ -242,7 +243,7 @@ def parse_file(filename, project_source_directory, include_directories,
     # Configure the xml generator
     config = parser.xml_generator_configuration_t(
         start_with_declarations=declaration_names.split(" "),
-        include_paths=include_directories.split(" "),
+        include_paths=include_directories,
         xml_generator_path=generator_path,
         xml_generator=generator_name,
         cflags='-std=c++11 -Wc++11-extensions')
@@ -567,7 +568,8 @@ if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('-I', '--include-dirs',
                             help='Add an include directory to the parser',
-                            default="")
+                            action='append',
+                            default=[])
 
     arg_parser.add_argument('-d', '--declaration-name',
                             help='names of C++ classes and functions',
@@ -591,8 +593,8 @@ if __name__ == '__main__':
 
     args = arg_parser.parse_args()
 
-    if not args.include_dirs:
-        args.include_dirs = args.input_directory
+    if len(args.include_dirs) == 0:
+        args.include_dirs.append(args.input_directory)
 
     def stream_with_line_breaks(stream):
         def write(string):

--- a/utilities/python/generate_pybind11_module.py
+++ b/utilities/python/generate_pybind11_module.py
@@ -25,8 +25,9 @@ if __name__ == '__main__':
 
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('-I', '--include-dirs',
+                            action='append',
                             help='Add an include directory to the parser',
-                            default="")
+                            default=[])
 
     arg_parser.add_argument('-i', '--input-directory',
                             help='<Required> Input directory',
@@ -57,8 +58,8 @@ if __name__ == '__main__':
     if not os.path.exists(args.input_directory):
         raise IOError("No directory \"%s\"" % args.input_directory)
 
-    if not args.include_dirs:
-        args.include_dirs = args.input_directory
+    if len(args.include_dirs) == 0:
+        args.include_dirs.append(args.input_directory)
 
     def stream_with_line_breaks(stream):
         def write(string):


### PR DESCRIPTION
Changed syntax of command line argument -I 
Until now to add multiple paths, you had to put them into one long quotation-mark-separated string, individual paths separated by spaces. This is not viable for paths including space characters and is also rather unconventional. Instead you can now add the "-I" argument multiple times. This is the approach used by e.g. compilers like clang or gcc

