### PR TITLE
COMP: Add missing VTK modules to vtkSMTKOperationsExt

### DIFF
--- a/smtk/extension/vtk/operators/CMakeLists.txt
+++ b/smtk/extension/vtk/operators/CMakeLists.txt
@@ -41,6 +41,8 @@ vtk_module_link(vtkSMTKOperationsExt
   PUBLIC
     smtkCore
     smtkIOVTK
+    VTK::FiltersGeometry
+    VTK::FiltersPoints
 )
 
 if (SMTK_ENABLE_PARAVIEW_SUPPORT)


### PR DESCRIPTION
Add missing VTK modules VTK::FiltersGeometry and VTK::FiltersPoints
so that required headers are correctly found when using VTK-build
folder in place of VTK-install folder.